### PR TITLE
【fix】修改集成测试中出现的问题

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/logback.xml
+++ b/sermant-agentcore/sermant-agentcore-config/config/logback.xml
@@ -4,11 +4,12 @@
 
     <!-- 定义日志文件 输出位置 -->
     <property name="log.home_dir" value="${sermant_log_dir:-./logs/sermant/core}"/>
-    <property name="log.app_name" value="sermant"/>
+    <property name="log.app_name" value="${sermant_app_name:-sermant}"/>
     <!-- 日志最大的历史 30天 -->
     <property name="log.maxHistory" value="${sermant_log_max_history:-30}"/>
     <property name="log.level" value="${sermant_log_level:-info}"/>
     <property name="log.maxSize" value="${sermant_log_max_size:-5MB}" />
+    <property name="log.totalSize" value="${sermant_log_total_size:-20GB}"/>
 
     <!-- 设置日志输出格式 -->
     <!-- %d{yyyy-MM-dd HH:mm:ss.SSS}日期-->
@@ -19,7 +20,7 @@
     <!-- %thread线程名称-->
     <!-- %m或者%msg为信息-->
     <!-- %n换行-->
-    <property name="log.pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %le %F %C %M %L [%thread] %m%n"/>
+    <property name="log.pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%le] [%C] [%M:%L] [%thread] %m%n"/>
 
     <!-- ConsoleAppender 控制台输出日志 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -41,17 +42,19 @@
             <fileNamePattern>${log.home_dir}/app/%d{yyyy-MM-dd}/${log.app_name}-%i.log</fileNamePattern>
             <maxHistory>${log.maxHistory}</maxHistory>
             <MaxFileSize>${log.maxSize}</MaxFileSize>
+            <totalSizeCap>${log.totalSize}</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder>
-            <pattern>${log.pattern}</pattern>
+            <pattern>
+                ${log.pattern}
+            </pattern>
         </encoder>
     </appender>
 
-    <!-- root级别   DEBUG -->
     <root>
         <!-- 打印debug级别日志及以上级别日志 -->
         <level value="${log.level}"/>
-        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="app" />
     </root>
 

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/FrameworkClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/FrameworkClassLoader.java
@@ -16,8 +16,11 @@
 
 package com.huaweicloud.sermant.core.classloader;
 
+import com.huaweicloud.sermant.core.common.BootArgsIndexer;
 import com.huaweicloud.sermant.core.common.CommonConstant;
 
