### PR TITLE
【feature】kakfa、rabbitmq禁消费插件开发

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
@@ -8,6 +8,7 @@ plugins:
   - loadbalancer
   - dynamic-config
   - monitor
+  - deny-consume
 adaptors:
   - lubanops
 profiles:

--- a/sermant-plugins/pom.xml
+++ b/sermant-plugins/pom.xml
@@ -35,6 +35,7 @@
                 <module>sermant-dynamic-config</module>
                 <module>sermant-router</module>
                 <module>sermant-loadbalancer</module>
+                <module>sermant-message</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -106,6 +107,7 @@
                 <module>sermant-loadbalancer</module>
                 <module>sermant-dynamic-config</module>
                 <module>sermant-monitor</module>
+                <module>sermant-message</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -132,6 +134,7 @@
                 <module>sermant-router</module>
                 <module>sermant-loadbalancer</module>
                 <module>sermant-monitor</module>
+                <module>sermant-message</module>
             </modules>
         </profile>
     </profiles>

--- a/sermant-plugins/sermant-message/config/config.yaml
+++ b/sermant-plugins/sermant-message/config/config.yaml
@@ -1,0 +1,3 @@
+deny.consume.plugin:
+  useRabbitmq: false
+  useKafka: false

--- a/sermant-plugins/sermant-message/kafka-consumer-plugin/pom.xml
+++ b/sermant-plugins/sermant-message/kafka-consumer-plugin/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-message</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kafka-consumer-plugin</artifactId>
+    <name>kafka-consumer-plugin</name>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <package.plugin.type>plugin</package.plugin.type>
+        <config.skip.flag>false</config.skip.flag>
+        <kafka.client.version>2.7.2</kafka.client.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>message-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/declarer/KafkaConsumerDeclarer.java
+++ b/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/declarer/KafkaConsumerDeclarer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huaweicloud.sermant.kafka.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.kafka.interceptor.KafkaConsumerConstructorInterceptor;
+import com.huaweicloud.sermant.kafka.interceptor.KafkaConsumerMethodInterceptor;
+import com.huaweicloud.sermant.kafka.matcher.KafkaConsumerMethodMatcher;
+
+/**
+ * kakfa消费端消费declarer<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-09
+ */
+public class KafkaConsumerDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "org.apache.kafka.clients.consumer.KafkaConsumer";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {
+            InterceptDeclarer.build(KafkaConsumerMethodMatcher.matchKafkaMethod(),
+                new KafkaConsumerMethodInterceptor()),
+            InterceptDeclarer.build(MethodMatcher.isConstructor(), new KafkaConsumerConstructorInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/interceptor/KafkaConsumerConstructorInterceptor.java
+++ b/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/interceptor/KafkaConsumerConstructorInterceptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.kafka.interceptor;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.message.common.config.DenyConsumeConfig;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+import java.util.logging.Logger;
+
+/**
+ * kafka consumer的构造方法拦截器，在kafka构造方法执行之后立即关闭KafkaConsumer<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-09
+ */
+public class KafkaConsumerConstructorInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        final DenyConsumeConfig pluginConfig = PluginConfigManager.getPluginConfig(DenyConsumeConfig.class);
+        if (pluginConfig.isUseKafka()) {
+            Object object = context.getObject();
+            if (object instanceof KafkaConsumer) {
+                KafkaConsumer<?, ?> consumer = (KafkaConsumer<?, ?>) object;
+
+                // 方法执行结束后，直接关闭consumer
+                consumer.close();
+                LOGGER.info("kafka consumer has been closed by sermant");
+            }
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/interceptor/KafkaConsumerMethodInterceptor.java
+++ b/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/interceptor/KafkaConsumerMethodInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huaweicloud.sermant.kafka.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.kafka.mock.MockKafkaConsumer;
+import com.huaweicloud.sermant.message.common.config.DenyConsumeConfig;
+import com.huaweicloud.sermant.message.common.utils.MockUtils;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+import java.util.Optional;
+
+/**
+ * KafkaConsumer 禁消费的一个增强拦截器，只处理非close方法<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-09
+ */
+public class KafkaConsumerMethodInterceptor extends AbstractInterceptor {
+    private final Consumer<?, ?> mockConsumer = new MockKafkaConsumer<>();
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        final DenyConsumeConfig pluginConfig = PluginConfigManager.getPluginConfig(DenyConsumeConfig.class);
+        if (pluginConfig.isUseKafka()) {
+            Optional<Object> resultOption =
+                MockUtils.invokeMethod(mockConsumer, context.getMethod(), context.getArguments());
+            context.skip(resultOption.orElse(null));
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/matcher/KafkaConsumerMethodMatcher.java
+++ b/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/matcher/KafkaConsumerMethodMatcher.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.kafka.matcher;
+
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+import net.bytebuddy.description.method.MethodDescription;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 一个自定义的方法匹配器<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-09
+ */
+public abstract class KafkaConsumerMethodMatcher extends MethodMatcher {
+    private static final List<String> INCLUDE_METHOD = Arrays.asList("assignment", "subscription", "subscribe",
+        "assign", "unsubscribe", "poll", "commitSync", "seek", "seekToBeginning", "seekToEnd", "position", "committed",
+        "metrics", "partitionsFor", "listTopics", "paused", "pause", "resume", "offsetsForTimes", "beginningOffsets",
+        "endOffsets", "groupMetadata", "enforceRebalance", "wakeup");
+
+    /**
+     * 非close方法，都需要增强
+     *
+     * @return {@link MethodMatcher}
+     */
+    public static MethodMatcher matchKafkaMethod() {
+        return new MethodMatcher() {
+            @Override
+            public boolean matches(MethodDescription methodDescription) {
+                return methodDescription.isPublic() && !methodDescription.isStatic()
+                    && INCLUDE_METHOD.contains(methodDescription.getActualName());
+            }
+        };
+    }
+}

--- a/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/mock/MockKafkaConsumer.java
+++ b/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/java/com/huaweicloud/sermant/kafka/mock/MockKafkaConsumer.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.kafka.mock;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+/**
+ * 用于kafka禁写的mock的kafka consumer<br>
+ * 非close方法都执行该mock的consumer，而close方法不能增强
+ *
+ * @author yuzl 俞真龙
+ * @param <K> key
+ * @param <V> value
+ * @since 2022-10-09
+ */
+public class MockKafkaConsumer<K, V> implements Consumer<K, V> {
+    @Override
+    public Set<TopicPartition> assignment() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> subscription() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void assign(Collection<TopicPartition> partitions) {
+    }
+
+    @Override
+    public void subscribe(Collection<String> topics) {
+    }
+
+    @Override
+    public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
+    }
+
+    @Override
+    public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
+    }
+
+    @Override
+    public void subscribe(Pattern pattern) {
+    }
+
+    @Override
+    public void unsubscribe() {
+    }
+
+    @Override
+    public ConsumerRecords<K, V> poll(long timeout) {
+        return new ConsumerRecords<>(Collections.emptyMap());
+    }
+
+    @Override
+    public ConsumerRecords<K, V> poll(Duration timeout) {
+        return new ConsumerRecords<>(Collections.emptyMap());
+    }
+
+    @Override
+    public void commitSync() {
+    }
+
+    @Override
+    public void commitSync(Duration timeout) {
+    }
+
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    }
+
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+    }
+
+    @Override
+    public void commitAsync() {
+    }
+
+    @Override
+    public void commitAsync(OffsetCommitCallback callback) {
+    }
+
+    @Override
+    public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+    }
+
+    @Override
+    public void seek(TopicPartition partition, long offset) {
+    }
+
+    @Override
+    public void seek(TopicPartition partition, OffsetAndMetadata offsetAndMetadata) {
+    }
+
+    @Override
+    public void seekToBeginning(Collection<TopicPartition> partitions) {
+    }
+
+    @Override
+    public void seekToEnd(Collection<TopicPartition> partitions) {
+    }
+
+    @Override
+    public long position(TopicPartition partition) {
+        return 0;
+    }
+
+    @Override
+    public long position(TopicPartition partition, Duration timeout) {
+        return 0;
+    }
+
+    @Override
+    public OffsetAndMetadata committed(TopicPartition partition) {
+        return committed(partition, Duration.ZERO);
+    }
+
+    @Override
+    public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
+        return new OffsetAndMetadata(0);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions, Duration timeout) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<MetricName, ? extends Metric> metrics() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(String topic) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<PartitionInfo> partitionsFor(String topic, Duration timeout) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics(Duration timeout) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Set<TopicPartition> paused() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void pause(Collection<TopicPartition> partitions) {
+    }
+
+    @Override
+    public void resume(Collection<TopicPartition> partitions) {
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch,
+        Duration timeout) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions, Duration timeout) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        return new ConsumerGroupMetadata("");
+    }
+
+    @Override
+    public void enforceRebalance() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void close(long timeout, TimeUnit unit) {
+    }
+
+    @Override
+    public void close(Duration timeout) {
+    }
+
+    @Override
+    public void wakeup() {
+    }
+}

