### PR TITLE
【fix】Fix the issue that start with error when application not define server port

### DIFF
--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/pom.xml
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/pom.xml
@@ -36,6 +36,8 @@
         <package.plugin.type>plugin</package.plugin.type>
         <spring-components.version>5.3.14</spring-components.version>
         <spring-cloud.version>3.0.0</spring-cloud.version>
+        <zk-config.version>3.0.0</zk-config.version>
+        <nacos-config.version>2.2.0.RELEASE</nacos-config.version>
     </properties>
 
     <dependencies>
@@ -90,6 +92,18 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito-inline.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-zookeeper-config</artifactId>
+            <version>${zk-config.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
+            <version>${nacos-config.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/RefreshNotifier.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/RefreshNotifier.java
@@ -17,13 +17,11 @@
 
 package com.huawei.dynamic.config;
 
-import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * 配置刷新通知器
@@ -32,8 +30,6 @@ import java.util.logging.Logger;
  * @since 2022-04-13
  */
 public class RefreshNotifier {
-    private static final Logger LOGGER = LoggerFactory.getLogger();
-
     private static final int LISTENER_INIT_SIZE = 4;
 
     private final List<DynamicConfigListener> dynamicConfigListeners = new ArrayList<>(LISTENER_INIT_SIZE);

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/CseDynamicConfigSourceTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/CseDynamicConfigSourceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.OrderConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+/**
+ * 测试cse配置类
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class CseDynamicConfigSourceTest {
+    @Test
+    public void test() {
+        try (final MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class)){
+            pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
+                    .thenReturn(new DynamicConfiguration());
+            final DynamicConfigSource source = getSource();
+            String key = "dynamicConfig";
+            Object value = "test";
+            source.doAccept(new OrderConfigEvent("id", "group", key + ": " + value, DynamicConfigEventType.CREATE,
+                    Collections.singletonMap(key, value)));
+            Assert.assertEquals(source.getConfig(key), value);
+        }
+    }
+
+    /**
+     * 获取配置源
+     *
+     * @return 配置源
+     */
+    protected DynamicConfigSource getSource() {
+        return new CseDynamicConfigSource();
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/DefaultDynamicConfigSourceTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/DefaultDynamicConfigSourceTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config;
+
+/**
+ * 默认配置
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class DefaultDynamicConfigSourceTest extends CseDynamicConfigSourceTest {
+    @Override
+    protected DynamicConfigSource getSource() {
+        return new DefaultDynamicConfigSource();
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/closer/ConfigCenterCloserTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/closer/ConfigCenterCloserTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.closer;
+
+import com.alibaba.cloud.nacos.client.NacosPropertySource;
+import com.huaweicloud.sermant.core.utils.ClassUtils;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.cloud.zookeeper.config.ZookeeperPropertySource;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+/**
+ * 关闭器测试
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class ConfigCenterCloserTest {
+    /**
+     * 测试加载api
+     */
+    @Test
+    public void loadSpi() {
+        List<ConfigCenterCloser> closers = new ArrayList<>();
+        for(ConfigCenterCloser closer : ServiceLoader.load(ConfigCenterCloser.class)) {
+            closers.add(closer);
+        }
+        Assert.assertFalse(closers.isEmpty());
+    }
+
+    /**
+     * 测试nacos关闭器
+     */
+    @Test
+    public void testNacosClose() {
+        final BeanFactory beanFactory = Mockito.mock(BeanFactory.class);
+        final ConfigurableEnvironment environment = Mockito.mock(ConfigurableEnvironment.class);
+        final NacosConfigCenterCloser nacosConfigCenterCloser = new NacosConfigCenterCloser();
+        final Optional<Object> refresherName = ReflectUtils.getFieldValue(nacosConfigCenterCloser, "REFRESHER_NAME");
+        Assert.assertTrue(refresherName.isPresent());
+        final String realName = (String) refresherName.get();
+        Mockito.when(beanFactory.getBean(realName)).thenReturn(new Object());
+        try(final MockedStatic<ClassUtils> classUtilsMockedStatic = Mockito.mockStatic(ClassUtils.class);) {
+            classUtilsMockedStatic.when(() -> ClassUtils
+                    .loadClass("com.alibaba.cloud.nacos.refresh.NacosContextRefresher", Thread.currentThread()
+                            .getContextClassLoader(), false)).thenReturn(Optional.of(Object.class));
+            Assert.assertTrue(nacosConfigCenterCloser.isSupport(beanFactory));
+            final MutablePropertySources propertySources = Mockito.mock(MutablePropertySources.class);
+            Mockito.when(environment.getPropertySources()).thenReturn(propertySources);
+            final CompositePropertySource compositePropertySource = new CompositePropertySource("test-nacos");
+            final CompositePropertySource innerSource = new CompositePropertySource("NACOS");
+            innerSource.getPropertySources().add(buildNacosPropertySource());
+            compositePropertySource.addPropertySource(innerSource);
+            Mockito.when(propertySources.get(ConfigCenterCloser.BOOTSTRAP_SOURCE_NAME)).thenReturn((PropertySource) compositePropertySource);
+            Assert.assertTrue(nacosConfigCenterCloser.close(beanFactory, environment));
+        } catch (Exception exception) {
+            // ignored
+        }
+    }
+
+    /**
+     * nacos源构建
+     *
+     * @return source
+     * @throws Exception 不会抛出
+     */
+    public NacosPropertySource buildNacosPropertySource() throws Exception {
+        final Class<?> sourceClass = Thread.currentThread().getContextClassLoader()
+                .loadClass(NacosPropertySource.class.getName());
+        final Constructor<?> declaredConstructor = sourceClass
+                .getDeclaredConstructor(String.class, String.class, Map.class, Date.class, boolean.class);
+        declaredConstructor.setAccessible(true);
+        return (NacosPropertySource) declaredConstructor
+                .newInstance("id", "group", new HashMap<>(), new Date(), false);
+    }
+
+    /**
+     * 测试zk关闭器
+     */
+    @Test
+    public void testZkClose() {
+        final BeanFactory beanFactory = Mockito.mock(BeanFactory.class);
+        final ConfigurableEnvironment environment = Mockito.mock(ConfigurableEnvironment.class);
+        final ZkConfigCenterCloser zkConfigCenterCloser = new ZkConfigCenterCloser();
+        final Optional<Object> watcherNames = ReflectUtils.getFieldValue(zkConfigCenterCloser, "watcherNames");
+        Assert.assertTrue(watcherNames.isPresent() && watcherNames.get() instanceof List);
+        List<String> realNames = (List<String>) watcherNames.get();
+        Assert.assertFalse(realNames.isEmpty());
+        Mockito.when(beanFactory.getBean(realNames.get(0))).thenReturn(new CloseWatcher());
+        try(final MockedStatic<ClassUtils> classUtilsMockedStatic = Mockito.mockStatic(ClassUtils.class);) {
+            classUtilsMockedStatic.when(() -> ClassUtils
+                    .loadClass("org.springframework.cloud.zookeeper.config.ConfigWatcher", Thread.currentThread()
+                            .getContextClassLoader(), false)).thenReturn(Optional.of(Object.class));
+            Assert.assertTrue(zkConfigCenterCloser.isSupport(beanFactory));
+            final MutablePropertySources propertySources = Mockito.mock(MutablePropertySources.class);
+            Mockito.when(environment.getPropertySources()).thenReturn(propertySources);
+            final CompositePropertySource compositePropertySource = new CompositePropertySource("test-zk");
+            final CompositePropertySource innerSource = new CompositePropertySource("zookeeper");
+            innerSource.getPropertySources().add(buildZkSource());
+            compositePropertySource.addPropertySource(innerSource);
+            Mockito.when(propertySources.get(ConfigCenterCloser.BOOTSTRAP_SOURCE_NAME)).thenReturn((PropertySource) compositePropertySource);
+            Assert.assertTrue(zkConfigCenterCloser.close(beanFactory, environment));
+        } catch (Exception exception) {
+            // ignored
+        }
+    }
+
+    /**
+     * 构建zk配置源
+     *
+     * @return source
+     * @throws Exception 不会抛出
+     */
+    public ZookeeperPropertySource buildZkSource() throws Exception {
+        final CuratorFramework framework = Mockito.mock(CuratorFramework.class);
+        final GetChildrenBuilder childrenBuilder = Mockito.mock(GetChildrenBuilder.class);
+        Mockito.when(childrenBuilder.forPath("config/application")).thenReturn(Collections.singletonList("/test"));
+        Mockito.when(framework.getChildren()).thenReturn(childrenBuilder);
+        return new ZookeeperPropertySource("config/application", framework);
+    }
+
+    /**
+     * 测试用watch
+     *
+     * @since 2022-09-05
+     */
+    static class CloseWatcher {
+        private void close() {
+        }
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/entity/DynamicPropertiesTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/entity/DynamicPropertiesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.entity;
+
+import com.huawei.dynamic.config.init.DynamicConfigInitializer;
+
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 属性初始化测试
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class DynamicPropertiesTest {
+    /**
+     * 测试初始化方法
+     */
+    @Test
+    public void testInit() {
+        final DynamicProperties dynamicProperties = new DynamicProperties();
+        String serviceName = "testService";
+        ReflectUtils.setFieldValue(dynamicProperties, "serviceName", serviceName);
+        try(final MockedStatic<ServiceManager> serviceManagerMockedStatic = Mockito.mockStatic(ServiceManager.class)) {
+            final AtomicBoolean executed = new AtomicBoolean();
+            final DynamicConfigInitializer dynamicConfigInitializer = new DynamicConfigInitializer() {
+                @Override
+                public void doStart() {
+                    executed.set(true);
+                }
+            };
+            serviceManagerMockedStatic.when(() -> ServiceManager.getService(DynamicConfigInitializer.class))
+                    .thenReturn(dynamicConfigInitializer);
+            dynamicProperties.init();
+            Assert.assertTrue(executed.get());
+            Assert.assertEquals(ClientMeta.INSTANCE.getServiceName(), serviceName);
+        }
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/init/DynamicConfigThreadFactoryTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/init/DynamicConfigThreadFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.init;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 线程工厂测试
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class DynamicConfigThreadFactoryTest {
+    /**
+     * 测试线程工厂是否生效
+     */
+    @Test
+    public void test() {
+        String threadName = "thread-1";
+        final DynamicConfigThreadFactory dynamicConfigThreadFactory = new DynamicConfigThreadFactory(threadName);
+        final ExecutorService executorService = Executors.newFixedThreadPool(1, dynamicConfigThreadFactory);
+        executorService.execute(() -> {
+            Assert.assertEquals(Thread.currentThread().getName(), threadName);
+        });
+        executorService.shutdown();
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/interceptors/MutableSourceInterceptorTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/interceptors/MutableSourceInterceptorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.interceptors;
+
+import com.huawei.dynamic.config.ConfigHolder;
+import com.huawei.dynamic.config.DynamicConfiguration;
+import com.huawei.dynamic.config.closer.ConfigCenterCloserTest;
+import com.huawei.dynamic.config.source.OriginConfigDisableSource;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.PropertySource;
+
+import java.util.Collections;
+
+/**
+ * MutableSource拦截器测试
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class MutableSourceInterceptorTest {
+    @Test
+    public void test() {
+        try (final MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic = Mockito
+                .mockStatic(PluginConfigManager.class)) {
+            final DynamicConfiguration configuration = new DynamicConfiguration();
+            pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
+                    .thenReturn(configuration);
+            final MutableSourceInterceptor interceptor = new MutableSourceInterceptor();
+            final ExecuteContext context = interceptor.doBefore(buildContext(null));
+            Assert.assertFalse(context.isSkip());
+            final OriginConfigDisableSource test = new OriginConfigDisableSource("test");
+            ConfigHolder.INSTANCE.getConfigSources().add(test);
+            final ExecuteContext zkContext = interceptor.doBefore(buildContext(false));
+            Assert.assertTrue(zkContext.isSkip());
+            final ExecuteContext nacosContext = interceptor.doBefore(buildContext(true));
+            Assert.assertTrue(nacosContext.isSkip());
+        } catch (Exception exception) {
+            // ignored
+        } finally {
+            ConfigHolder.INSTANCE.getConfigSources()
+                    .removeIf(configSource -> configSource.getClass() == OriginConfigDisableSource.class);
+        }
+    }
+
+    private ExecuteContext buildContext(Boolean isNacos) throws Exception {
+        final BootstrapPropertySource bootstrapPropertySource = Mockito.mock(BootstrapPropertySource.class);
+        final ConfigCenterCloserTest configCenterCloserTest = new ConfigCenterCloserTest();
+        PropertySource source;
+        if (isNacos == null) {
+            source = new CompositePropertySource("test");
+        } else if (isNacos) {
+            source = configCenterCloserTest.buildNacosPropertySource();
+        } else {
+            source = configCenterCloserTest.buildZkSource();
+        }
+        Mockito.when(bootstrapPropertySource.getDelegate()).thenReturn(source);
+        final ExecuteContext context = ExecuteContext.forMemberMethod(this, String.class.getDeclaredMethod("trim"),
+                new Object[]{bootstrapPropertySource}, Collections.emptyMap(), Collections.emptyMap());
+        context.changeResult(new Object());
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/interceptors/ZookeeperLocatorInterceptorTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/interceptors/ZookeeperLocatorInterceptorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.interceptors;
+
+import com.huawei.dynamic.config.ConfigHolder;
+import com.huawei.dynamic.config.DynamicConfiguration;
+import com.huawei.dynamic.config.source.OriginConfigDisableSource;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * 测试zk拦截
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class ZookeeperLocatorInterceptorTest {
+    @Test
+    public void test() {
+        try (final MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic = Mockito
+                .mockStatic(PluginConfigManager.class)) {
+            final DynamicConfiguration configuration = new DynamicConfiguration();
+            pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
+                    .thenReturn(configuration);
+            final ZookeeperLocatorInterceptor zookeeperLocatorInterceptor = new ZookeeperLocatorInterceptor();
+            final ExecuteContext context = zookeeperLocatorInterceptor.doBefore(buildContext());
+            Assert.assertFalse(context.isSkip());
+            ConfigHolder.INSTANCE.getConfigSources().add(new OriginConfigDisableSource("test"));
+            final ExecuteContext closeContext = zookeeperLocatorInterceptor.doBefore(buildContext());
+            Assert.assertTrue(closeContext.isSkip());
+            configuration.setEnableDynamicConfig(true);
+        } catch (NoSuchMethodException e) {
+            // ignored
+        } finally {
+            ConfigHolder.INSTANCE.getConfigSources()
+                    .removeIf(configSource -> configSource.getClass() == OriginConfigDisableSource.class);
+        }
+    }
+
+    private ExecuteContext buildContext() throws NoSuchMethodException {
+        return ExecuteContext.forMemberMethod(this, String.class.getDeclaredMethod("trim"), null, null, null);
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListenerTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListenerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.source;
+
+import static org.junit.Assert.assertEquals;
+
+import com.huawei.dynamic.config.ConfigHolder;
+import com.huawei.dynamic.config.DynamicConfigListener;
+import com.huawei.dynamic.config.DynamicConfiguration;
+import com.huawei.dynamic.config.RefreshNotifier;
+import com.huawei.dynamic.config.closer.ConfigCenterCloser;
+import com.huawei.dynamic.config.entity.DynamicConstants;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 监听器测试
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class OriginConfigCenterDisableListenerTest {
+    private List<DynamicConfigListener> listeners;
+    /**
+     * 测试通知流程
+     */
+    @Test
+    public void test() {
+        try (final MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic = Mockito
+                .mockStatic(PluginConfigManager.class)) {
+            final DynamicConfiguration configuration = new DynamicConfiguration();
+            pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
+                    .thenReturn(configuration);
+            final OriginConfigCenterDisableListener originConfigCenterDisableListener = new OriginConfigCenterDisableListener();
+            final BeanFactory beanFactory = Mockito.mock(BeanFactory.class);
+            originConfigCenterDisableListener.setBeanFactory(beanFactory);
+            originConfigCenterDisableListener.addListener();
+            final RefreshNotifier refreshNotifier = checkConfigListeners();
+            checkClosers(originConfigCenterDisableListener);
+            checkNotify(refreshNotifier, originConfigCenterDisableListener);
+        } finally {
+            listeners.clear();
+        }
+    }
+
+    private void checkNotify(RefreshNotifier refreshNotifier,
+            OriginConfigCenterDisableListener originConfigCenterDisableListener) {
+        final ConfigurableEnvironment environment = Mockito.mock(ConfigurableEnvironment.class);
+        final MutablePropertySources propertySources = new MutablePropertySources();
+        propertySources.addFirst(new CompositePropertySource("test1"));
+        propertySources.addFirst(new CompositePropertySource("test2"));
+        propertySources.addFirst(new CompositePropertySource("test3"));
+        propertySources.addFirst(new CompositePropertySource(DynamicConstants.PROPERTY_NAME));
+        propertySources.addFirst(new CompositePropertySource(DynamicConstants.DISABLE_CONFIG_SOURCE_NAME));
+        Mockito.when(environment.getPropertySources()).thenReturn(propertySources);
+        Mockito.when(environment.getProperty(DynamicConstants.ORIGIN_CONFIG_CENTER_CLOSE_KEY)).thenReturn("true");
+        ReflectUtils.setFieldValue(originConfigCenterDisableListener, "environment", environment);
+        final DynamicConfigEvent event = new DynamicConfigEvent("test", "service:test",
+                DynamicConstants.ORIGIN_CONFIG_CENTER_CLOSE_KEY + ": true", DynamicConfigEventType.CREATE);
+        refreshNotifier.refresh(event);
+        final Optional<Object> isShutdown = ReflectUtils
+                .getFieldValue(originConfigCenterDisableListener, "isShutdown");
+        Assert.assertTrue(isShutdown.isPresent());
+        Assert.assertTrue(isShutdown.get() instanceof AtomicBoolean);
+        Assert.assertTrue(((AtomicBoolean) isShutdown.get()).get());
+        final Iterator<PropertySource<?>> iterator = propertySources.stream().iterator();
+        int index = 0;
+        int count = 2;
+        while (iterator.hasNext()) {
+            final PropertySource<?> next = iterator.next();
+            if (index == 0 && DynamicConstants.PROPERTY_NAME.equals(next.getName())) {
+                count--;
+            }
+            if (index == 1 && DynamicConstants.DISABLE_CONFIG_SOURCE_NAME.equals(next.getName())) {
+                count--;
+            }
+            index++;
+        }
+        assertEquals(0, count);
+    }
+
+    /**
+     * 判断是否添加监听器, 并返回监听器
+     * @return RefreshNotifier
+     */
+    public RefreshNotifier checkConfigListeners() {
+        final Optional<Object> notifier = ReflectUtils.getFieldValue(ConfigHolder.INSTANCE, "notifier");
+        Assert.assertTrue(notifier.isPresent());
+        Assert.assertTrue(notifier.get() instanceof RefreshNotifier);
+        final RefreshNotifier refreshNotifier = (RefreshNotifier) notifier.get();
+        final Optional<Object> dynamicConfigListeners = ReflectUtils
+                .getFieldValue(refreshNotifier, "dynamicConfigListeners");
+        Assert.assertTrue(dynamicConfigListeners.isPresent());
+        Assert.assertTrue(dynamicConfigListeners.get() instanceof List);
+        listeners = (List<DynamicConfigListener>) dynamicConfigListeners.get();
+        Assert.assertFalse(listeners.isEmpty());
+        return refreshNotifier;
+    }
+
+    private void checkClosers(OriginConfigCenterDisableListener originConfigCenterDisableListener) {
+        final Optional<Object> configCenterClosers = ReflectUtils
+                .getFieldValue(originConfigCenterDisableListener, "configCenterClosers");
+        Assert.assertTrue(configCenterClosers.isPresent());
+        Assert.assertTrue(configCenterClosers.get() instanceof List);
+        List<ConfigCenterCloser> closers = (List<ConfigCenterCloser>) configCenterClosers.get();
+        Assert.assertFalse(closers.isEmpty());
+    }
+
+    public List<DynamicConfigListener> getListeners() {
+        return listeners;
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/OriginConfigDisableSourceTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/OriginConfigDisableSourceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.source;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Set;
+
+/**
+ * 测试禁用配置
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class OriginConfigDisableSourceTest {
+    private final OriginConfigDisableSource source = new OriginConfigDisableSource("test");
+
+    @Test
+    public void getConfigNames() {
+        final Set<String> configNames = source.getConfigNames();
+        Assert.assertFalse(configNames.isEmpty());
+    }
+
+    @Test
+    public void getConfig() {
+        final Object config = source.getConfig(OriginConfigDisableSource.ZK_CONFIG_CENTER_ENABLED);
+        Assert.assertNotNull(config);
+        Assert.assertTrue(config instanceof Boolean);
+        Assert.assertEquals(config, false);
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/SpringEventPublisherTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/SpringEventPublisherTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.source;
+
+import com.huawei.dynamic.config.DynamicConfiguration;
+import com.huawei.dynamic.config.RefreshNotifier;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * 事件发布器测试
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class SpringEventPublisherTest {
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Test
+    public void test() {
+        MockitoAnnotations.openMocks(this);
+        try (final MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class)){
+            pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
+                    .thenReturn(new DynamicConfiguration());
+            final SpringEventPublisher springEventPublisher = new SpringEventPublisher();
+            springEventPublisher.setApplicationEventPublisher(applicationEventPublisher);
+            final OriginConfigCenterDisableListenerTest originConfigCenterDisableListenerTest = new OriginConfigCenterDisableListenerTest();
+            final RefreshNotifier refreshNotifier = originConfigCenterDisableListenerTest.checkConfigListeners();
+            refreshNotifier.refresh(new DynamicConfigEvent("id", "group", "config", DynamicConfigEventType.INIT));
+            Mockito.verify(applicationEventPublisher, Mockito.times(0)).publishEvent(Mockito.any());
+            refreshNotifier.refresh(new DynamicConfigEvent("id", "group", "config", DynamicConfigEventType.CREATE));
+            Mockito.verify(applicationEventPublisher, Mockito.times(1)).publishEvent(Mockito.any());
+            originConfigCenterDisableListenerTest.getListeners().clear();
+        }
+    }
+}

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/subscribe/ConfigListenerTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/subscribe/ConfigListenerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.dynamic.config.subscribe;
+
+import com.huawei.dynamic.config.ConfigHolder;
+import com.huawei.dynamic.config.DynamicConfiguration;
+import com.huawei.dynamic.config.sources.TestConfigSources;
+import com.huawei.dynamic.config.sources.TestLowestConfigSources;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.OrderConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+/**
+ * 配置监听器测试
+ *
+ * @author zhouss
+ * @since 2022-09-05
+ */
+public class ConfigListenerTest {
+    @Test
+    public void test() {
+        try (final MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic = Mockito
+                .mockStatic(PluginConfigManager.class);) {
+            pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
+                    .thenReturn(new DynamicConfiguration());
+            final ConfigListener configListener = new ConfigListener();
+            ConfigHolder.INSTANCE.getConfigSources()
+                    .removeIf(configSource -> configSource.getClass() == TestConfigSources.class
+                            || configSource.getClass() == TestLowestConfigSources.class);
+            configListener.process(new OrderConfigEvent("id", "group", "test: 1", DynamicConfigEventType.CREATE,
+                    Collections.singletonMap("test", 1)));
+            Assert.assertEquals(ConfigHolder.INSTANCE.getConfig("test"), 1);
+            ConfigHolder.INSTANCE.getConfigSources().add(new TestConfigSources());
+            ConfigHolder.INSTANCE.getConfigSources().add(new TestLowestConfigSources());
+        }
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/config/RegistrationProperties.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/config/RegistrationProperties.java
@@ -58,7 +58,7 @@ public class RegistrationProperties implements BeanFactoryAware {
     @Value("${dubbo.application.name:${spring.application.name:application}}")
     private String serviceName;
 
-    @Value("${server.port}")
+    @Value("${server.port:8080}")
     private int port;
 
     @Autowired


### PR DESCRIPTION
**What type of PR is this?**
/bugfix

**Which issue(s) this PR fixes**:
**Fixes** #728

- Fix the problem that application start error when user not define server port in config file and env
- Add UT for loadbalancer plugin

**Use case description**:

Start application with registry plugin,  do not config server port for application, then check the application state.
It passed when application start normally.

**Does this PR introduce a user-facing change**?

No

**Additional documentation e.g., usage docs, etc.**:

Affect sermant-loadbalancer;sermant-registry-plugin(spring)



