### PR TITLE
package add monitor module, fix arm can not get cpu cores.

### DIFF
--- a/sermant-plugins/pom.xml
+++ b/sermant-plugins/pom.xml
@@ -34,7 +34,6 @@
                 <module>sermant-service-registry</module>
                 <module>sermant-dynamic-config</module>
                 <module>sermant-router</module>
-                <module>sermant-monitor</module>
                 <module>sermant-loadbalancer</module>
             </modules>
             <build>
@@ -131,6 +130,7 @@
                 <module>sermant-dynamic-config</module>
                 <module>sermant-router</module>
                 <module>sermant-loadbalancer</module>
+                <module>sermant-monitor</module>
             </modules>
         </profile>
     </profiles>

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CpuInfoCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/CpuInfoCommand.java
@@ -16,11 +16,8 @@
 
 package com.huawei.monitor.command;
 
-import com.huaweicloud.sermant.core.common.LoggerFactory;
-
 import java.io.InputStream;
 import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * CPU信息命令
@@ -31,7 +28,7 @@ import java.util.logging.Logger;
  */
 public class CpuInfoCommand extends CommonMonitorCommand<CpuInfoCommand.CpuInfoStat> {
 
-    private static final String COMMAND = "cat /proc/cpuinfo | grep 'core id' | uniq |  wc -l";
+    private static final String COMMAND = "lscpu | grep 'Socket(s)' | uniq |  wc -l";
 
     @Override
     public String getCommand() {


### PR DESCRIPTION
【issue号/问题单号/需求单号】#698

【修改内容】
   1、修复ARM服务器无法获取CPU核心数
   2、修改打包配置，增加monitor插件

【用例描述】
        1、测试linux环境下命令执行获取CPU核心数情况

【自测情况】
        1、测试通过

【影响范围】1、sermant-monior