--- a/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-message/kafka-consumer-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,1 @@
+com.huaweicloud.sermant.kafka.declarer.KafkaConsumerDeclarer

--- a/sermant-plugins/sermant-message/message-common/pom.xml
+++ b/sermant-plugins/sermant-message/message-common/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-message</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>message-common</artifactId>
+    <name>message-common</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/sermant-plugins/sermant-message/message-common/src/main/java/com/huaweicloud/sermant/message/common/config/DenyConsumeConfig.java
+++ b/sermant-plugins/sermant-message/message-common/src/main/java/com/huaweicloud/sermant/message/common/config/DenyConsumeConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huaweicloud.sermant.message.common.config;
+
+import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfig;
+
+/**
+ * 禁消费的启用配置类<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-13
+ */
+@ConfigTypeKey("deny.consume.plugin")
+public class DenyConsumeConfig implements PluginConfig {
+    /**
+     * 是否使用rabbitmq
+     */
+    private boolean useRabbitmq;
+
+    /**
+     * 是否使用kafka
+     */
+    private boolean useKafka;
+
+    public boolean isUseRabbitmq() {
+        return useRabbitmq;
+    }
+
+    public void setUseRabbitmq(boolean useRabbitmq) {
+        this.useRabbitmq = useRabbitmq;
+    }
+
+    public boolean isUseKafka() {
+        return useKafka;
+    }
+
+    public void setUseKafka(boolean useKafka) {
+        this.useKafka = useKafka;
+    }
+}

