### PR TITLE
框架心跳支持插件扩展字段信息

### DIFF
--- a/lubanops-apm-javaagent-core/src/main/java/com/lubanops/apm/core/transfer/dto/heartbeat/HeartbeatMessage.java
+++ b/lubanops-apm-javaagent-core/src/main/java/com/lubanops/apm/core/transfer/dto/heartbeat/HeartbeatMessage.java
@@ -26,6 +26,10 @@ public class HeartbeatMessage {
         message.put("lastHeartbeat", String.valueOf(TimeUtil.currentTimeMillis()));
     }
 
+    public HeartbeatMessage registerInformation(String key, String value) {
+        message.put(key, value);
+        return this;
+    }
 
     public String generateCurrentMessage() {
         String msg = null;


### PR DESCRIPTION
【issue号】#13
【修改原因】
框架心跳信息没有添加字段接口
【修改内容】
框架心跳模块添加可增加字段接口
【检查者】@fuziye01
【用例描述】暂无用例
【自测情况】本地插件扩展框架心跳信息成功写入kafka
【影响范围】框架支持插件扩展心跳字段