+import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.HashMap;
@@ -80,7 +83,16 @@ public class FrameworkClassLoader extends URLClassLoader {
 
         // 针对日志配置文件，定制化getResource方法，获取FrameworkClassloader下资源文件中的logback.xml
         if (CommonConstant.LOG_SETTING_FILE_NAME.equals(name)) {
-            url = findResource(name);
+            File logSettingFile = BootArgsIndexer.getLogSettingFile();
+            if (logSettingFile.exists() && logSettingFile.isFile()) {
+                try {
+                    url = logSettingFile.toURI().toURL();
+                } catch (MalformedURLException e) {
+                    url = findResource(name);
+                }
+            } else {
+                url = findResource(name);
+            }
         }
         if (url == null) {
             url = super.getResource(name);

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/BootArgsIndexer.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/BootArgsIndexer.java
@@ -61,6 +61,11 @@ public class BootArgsIndexer {
     private static File pluginSettingFile;
 
     /**
+     * 日志配置
+     */
+    private static File logSettingFile;
+
+    /**
      * pluginPackage插件包
      */
     private static File pluginPackageDir;
@@ -94,6 +99,10 @@ public class BootArgsIndexer {
         return pluginPackageDir;
     }
 
+    public static File getLogSettingFile() {
+        return logSettingFile;
+    }
+
     public static String getAppName() {
         return appName;
     }
@@ -124,6 +133,11 @@ public class BootArgsIndexer {
                 .toString()));
         if (!pluginSettingFile.exists() || !pluginSettingFile.isFile()) {
             LOGGER.warning("Plugin setting file is not found! ");
+        }
+        logSettingFile = new File(FileUtils.validatePath(argsMap.get(CommonConstant.LOG_SETTING_FILE_KEY)
+                .toString()));
+        if (!logSettingFile.exists() || !logSettingFile.isFile()) {
+            LOGGER.warning("Log setting file is not found! Using default log setting file in resources.");
         }
         pluginPackageDir = new File(FileUtils.validatePath(argsMap.get(CommonConstant.PLUGIN_PACKAGE_DIR_KEY)
                 .toString()));

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
@@ -21,6 +21,7 @@ import com.huaweicloud.sermant.core.classloader.FrameworkClassLoader;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -52,6 +53,7 @@ public class LoggerFactory {
             throw new RuntimeException(e);
         }
         logger = java.util.logging.Logger.getLogger("sermant");
+        logger.setLevel(Level.ALL);
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/resources/logback.xml
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/resources/logback.xml
@@ -3,12 +3,24 @@
 <configuration scan="true">
 
     <!-- 定义日志文件 输出位置 -->
-    <property name="log.home_dir" value="./logs/sermant/core"/>
-    <property name="log.app_name" value="sermant"/>
+    <property name="log.home_dir" value="${sermant_log_dir:-./logs/sermant/core}"/>
+    <property name="log.app_name" value="${sermant_app_name:-sermant}"/>
     <!-- 日志最大的历史 30天 -->
-    <property name="log.maxHistory" value="30"/>
-    <property name="log.level" value="info"/>
-    <property name="log.maxSize" value="5MB" />
+    <property name="log.maxHistory" value="${sermant_log_max_history:-30}"/>
+    <property name="log.level" value="${sermant_log_level:-info}"/>
+    <property name="log.maxSize" value="${sermant_log_max_size:-5MB}" />
+    <property name="log.totalSize" value="${sermant_log_total_size:-20GB}"/>
+
+    <!-- 设置日志输出格式 -->
+    <!-- %d{yyyy-MM-dd HH:mm:ss.SSS}日期-->
+    <!-- %C类的完整名称-->
+    <!-- %F文件名-->
+    <!-- %M为method-->
+    <!-- %L为行号-->
+    <!-- %thread线程名称-->
+    <!-- %m或者%msg为信息-->
+    <!-- %n换行-->
+    <property name="log.pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%le] [%C] [%M:%L] [%thread] %m%n"/>
 
     <!-- ConsoleAppender 控制台输出日志 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -19,8 +31,7 @@
         </filter>
         <encoder>
             <pattern>
-                <!-- 设置日志输出格式 -->
-                %d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%thread] %logger - %msg%n
+                ${log.pattern}
             </pattern>
         </encoder>
     </appender>
@@ -31,17 +42,19 @@
             <fileNamePattern>${log.home_dir}/app/%d{yyyy-MM-dd}/${log.app_name}-%i.log</fileNamePattern>
             <maxHistory>${log.maxHistory}</maxHistory>
             <MaxFileSize>${log.maxSize}</MaxFileSize>
+            <totalSizeCap>${log.totalSize}</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] %logger - %msg%n</pattern>
+            <pattern>
+                ${log.pattern}
+            </pattern>
         </encoder>
     </appender>
 
-    <!-- root级别   DEBUG -->
     <root>
         <!-- 打印debug级别日志及以上级别日志 -->
         <level value="${log.level}"/>
-        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="app" />
     </root>
 

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/AgentPremain.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/AgentPremain.java
@@ -56,13 +56,13 @@ public class AgentPremain {
      * @throws DupPremainException
      */
     public static void premain(String agentArgs, Instrumentation instrumentation) {
-        // 执行标记，防止重复运行
-        if (executeFlag) {
-            throw new DupPremainException();
-        }
-        executeFlag = true;
-
         try {
+            // 执行标记，防止重复运行
+            if (executeFlag) {
+                throw new DupPremainException();
+            }
+            executeFlag = true;
+
             // 添加核心库
             LOGGER.info(String.format(Locale.ROOT, "Loading core library from [%s].", PathDeclarer.getCorePath()));
             loadCoreLib(instrumentation);

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/common/BootArgsBuilder.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/common/BootArgsBuilder.java
@@ -113,11 +113,7 @@ public abstract class BootArgsBuilder {
         String key = CommonConstant.APP_NAME_KEY;
         if (!argsMap.containsKey(key)) {
             final String value = getCommonValue(key, configMap);
-            if (value == null) {
-                throw new IllegalArgumentException(CommonConstant.APP_NAME_KEY + " not found. ");
-            } else {
-                argsMap.put(key, value);
-            }
+            argsMap.put(key, value == null ? "default" : value);
         }
         key = CommonConstant.INSTANCE_NAME_KEY;
         if (!argsMap.containsKey(key)) {


### PR DESCRIPTION
【修复issue】#818
【修改内容】
1、日志配置新增全部日志存储上限 
2、日志默认不打印到控制台 
3、日志配置优先读取构建产物config目录下的logback.xml
4、不再校验启动命令中的appName 
5、捕获premain重复运行抛出异常，防止中断宿主应用
【用例描述】不涉及
【自测情况】相关集成测试用例已通过
【影响范围】不涉及