### PR TITLE
Fix netdev initialization parameter error

### DIFF
--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/NetworkCommand.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/command/NetworkCommand.java
@@ -70,7 +70,7 @@ public class NetworkCommand extends CommonMonitorCommand<NetworkCommand.NetDev> 
                 transmitPackets += Long.parseLong(netDev[TRANSMIT_PACKETS_INDEX]);
             }
         }
-        return new NetDev(receiveBytes, transmitBytes, receivePackets, transmitPackets);
+        return new NetDev(receiveBytes, receivePackets, transmitBytes, transmitPackets);
     }
 
     /**
@@ -86,12 +86,12 @@ public class NetworkCommand extends CommonMonitorCommand<NetworkCommand.NetDev> 
         private final long receiveBytes;
 
         /**
-         * 写速度
+         * 读包速度
          */
         private final long receivePackets;
 
         /**
-         * 读包速度
+         * 写速度
          */
         private final long transmitBytes;
 

--- a/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/plugin/servermonitor/command/NetworkCommand.java
+++ b/sermant-plugins/sermant-server-monitor/server-monitor-service/src/main/java/com/huawei/sermant/plugin/servermonitor/command/NetworkCommand.java
@@ -74,7 +74,7 @@ public class NetworkCommand extends CommonMonitorCommand<NetworkCommand.NetDev> 
                 transmitPackets += Long.parseLong(netDev[TRANSMIT_PACKETS_INDEX]);
             }
         }
-        return new NetDev(receiveBytes, transmitBytes, receivePackets, transmitPackets);
+        return new NetDev(receiveBytes, receivePackets, transmitBytes, transmitPackets);
     }
 
     public static class NetDev {


### PR DESCRIPTION
【修复issue】#719

【修改内容】修改读包速度和写字节速度传输错误。

【用例描述】无用例。

【自测情况】
     1、本地静态检查清理情况；
     2、自测通过；
     3、测试方式：在linux服务器上测试读写字节速度、读写包速度，对比是否读写速度 、读写速度是否差别不大。

【影响范围】1、只影响网络IO具体数值。其他不影响。