### PR TITLE
录制插件实现BaseConfig接口，心跳调用框架心跳服务

### DIFF
--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/pom.xml
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/pom.xml
@@ -130,16 +130,6 @@
         </dependency>
         <dependency>
             <groupId>com.huawei.javamesh</groupId>
-            <artifactId>javamesh-agentcore-core</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.huawei.javamesh</groupId>
-            <artifactId>javamesh-agentcore-core-ext</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.huawei.javamesh</groupId>
             <artifactId>javamesh-agentcore-bootstrap</artifactId>
         </dependency>
         <dependency>

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/FlowrecordService.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/FlowrecordService.java
@@ -1,60 +1,26 @@
 package com.huawei.flowrecord;
 
+import com.huawei.apm.bootstrap.boot.CoreServiceManager;
 import com.huawei.apm.bootstrap.boot.PluginService;
-import com.huawei.apm.bootstrap.lubanops.config.AgentConfigManager;
-import com.huawei.apm.bootstrap.lubanops.log.LogFactory;
-import com.huawei.apm.core.ext.lubanops.transport.ClientManager;
-import com.huawei.apm.core.ext.lubanops.transport.netty.client.NettyClient;
-import com.huawei.apm.core.ext.lubanops.transport.netty.client.NettyClientFactory;
-import com.huawei.apm.core.lubanops.transfer.dto.heartbeat.HeartbeatMessage;
-import com.huawei.apm.core.ext.lubanops.transport.netty.pojo.Message;
-import lombok.SneakyThrows;
+import com.huawei.apm.bootstrap.boot.heartbeat.HeartbeatService;
+import com.huawei.flowrecord.config.FlowRecordConfig;
+import com.huawei.flowrecord.utils.PluginConfigUtil;
 
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.logging.Level;
+import java.util.HashMap;
+import java.util.Map;
 