--- a/sermant-plugins/sermant-message/message-common/src/main/java/com/huaweicloud/sermant/message/common/utils/MockUtils.java
+++ b/sermant-plugins/sermant-message/message-common/src/main/java/com/huaweicloud/sermant/message/common/utils/MockUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.message.common.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 用于缓存增强类的元数据，并且反射调用mock实例的方法的一个工具类<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-11
+ */
+public final class MockUtils {
+    private static final Map<Method, Optional<Method>> METHODS = new ConcurrentHashMap<>();
+
+    private MockUtils() {
+    }
+
+    /**
+     * 调用方法
+     *
+     * @param mockObj   模拟obj
+     * @param method    方法
+     * @param arguments 参数
+     * @return {@link Object}
+     */
+    public static Optional<Object> invokeMethod(Object mockObj, Method method, Object[] arguments) {
+        Optional<Method> methodOptional = METHODS.computeIfAbsent(method, m -> getMethod(mockObj, m));
+        if (!methodOptional.isPresent()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(methodOptional.get().invoke(mockObj, arguments));
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<Method> getMethod(Object mockObj, Method method) {
+        try {
+            return Optional
+                .ofNullable(mockObj.getClass().getDeclaredMethod(method.getName(), method.getParameterTypes()));
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/sermant-plugins/sermant-message/message-common/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
+++ b/sermant-plugins/sermant-message/message-common/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
@@ -1,0 +1,1 @@
+com.huaweicloud.sermant.message.common.config.DenyConsumeConfig

--- a/sermant-plugins/sermant-message/pom.xml
+++ b/sermant-plugins/sermant-message/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-plugins</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>sermant-message</artifactId>
+    <name>sermant-message</name>
+    <modules>
+        <module>kafka-consumer-plugin</module>
+        <module>rabbitmq-consumer-plugin</module>
+        <module>message-common</module>
+    </modules>
+    <packaging>pom</packaging>
+
+    <properties>
+        <sermant.basedir>${pom.basedir}/../../..</sermant.basedir>
+        <package.plugin.name>deny-consume</package.plugin.name>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.huaweicloud.sermant</groupId>
+                <artifactId>message-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>agent</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>kafka-consumer-plugin</module>
+                <module>rabbitmq-consumer-plugin</module>
+                <module>message-common</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>all</id>
+            <modules>
+                <module>kafka-consumer-plugin</module>
+                <module>rabbitmq-consumer-plugin</module>
+                <module>message-common</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>release</id>
+            <modules>
+                <module>kafka-consumer-plugin</module>
+                <module>rabbitmq-consumer-plugin</module>
+                <module>message-common</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>

--- a/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/pom.xml
+++ b/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-message</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rabbitmq-consumer-plugin</artifactId>
+
+    <name>rabbitmq-consumer-plugin</name>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <package.plugin.type>plugin</package.plugin.type>
+        <config.skip.flag>false</config.skip.flag>
+        <amqp.client.version>5.8.0</amqp.client.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>message-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <version>${amqp.client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/src/main/java/com/huaweicloud/sermant/rabbitmq/declarer/RabbitmqChannelDeclarer.java
+++ b/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/src/main/java/com/huaweicloud/sermant/rabbitmq/declarer/RabbitmqChannelDeclarer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rabbitmq.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.rabbitmq.interceptor.RabbitmqChannelInterceptor;
+
+import net.bytebuddy.description.method.MethodDescription;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 对rabbit mq的禁消费的一个增强定义<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-11
+ */
+public class RabbitmqChannelDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 基本的消费
+     */
+    public static final String BASIC_CONSUME = "basicConsume";
+    /**
+     * 基本消
+     */
+    public static final String BASIC_ACK = "basicAck";
+
+    private static final String ENHANCE_CLASS = "com.rabbitmq.client.impl.ChannelN";
+    private static final List<String> ENHANCE_METHODS = Arrays.asList(BASIC_CONSUME, BASIC_ACK);
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {InterceptDeclarer.build(rabbitmqMatcher(), new RabbitmqChannelInterceptor())};
+    }
+
+    private MethodMatcher rabbitmqMatcher() {
+        return new MethodMatcher() {
+            @Override
+            public boolean matches(MethodDescription methodDescription) {
+                return ENHANCE_METHODS.contains(methodDescription.getActualName());
+            }
+        };
+    }
+}

--- a/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/src/main/java/com/huaweicloud/sermant/rabbitmq/interceptor/RabbitmqChannelInterceptor.java
+++ b/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/src/main/java/com/huaweicloud/sermant/rabbitmq/interceptor/RabbitmqChannelInterceptor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rabbitmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.message.common.config.DenyConsumeConfig;
+import com.huaweicloud.sermant.rabbitmq.declarer.RabbitmqChannelDeclarer;
+
+/**
+ * 用于对rabbit mq的一个拦截操作<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-11
+ */
+public class RabbitmqChannelInterceptor extends AbstractInterceptor {
+    private static final String MOCK_CONSUMER_TAG = "";
+    private static final String MOCK_VOID = null;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        final DenyConsumeConfig pluginConfig = PluginConfigManager.getPluginConfig(DenyConsumeConfig.class);
+        if (pluginConfig.isUseRabbitmq()) {
+            skip(context);
+        }
+        return context;
+    }
+
+    private void skip(ExecuteContext context) {
+        String methodName = context.getMethod().getName();
+        if (RabbitmqChannelDeclarer.BASIC_CONSUME.equals(methodName)) {
+            context.skip(MOCK_CONSUMER_TAG);
+        } else if (RabbitmqChannelDeclarer.BASIC_ACK.equals(methodName)) {
+            context.skip(MOCK_VOID);
+        }
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-message/rabbitmq-consumer-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,1 @@
+com.huaweicloud.sermant.rabbitmq.declarer.RabbitmqChannelDeclarer


### PR DESCRIPTION
【修复issue】#816

【修改内容】新增了kafka、rabbitmq的禁消费插件

【用例描述】暂无

【自测情况】1、本地静态检查清理情况；2、本地集成测试通过；3、UT待补充；

【影响范围】1、启用后对kafka、rabbitmq消费存在影响 
