### PR TITLE
【bug】修复路由规则，配置策略中策略值的bug

### DIFF
--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/label/entity/ValueMatchDeserializer.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/label/entity/ValueMatchDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.huaweicloud.sermant.router.config.label.entity;
 
-import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.router.common.constants.RouterConstant;
 
 import com.alibaba.fastjson.JSONArray;
@@ -35,7 +34,6 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Logger;
 
 /**
  * 值匹配反序列化器
@@ -44,8 +42,6 @@ import java.util.logging.Logger;
  * @since 2022-02-18
  */
 public class ValueMatchDeserializer implements ObjectDeserializer {
-    private static final Logger LOGGER = LoggerFactory.getLogger();
-
     @Override
     public Map<String, List<MatchRule>> deserialze(DefaultJSONParser parser, Type type, Object fieldName) {
         JSONObject args = parser.parseObject();
@@ -119,7 +115,7 @@ public class ValueMatchDeserializer implements ObjectDeserializer {
         if (MatchStrategy.IN.name().equalsIgnoreCase(fieldName)) {
             values.addAll(((JSONArray) value).toJavaList(String.class));
         } else {
-            values.add((String) value);
+            values.add(String.valueOf(value));
         }
         valueMatch.setMatchStrategy(matchStrategy);
         valueMatch.setValues(values);

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/strategy/match/RegexValueMatchStrategy.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/strategy/match/RegexValueMatchStrategy.java
@@ -21,6 +21,7 @@ import com.huaweicloud.sermant.router.config.strategy.ValueMatchStrategy;
 
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * 正则表达式匹配策略
@@ -31,7 +32,12 @@ import java.util.regex.Pattern;
 public class RegexValueMatchStrategy implements ValueMatchStrategy {
     @Override
     public boolean isMatch(List<String> values, String arg) {
-        return !CollectionUtils.isEmpty(values) && values.get(0) != null && arg != null
-            && Pattern.matches(values.get(0), arg);
+        try {
+            return !CollectionUtils.isEmpty(values) && values.get(0) != null && arg != null
+                && Pattern.matches(values.get(0), arg);
+        } catch (PatternSyntaxException ignored) {
+            // 正则表达式不符合，返回false
+            return false;
+        }
     }
 }

--- a/sermant-plugins/sermant-router/router-config-common/src/test/java/com/huaweicloud/sermant/router/config/strategy/match/MatchStrategyTest.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/test/java/com/huaweicloud/sermant/router/config/strategy/match/MatchStrategyTest.java
@@ -57,6 +57,8 @@ public class MatchStrategyTest {
 
     private List<String> regexValues;
 
+    private List<String> invalidRegexValues;
+
     private List<String> emptyList;
 
     private List<String> nullValueList;
@@ -82,6 +84,8 @@ public class MatchStrategyTest {
         intValues.add("10");
         regexValues = new ArrayList<>();
         regexValues.add("^bar.*");
+        invalidRegexValues = new ArrayList<>();
+        invalidRegexValues.add("*");
         emptyList = Collections.emptyList();
         nullValueList = Collections.singletonList(null);
     }
@@ -144,6 +148,9 @@ public class MatchStrategyTest {
 
         // 测试null arg
         Assert.assertFalse(regex.isMatch(regexValues, null, true));
+
+        // 测试无效正则
+        Assert.assertFalse(regex.isMatch(invalidRegexValues, "a", false));
 
         // 测试null values
         Assert.assertFalse(regex.isMatch(null, "BaR", false));

--- a/sermant-plugins/sermant-router/router-config-common/src/test/java/com/huaweicloud/sermant/router/config/utils/RuleUtilsTest.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/test/java/com/huaweicloud/sermant/router/config/utils/RuleUtilsTest.java
@@ -42,8 +42,10 @@ public class RuleUtilsTest {
 
     @Before
     public void before() {
-        String json = "[{\"precedence\":3,\"match\":{\"headers\":{\"region\":{\"parameterName\":\"region\","
-            + "\"exact\":\"foo\",\"operationMark\":\"~\",\"caseInsensitive\":false}}},\"route\":[{\"name\":\"foo\","
+        String json = "[{\"precedence\":3,\"match\":{\"headers\":{\"region\":{\"parameterName\":\"region\",\"exact\":1,"
+            + "\"operationMark\":\"~\",\"caseInsensitive\":false},\"id\":{\"parameterName\":\"region\",\"regex\":\"*\","
+            + "\"operationMark\":\"~\",\"caseInsensitive\":false},\"name\":{\"parameterName\":\"region\","
+            + "\"exact\":\"test\",\"operationMark\":\"~\",\"caseInsensitive\":false}}},\"route\":[{\"name\":\"foo\","
             + "\"weight\":100,\"tags\":{\"version\":\"1.0.1\"}}]},{\"precedence\":2,\"route\":[{\"name\":\"bar\","
             + "\"weight\":100,\"tags\":{\"version\":\"1.0.0\"}}]}]";
         list = Collections.unmodifiableList(JSONArray.parseArray(json, Rule.class));


### PR DESCRIPTION
【修复issue】 #714 

【修改内容】获取策略值时，由强转改为String.valueOf()，正则策略增加try-catch，正则不合法时，返回false

【用例描述】修改UT，覆盖exact: 1与regex: *的情况，

【自测情况】1.启动应用，2.下发路由配置 ，其中策略包含exact: 1与regex: *，规则下发成功

【影响范围】修复bug，对使用无影响