-public class FlowrecordService implements PluginService {
+public class FlowRecordService implements PluginService {
 
-    private final ExecutorService executorService = Executors.newSingleThreadExecutor(
-            new FlowrecordThreadFactory("FLOW_RECORD_INIT_THREAD"));
+    private static final HeartbeatService HEARTBEAT_SERVICE = CoreServiceManager.INSTANCE.getService(HeartbeatService.class);
+    private final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
 
     @Override
     public void init() {
-        executorService.execute(new FlowRecordInitTask());
+        HEARTBEAT_SERVICE.heartbeat(flowRecordConfig.getHeartBeatName());
     }
 
     @Override
     public void stop() {
-        executorService.shutdown();
-    }
-
-    static class FlowRecordInitTask implements Runnable {
-        @SneakyThrows
-        @Override
-        public void run() {
-            while (true) {
-                try {
-                    // 开启定时任务（发送心跳）
-                    HeartbeatMessage heartbeatMessage = new HeartbeatMessage();
-                    String msg = heartbeatMessage.registerInformation("name", "flowrecord").generateCurrentMessage();
-                    if (msg != null && !"".equals(msg)) {
-                        LogFactory.getLogger().log(Level.INFO, "[KafkaHeartbeatSender] heartbeat message=" + msg);
-                        NettyClientFactory factory = ClientManager.getNettyClientFactory();
-                        NettyClient nettyClient = factory.getNettyClient(
-                                AgentConfigManager.getNettyServerIp(),
-                                Integer.parseInt(AgentConfigManager.getNettyServerPort()));
-                        nettyClient.sendData(msg.getBytes(StandardCharsets.UTF_8), Message.ServiceData.DataType.SERVICE_HEARTBEAT);
-                        Thread.sleep(5000);
-                    } else {
-                        LogFactory.getLogger().log(Level.SEVERE, "[KafkaHeartbeatSender] heartbeat json conversion error ");
-                    }
-
-                } catch (Exception e) {
-                    LogFactory.getLogger().warning(String.format("Init Flow record plugin failed, {%s}", e));
-                }
-            }
-        }
+        HEARTBEAT_SERVICE.stopHeartbeat(flowRecordConfig.getHeartBeatName());
     }
 }

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/FlowRecordConfig.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/FlowRecordConfig.java
@@ -1,0 +1,122 @@
+package com.huawei.flowrecord.config;
+
+import com.huawei.apm.bootstrap.config.BaseConfig;
+import com.huawei.apm.bootstrap.config.ConfigTypeKey;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigTypeKey("flow.record.plugin")
+public class FlowRecordConfig implements BaseConfig {
+
+    /**
+     * 流配置中心 zookeeper地址
+     */
+    private String zookeeperAddress = "127.0.0.1:2181";
+
+    /**
+     * 配置中心 zookeeper路径
+     */
+    private String zookeeperPath = "/record_jobs";
+
+    /**
+     * 配置中心 Session超时时间
+     */
+    private String zookeeperTimeout = "50000";
+
+    /**
+     * kafka配置参数 连接服务端地址
+     */
+    private String kafkaBootstrapServers = "127.0.0.1:9092";
+
+    /**
+     * kafka配置参数 key序列化
+     */
+    private String kafkaKeySerializer = "org.apache.kafka.common.serialization.StringSerializer";
+
+    /**
+     * kafka配置参数 value序列化
+     */
+    private String kafkaValueSerializer = "org.apache.kafka.common.serialization.StringSerializer";
+
+    /**
+     * kafka配置参数 request的topic名称
+     */
+    private String kafkaRequestTopic = "request";
+
+    /**
+     * kafka配置参数 response的topic名称
+     */
+    private String kafkaResponseTopic = "response";
+
+    /**
+     * kafka配置参数 producer需要server接收到数据之后发出的确认接收的信号 ack 0,1,all
+     */
+    private String kafkaAcks = "1";
+
+    /**
+     * kafka配置参数 控制生产者发送请求最大大小,默认1M （这个参数和Kafka主机的message.max.bytes 参数有关系）
+     */
+    private String kafkaMaxRequestSize = "1048576";
+
+    /**
+     * kafka配置参数 生产者内存缓冲区大小 32M
+     */
+    private String kafkaBufferMemory = "33554432";
+
+    /**
+     * kafka配置参数 重发消息次数
+     */
+    private String kafkaRetries = "0";
+
+    /**
+     * kafka配置参数 客户端将等待请求的响应的最大时间
+     */
+    private String kafkaRequestTimeoutMs = "10000";
+
+    /**
+     * kafka配置参数 最大阻塞时间，超过则抛出异常
+     */
+    private String kafkaMaxBlockMs = "60000";
+
+    /**
+     * redis ip地址
+     */
+    private String redisHost = "127.0.0.1";
+
+    /**
+     * redis 端口
+     */
+    private String redisPort = "6379";
+
+    /**
+     * redis 密码
+     */
+    private String redisPassword = "";
+
+    /**
+     * redis 集群地址
+     */
+    private String redisUris = "redis://127.0.0.1:6379";
+
+    /**
+     * 自定义录制插件拦截类
+     */
+    private String customEnhanceClass = "org.apache.dubbo.demo.provider.CustomService";
+
+    /**
+     * 自定义录制插件拦截的实例方法（多个方法以逗号分隔）
+     */
+    private String customEnhanceInstanceMethod = "testCustom,newTest";
+
+    /**
+     * 自定义录制插件拦截的静态方法（多个方法以逗号分隔）
+     */
+    private String customEnhanceStaticMethod = "testCustom2";
+    /**
+     * 心跳名
+     */
+    private String heartBeatName = "flowRecord-heartbeat";
+}
+

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/KafkaConst.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/KafkaConst.java
@@ -11,7 +11,6 @@ import java.util.Properties;
 
 /**
  * kafka配置
- *
  */
 public class KafkaConst {
     /**
@@ -20,37 +19,38 @@ public class KafkaConst {
      * @return Properties
      */
     public static Properties producerConfig() {
+        FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
         Properties properties = new Properties();
         properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_BOOTSTRAP_SERVERS));
+                flowRecordConfig.getKafkaBootstrapServers());
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_KEY_SERIALIZER));
+                flowRecordConfig.getKafkaKeySerializer());
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_VALUE_SERIALIZER));
+                flowRecordConfig.getKafkaValueSerializer());
 
         // producer需要server接收到数据之后发出的确认接收的信号 ack 0,1,all
         properties.put(ProducerConfig.ACKS_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_ACKS));
+                flowRecordConfig.getKafkaAcks());
 
         // 控制生产者发送请求最大大小,默认1M （这个参数和Kafka主机的message.max.bytes 参数有关系）
         properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_MAX_REQUEST_SIZE));
