### PR TITLE
【fix】添加在mvn的clean阶段删除前端的构建产物的配置

### DIFF
--- a/sermant-backend/pom.xml
+++ b/sermant-backend/pom.xml
@@ -274,6 +274,24 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>src/main/webapp/frontend/dist</directory>
+                        </fileset>
+                        <fileset>
+                            <directory>src/main/webapp/frontend/node</directory>
+                        </fileset>
+                        <fileset>
+                            <directory>src/main/webapp/frontend/node_modules</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#498

【修改内容】1、backend添加clean时删除前端构建产物的配置

【用例描述】不涉及

【自测情况】1、本地静态检查清理情况；2、基线测试用例已过

【影响范围】不涉及