### PR TITLE
统一消息发送添加数据类型

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/proto/Message.proto
+++ b/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/proto/Message.proto
@@ -21,6 +21,9 @@ message HeartBeat{
 message ServiceData{
   enum DataType{
     SERVICE_HEARTBEAT = 0;
+    LOG = 1;
+    PLUGIN_FLOW_CONTROL_DATA = 2;
+    PLUGIN_FLOW_RECORD_DATA = 3;
   }
   DataType dataType = 1;
   bytes data = 2;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/lubanops/master/RegionMasterService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/lubanops/master/RegionMasterService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.huawei.apm.core.ext.lubanops.transport.ClientManager;
 import com.huawei.apm.core.lubanops.transfer.dto.heartbeat.HeartbeatMessage;
 import com.huawei.apm.core.ext.lubanops.transport.netty.client.NettyClient;
 import com.huawei.apm.core.ext.lubanops.transport.netty.client.NettyClientFactory;
@@ -110,7 +111,7 @@ public class RegionMasterService extends AbstractMasterService {
             String msg = heartbeatMessage.generateCurrentMessage();
             if (msg != null && !"".equals(msg)) {
                 LOGGER.log(Level.INFO, "[KafkaHeartbeatSender] heartbeat message=" + msg);
-                NettyClientFactory factory = NettyClientFactory.getInstance();
+                NettyClientFactory factory = ClientManager.getNettyClientFactory();
                 NettyClient nettyClient = factory.getNettyClient(
                         AgentConfigManager.getNettyServerIp(),
                         Integer.parseInt(AgentConfigManager.getNettyServerPort()));

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/common/conf/KafkaConf.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/common/conf/KafkaConf.java
@@ -30,4 +30,16 @@ public class KafkaConf {
     // common主题名
     @Value("${kafka.heartbeat.topic}")
     private String topicHeartBeat;
+
+    // Log topic  name
+    @Value("topic-log")
+    private String topicLog;
+
+    // 流控插件topic name
+    @Value("topic-flowcontrol")
+    private String topicFlowControl;
+
+    // 录制插件topic name
+    @Value("topic-flowecord")
+    private String topicFlowRecord;
 }

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/server/ServerHandler.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/server/ServerHandler.java
@@ -62,6 +62,15 @@ public class ServerHandler extends BaseHandler {
                 case Message.ServiceData.DataType.SERVICE_HEARTBEAT_VALUE:
                     producer.send(new ProducerRecord<>(conf.getTopicHeartBeat(), Bytes.wrap(message)));
                     break;
+                case Message.ServiceData.DataType.LOG_VALUE:
+                    producer.send(new ProducerRecord<>(conf.getTopicLog(), Bytes.wrap(message)));
+                    break;
+                case Message.ServiceData.DataType.PLUGIN_FLOW_CONTROL_DATA_VALUE:
+                    producer.send(new ProducerRecord<>(conf.getTopicFlowControl(), Bytes.wrap(message)));
+                    break;
+                case Message.ServiceData.DataType.PLUGIN_FLOW_RECORD_DATA_VALUE:
+                    producer.send(new ProducerRecord<>(conf.getTopicFlowRecord(), Bytes.wrap(message)));
+                    break;
                 default:
                     break;
             }

--- a/javamesh-backend/src/main/proto/Message.proto
+++ b/javamesh-backend/src/main/proto/Message.proto
@@ -21,6 +21,9 @@ message HeartBeat{
 message ServiceData{
   enum DataType{
     SERVICE_HEARTBEAT = 0;
+    LOG = 1;
+    PLUGIN_FLOW_CONTROL_DATA = 2;
+    PLUGIN_FLOW_RECORD_DATA = 3;
   }
   DataType dataType = 1;
   bytes data = 2;


### PR DESCRIPTION
【issue号】#39
【修改原因】
统一消息发送数据类型缺少日志与插件数据类型
【修改内容】
统一消息发送proto文件添加日志，流量控制，流量录制插件数据类型
统一消息发送server端添加日志，流量控制，流量录制插件数据类型写入kafka
支持topic可配置
【检查者】@HapThorin @lilai23
【影响范围】框架统一消息支持日志类型，流量控制，流量录制数据类型