+                flowRecordConfig.getKafkaMaxRequestSize());
 
         // 生产者内存缓冲区大小
         properties.put(ProducerConfig.BUFFER_MEMORY_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_BUFFER_MEMORY));
+                flowRecordConfig.getKafkaBufferMemory());
 
         // 重发消息次数
         properties.put(ProducerConfig.RETRIES_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_RETRIES));
+                flowRecordConfig.getKafkaRetries());
 
         // 客户端将等待请求的响应的最大时间
         properties.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_REQUEST_TIMEOUT_MS));
+                flowRecordConfig.getKafkaRequestTimeoutMs());
 
         // 最大阻塞时间，超过则抛出异常
         properties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG,
-            PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_MAX_BLOCK_MS));
+                flowRecordConfig.getKafkaMaxBlockMs());
 
         return properties;
     }

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/boot/BootInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/boot/BootInterceptor.java
@@ -7,7 +7,10 @@ package com.huawei.flowrecord.plugins.boot;
 import com.huawei.apm.bootstrap.common.BeforeResult;
 import com.huawei.apm.bootstrap.interceptors.StaticMethodInterceptor;
 import com.huawei.flowrecord.init.InitListener;
+import com.huawei.flowrecord.plugins.dubbo.AliDubboInterceptor;
 import lombok.SneakyThrows;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 
@@ -16,6 +19,8 @@ import java.lang.reflect.Method;
  *
  */
 public class BootInterceptor implements StaticMethodInterceptor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BootInterceptor.class);
     @Override
     public void before(Class<?> clazz, Method method, Object[] arguments, BeforeResult beforeResult) throws Exception {
         new Thread(new Runnable() {
@@ -25,6 +30,7 @@ public class BootInterceptor implements StaticMethodInterceptor {
                 try {
                     InitListener.doinit();
                 } catch (Exception e) {
+                    LOGGER.error(e.getMessage());
                 }
             }
         }).start();

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstanceMethodInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstanceMethodInterceptor.java
@@ -8,6 +8,7 @@ import com.huawei.apm.bootstrap.common.BeforeResult;
 import com.huawei.apm.bootstrap.interceptors.InstanceMethodInterceptor;
 import com.huawei.apm.bootstrap.lubanops.trace.TraceCollector;
 import com.huawei.flowrecord.config.ConfigConst;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import com.huawei.flowrecord.domain.RecordStatus;
 import com.huawei.flowrecord.domain.Recorder;
 import com.huawei.flowrecord.utils.PluginConfigUtil;
@@ -28,10 +29,10 @@ import java.util.HashMap;
 
 /**
  * 自定义应用实例方法增强类
- *
  */
 public class CustomInstanceMethodInterceptor implements InstanceMethodInterceptor {
     private static final Logger LOGGER = LoggerFactory.getLogger(CustomInstanceMethodInterceptor.class);
+    private static final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
 
     private void sendRecorder(String subCallKey, int subCallCount, Method method, Object[] params, Object ret,
                               HashMap<String, String> jobMap) {
@@ -50,7 +51,7 @@ public class CustomInstanceMethodInterceptor implements InstanceMethodIntercepto
             recordRequest.setResponseClass(ret.getClass().getName());
             recordRequest.setTimestamp(new Date());
             String serializedRequest = JSON.toJSONString(recordRequest, SerializerFeature.WriteMapNullValue);
-            KafkaProducerUtil.sendMessage(PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_REQUEST_TOPIC), serializedRequest);
+            KafkaProducerUtil.sendMessage(flowRecordConfig.getKafkaRequestTopic(), serializedRequest);
         }
     }
 

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstrumentation.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstrumentation.java
@@ -11,7 +11,7 @@ import com.huawei.apm.bootstrap.definition.MethodInterceptPoint;
 import com.huawei.apm.bootstrap.matcher.ClassMatcher;
 import com.huawei.apm.bootstrap.matcher.ClassMatchers;
 import com.huawei.flowrecord.config.CommonConst;
-import com.huawei.flowrecord.config.ConfigConst;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import com.huawei.flowrecord.utils.PluginConfigUtil;
 
 import net.bytebuddy.description.method.MethodDescription;
@@ -21,10 +21,10 @@ import net.bytebuddy.matcher.StringMatcher;
 
 /**
  * 自定义应用拦截点
- *
  */
 public class CustomInstrumentation implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = PluginConfigUtil.getValueByKey(ConfigConst.CUSTOM_ENHANCE_CLASS);
