### PR TITLE
修改打包问题

### DIFF
--- a/javamesh-samples/javamesh-flowrecord/flowrecord-replay/pom.xml
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-replay/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>javamesh-samples</artifactId>
+        <artifactId>javamesh-flowrecord</artifactId>
         <groupId>com.huawei.javamesh</groupId>
         <version>1.0.0</version>
     </parent>
@@ -23,7 +23,7 @@
 
     <properties>
         <javamesh.basedir>${pom.basedir}/../../../..</javamesh.basedir>
-        <package.sample.name>${package.server.dir}</package.sample.name>
+<!--        <package.sample.name>${package.server.dir}</package.sample.name>-->
 
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>


### PR DESCRIPTION
【issue号】#44
【修改原因】
package打包时目录会进行追加，导致目录结构混乱，打包不成功。
如：C:\GitHub\java-mesh\javamesh-samples\javamesh-flowrecord\flowrecord-replay\mockserver\..\..\..\..\javamesh-agent-2.0.5\C:\GitHub\java-mesh\javamesh-samples\javamesh-flowrecord\flowrecord-replay\mockserver\..\..\..\..\javamesh-agent-2.0.5\server\mockserver-2.0.5.jar (文件名、目录名或卷标语法不正确。)
当前删除后面打包目录，使用一个目录
【修改内容】
添加流量录制回放pom文件
【检查者】@fuziye01
【用例描述】ut用例
【自测情况】本地编译成功
【影响范围】流量录制回放
Signed-off-by: useless223 1209750741@qq.com