+    private static final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
+    private static final String ENHANCE_CLASS = flowRecordConfig.getCustomEnhanceClass();
     private static final String INSTANCE_METHOD_INTERCEPT_CLASS =
             "com.huawei.flowrecord.plugins.custom.CustomInstanceMethodInterceptor";
     private static final String STATIC_METHOD_INTERCEPT_CLASS =
@@ -39,9 +39,9 @@ public class CustomInstrumentation implements EnhanceDefinition {
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{
                 MethodInterceptPoint.newInstMethodInterceptPoint(INSTANCE_METHOD_INTERCEPT_CLASS,
-                        setMethodMatcher(PluginConfigUtil.getValueByKey(ConfigConst.CUSTOM_ENHANCE_INSTANCE_METHOD))),
+                        setMethodMatcher(flowRecordConfig.getCustomEnhanceInstanceMethod())),
                 MethodInterceptPoint.newStaticMethodInterceptPoint(STATIC_METHOD_INTERCEPT_CLASS,
-                        setMethodMatcher(PluginConfigUtil.getValueByKey(ConfigConst.CUSTOM_ENHANCE_STATIC_METHOD)))
+                        setMethodMatcher(flowRecordConfig.getCustomEnhanceStaticMethod()))
         };
     }
 

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomStaticMethodInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomStaticMethodInterceptor.java
@@ -8,6 +8,7 @@ import com.huawei.apm.bootstrap.common.BeforeResult;
 import com.huawei.apm.bootstrap.interceptors.StaticMethodInterceptor;
 import com.huawei.apm.bootstrap.lubanops.trace.TraceCollector;
 import com.huawei.flowrecord.config.ConfigConst;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import com.huawei.flowrecord.domain.RecordStatus;
 import com.huawei.flowrecord.domain.Recorder;
 import com.huawei.flowrecord.utils.PluginConfigUtil;
@@ -28,10 +29,10 @@ import java.util.HashMap;
 
 /**
  * 自定义应用静态方法增强类
- *
  */
 public class CustomStaticMethodInterceptor implements StaticMethodInterceptor {
     private static final Logger LOGGER = LoggerFactory.getLogger(CustomStaticMethodInterceptor.class);
+    private static final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
 
     private void sendRecorder(String subCallKey, int subCallCount, Method method, Object[] params, Object ret,
                               HashMap<String, String> jobMap) {
@@ -50,7 +51,7 @@ public class CustomStaticMethodInterceptor implements StaticMethodInterceptor {
             recordRequest.setResponseClass(ret.getClass().getName());
             recordRequest.setTimestamp(new Date());
             String serializedRequest = JSON.toJSONString(recordRequest, SerializerFeature.WriteMapNullValue);
-            KafkaProducerUtil.sendMessage(PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_REQUEST_TOPIC), serializedRequest);
+            KafkaProducerUtil.sendMessage(flowRecordConfig.getKafkaRequestTopic(), serializedRequest);
         }
     }
 

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java
@@ -17,6 +17,7 @@ import com.huawei.apm.bootstrap.lubanops.trace.TraceCollector;
 import com.huawei.flowrecord.config.CommonConst;
 import com.huawei.flowrecord.config.ConfigConst;
 import com.huawei.flowrecord.config.CorrelationConst;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import com.huawei.flowrecord.domain.RecordContext;
 import com.huawei.flowrecord.domain.RecordJob;
 import com.huawei.flowrecord.domain.RecordStatus;
@@ -47,10 +48,10 @@ import java.util.Stack;
 
 /**
  * alibaba dubbo拦截后的增强类
- *
  */
 public class AliDubboInterceptor implements InstanceMethodInterceptor {
     private static final Logger LOGGER = LoggerFactory.getLogger(AliDubboInterceptor.class);
+    private static final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
     public static final String CONSUMER_TAG = "DUBBO_CONSUMER";
     public static final String PROVIDER_TAG = "DUBBO_PROVIDER";
 
@@ -200,7 +201,7 @@ public class AliDubboInterceptor implements InstanceMethodInterceptor {
         recordRequest.setRequestClass(recordContext.requestClass);
         recordRequest.setResponseClass(result.recreate().getClass().getName());
         String serializedrequest = JSON.toJSONString(recordRequest, SerializerFeature.WriteMapNullValue);
-        KafkaProducerUtil.sendMessage(PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_REQUEST_TOPIC), serializedrequest);
+        KafkaProducerUtil.sendMessage(flowRecordConfig.getKafkaRequestTopic(), serializedrequest);
     }
 
     private boolean isRecord(RecordJob recordJob, Invocation invocation) throws UnknownHostException {

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java
@@ -6,6 +6,7 @@ import com.huawei.apm.bootstrap.lubanops.trace.Headers;
 import com.huawei.apm.bootstrap.lubanops.trace.SpanEvent;
 import com.huawei.apm.bootstrap.lubanops.trace.StartTraceRequest;
 import com.huawei.apm.bootstrap.lubanops.trace.TraceCollector;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import com.huawei.flowrecord.utils.*;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
@@ -41,6 +42,7 @@ import java.util.Stack;
 
 public class DubboInterceptor implements InstanceMethodInterceptor {
     private static final Logger LOGGER = LoggerFactory.getLogger(DubboInterceptor.class);
+    private static final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
     public static final String CONSUMER_TAG = "DUBBO_CONSUMER";
     public static final String PROVIDER_TAG = "DUBBO_PROVIDER";
 
@@ -190,7 +192,7 @@ public class DubboInterceptor implements InstanceMethodInterceptor {
         recordRequest.setRequestClass(recordContext.requestClass);
         recordRequest.setResponseClass(result.recreate().getClass().getName());
         String serializedrequest = JSON.toJSONString(recordRequest, SerializerFeature.WriteMapNullValue);
-        KafkaProducerUtil.sendMessage(PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_REQUEST_TOPIC), serializedrequest);
+        KafkaProducerUtil.sendMessage(flowRecordConfig.getKafkaRequestTopic(), serializedrequest);
     }
 
     private boolean isRecord(RecordJob recordJob, Invocation invocation) throws UnknownHostException {

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInterceptor.java
@@ -1,16 +1,16 @@
 package com.huawei.flowrecord.plugins.http.v4;
 
+import com.alibaba.fastjson.JSONObject;
 import com.huawei.apm.bootstrap.common.BeforeResult;
 import com.huawei.apm.bootstrap.interceptors.InstanceMethodInterceptor;
 import com.huawei.apm.bootstrap.lubanops.trace.TraceCollector;
 import com.huawei.flowrecord.config.CommonConst;
-import com.huawei.flowrecord.config.ConfigConst;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import com.huawei.flowrecord.domain.*;
 import com.huawei.flowrecord.utils.AppNameUtil;
 import com.huawei.flowrecord.utils.KafkaProducerUtil;
 import com.huawei.flowrecord.utils.PluginConfigUtil;
 import org.apache.curator.shaded.com.google.common.hash.Hashing;
-import com.huawei.apm.core.ext.lubanops.utils.JSON;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,6 +24,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class HttpServerInterceptor implements InstanceMethodInterceptor {
+
+    private static final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
+
     @Override
     public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) throws Exception {
         if (!"doService".equals(method.getName())) {
@@ -156,10 +159,10 @@ public class HttpServerInterceptor implements InstanceMethodInterceptor {
         recordData.setSubCallKey(subCallKey);
         recordData.setSubCallCount(setSubCallCount(subCallKey));
         recordData.setRequestClass("java.lang.String");
-        recordData.setRequestBody(JSON.toJSONString(requestEntity));
+        recordData.setRequestBody(JSONObject.toJSONString(requestEntity));
         recordData.setResponseClass("java.lang.Object");
-        recordData.setResponseBody(JSON.toJSONString(responseEntity));
-        String serializeData = JSON.toJSONString(recordData);
-        KafkaProducerUtil.sendMessage(PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_REQUEST_TOPIC), serializeData);
+        recordData.setResponseBody(JSONObject.toJSONString(responseEntity));
+        String serializeData = JSONObject.toJSONString(recordData);
+        KafkaProducerUtil.sendMessage(flowRecordConfig.getKafkaRequestTopic(), serializeData);
     }
 }

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/redisson/v3/RedissonInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/redisson/v3/RedissonInterceptor.java
@@ -8,6 +8,7 @@ import com.huawei.apm.bootstrap.common.BeforeResult;
 import com.huawei.apm.bootstrap.interceptors.InstanceMethodInterceptor;
 import com.huawei.apm.bootstrap.lubanops.trace.TraceCollector;
 import com.huawei.flowrecord.config.ConfigConst;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import com.huawei.flowrecord.domain.RecordStatus;
 import com.huawei.flowrecord.domain.Recorder;
 import com.huawei.flowrecord.init.RedissonProcessThreadPool;
@@ -32,10 +33,10 @@ import java.util.HashMap;
 
 /**
  * redisson拦截增强类
- *
  */
 public class RedissonInterceptor implements InstanceMethodInterceptor {
     private static final Logger LOGGER = LoggerFactory.getLogger(RedissonInterceptor.class);
+    private static final FlowRecordConfig flowRecordConfig = PluginConfigUtil.getFlowRecordConfig();
 
     public int setSubCallCount(String subCallKey) {
 
@@ -69,7 +70,7 @@ public class RedissonInterceptor implements InstanceMethodInterceptor {
             recordRequest.setResponseClass(result.getClass().getName());
             recordRequest.setTimestamp(new Date());
             String serializedRequest = JSON.toJSONString(recordRequest, SerializerFeature.WriteMapNullValue);
-            KafkaProducerUtil.sendMessage(PluginConfigUtil.getValueByKey(ConfigConst.KAFKA_REQUEST_TOPIC), serializedRequest);
+            KafkaProducerUtil.sendMessage(flowRecordConfig.getKafkaRequestTopic(), serializedRequest);
         }
     }
 

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/PluginConfigUtil.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/PluginConfigUtil.java
@@ -4,48 +4,27 @@
 
 package com.huawei.flowrecord.utils;
 
-import com.huawei.flowrecord.config.ConfigConst;
-
+import com.huawei.apm.bootstrap.config.ConfigLoader;
+import com.huawei.flowrecord.config.FlowRecordConfig;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-
 /**
  * 配置信息工具类
- *
  */
 public class PluginConfigUtil {
     private static final ILog LOGGER = LogManager.getLogger(PluginConfigUtil.class);
-    private static Properties properties;
-    private static String configFileName = null;
-    private static String active;
+    private static FlowRecordConfig flowRecordConfig;
 
     static {
-        active = ConfigConst.CONFIG_PROFILE_ACTIVE;
-
-        configFileName = "/config-" + active + ".properties";
-        InputStream in = null;
         try {
-            in = PluginConfigUtil.class.getResourceAsStream(configFileName);
-            properties = new Properties();
-            properties.load(in);
-        } catch (IOException e) {
+            flowRecordConfig = ConfigLoader.getConfig(FlowRecordConfig.class);
+        } catch (Exception e) {
             LOGGER.info("[flowrecord]: cannot get properties");
-        } finally {
-            if (null != in) {
-                try {
-                    in.close();
-                } catch (IOException e) {
-                    LOGGER.info("[flowrecord]: cannot close the file");
-                }
-            }
         }
     }
 
-    public static String getValueByKey(String key) {
-        return String.valueOf(properties.getOrDefault(key, "")).trim();
+    public static FlowRecordConfig getFlowRecordConfig() {
+        return flowRecordConfig;
     }
 }

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/resources/META-INF/services/com.huawei.apm.bootstrap.boot.PluginService
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/resources/META-INF/services/com.huawei.apm.bootstrap.boot.PluginService
@@ -1,1 +1,1 @@
-com.huawei.flowrecord.FlowrecordService
+com.huawei.flowrecord.FlowRecordService

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/resources/META-INF/services/com.huawei.apm.bootstrap.config.BaseConfig
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/resources/META-INF/services/com.huawei.apm.bootstrap.config.BaseConfig
@@ -1,0 +1,1 @@
+com.huawei.flowrecord.config.FlowRecordConfig


### PR DESCRIPTION
【issue号】#52
【修改原因】
1.录制插件未实现BaseConfig接口，不支持修改配置文件
2.录制插件心跳发送未调用框架心跳服务
【修改内容】
1.实现BaseConfig接口
2.调用框架心跳服务发送心跳
支持topic可配置
【检查者】@HapThorin @fuziye01
【用例描述】暂无用例
【自测情况】本地测试通过
【影响范围】1.录制插件心跳发送由调用nettyclient改为调用框架心跳服务 2.录制插件中间件配置支持修改