### PR TITLE
【bug】修复纯springboot应用使用注册插件无法监听配置的bug

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -3,6 +3,7 @@ agent.config.isEnhanceBootStrapEnable=false
 agent.config.ignoredPrefixes=com.huawei.sermant,com.huaweicloud.sermant
 agent.config.combineStrategy=ALL
 agent.config.serviceBlackList=com.huaweicloud.sermant.implement.service.heartbeat.HeartbeatServiceImpl,com.huaweicloud.sermant.implement.service.send.NettyGatewayClient,com.huaweicloud.sermant.implement.service.tracing.TracingServiceImpl
+agent.config.serviceInjectList=com.huawei.discovery.service.lb.filter.NopInstanceFilter,com.huawei.discovery.service.lb.DiscoveryManager
 
 # adaptor config
 adaptor.config.isLoadExtAgentEnable=false

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/EnabledStrategyHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/EnabledStrategyHandler.java
@@ -17,9 +17,9 @@
 package com.huaweicloud.sermant.router.config.handler;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
-import com.huaweicloud.sermant.core.plugin.subscribe.processor.OrderConfigEvent;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
 import com.huaweicloud.sermant.router.config.cache.ConfigCache;
 import com.huaweicloud.sermant.router.config.entity.EnabledStrategy;
@@ -27,11 +27,9 @@ import com.huaweicloud.sermant.router.config.entity.Strategy;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -67,6 +65,7 @@ public class EnabledStrategyHandler extends AbstractConfigHandler {
             newStrategy = Strategy.valueOf(strategyValue.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException ignored) {
             // 不存在该策略，忽略
+            LOGGER.warning(String.format(Locale.ROOT, "Enabled strategy[%s] is invalid.", strategyValue));
             return;
         }
         String value = map.get("value");
@@ -83,14 +82,10 @@ public class EnabledStrategyHandler extends AbstractConfigHandler {
     }
 
     private Map<String, String> getEnabledStrategy(DynamicConfigEvent event) {
-        Map<String, String> map = new HashMap<>();
-        if (event instanceof OrderConfigEvent) {
-            Map<String, Object> allData = ((OrderConfigEvent) event).getAllData();
-            for (Entry<String, Object> entry : allData.entrySet()) {
-                map.put(entry.getKey(), String.valueOf(entry.getValue()));
-            }
-            return map;
+        String content = event.getContent();
+        if (StringUtils.isBlank(content)) {
+            return Collections.emptyMap();
         }
-        return yaml.load(event.getContent());
+        return yaml.load(content);
     }
 }

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/service/ConfigService.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/service/ConfigService.java
@@ -16,14 +16,17 @@
 
 package com.huaweicloud.sermant.router.config.service;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.subscribe.ConfigSubscriber;
 import com.huaweicloud.sermant.core.plugin.subscribe.CseGroupConfigSubscriber;
 import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.config.listener.RouterConfigListener;
 import com.huaweicloud.sermant.router.config.utils.RuleUtils;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
 
 /**
  * 配置服务
@@ -32,6 +35,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @since 2022-07-14
  */
 public abstract class ConfigService {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
     private final AtomicBoolean init = new AtomicBoolean();
 
     /**
@@ -42,6 +47,8 @@ public abstract class ConfigService {
      */
     public void init(String cacheName, String serviceName) {
         if (StringUtils.isBlank(cacheName) || StringUtils.isBlank(serviceName)) {
+            LOGGER.warning(
+                String.format(Locale.ROOT, "CacheName[%s] or serviceName[%s] is empty.", cacheName, serviceName));
             return;
         }
         if (init.compareAndSet(false, true)) {

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/EnabledStrategyHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/EnabledStrategyHandlerTest.java
@@ -118,6 +118,20 @@ public class EnabledStrategyHandlerTest {
     }
 
     /**
+     * 测试handle方法
+     */
+    @Test
+    public void testHandleWithNullContent() {
+        EnabledStrategy strategy = ConfigCache.getEnabledStrategy("testHandleWithNullContent");
+        strategy.reset(Strategy.NONE, Collections.emptyList());
+        DynamicConfigEvent event = new DynamicConfigEvent("sermant.plugin.router", "foo", null,
+            DynamicConfigEventType.MODIFY);
+        handler.handle(event, "testHandleWithNullContent");
+        Assert.assertEquals(Strategy.NONE, strategy.getStrategy());
+        Assert.assertEquals(0, strategy.getValue().size());
+    }
+
+    /**
      * 测试shouldHandle方法
      */
     @Test

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/DiscoveryManagerDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/DiscoveryManagerDeclarer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+
+/**
+ * 注册插件拦截点
+ *
+ * @author provenceee
+ * @since 2022-10-13
+ */
+public class DiscoveryManagerDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS
+        = "com.huawei.discovery.service.lb.DiscoveryManager";
+
+    private static final String INTERCEPT_CLASS
+        = "com.huaweicloud.sermant.router.spring.interceptor.DiscoveryManagerInterceptor";
+
+    private static final String METHOD_NAME = "registry";
+
+    /**
+     * 构造方法
+     */
+    public DiscoveryManagerDeclarer() {
+        super(ENHANCE_CLASS, INTERCEPT_CLASS, METHOD_NAME);
+    }
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/DiscoveryManagerInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/DiscoveryManagerInterceptor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.spring.cache.AppCache;
+import com.huaweicloud.sermant.router.spring.service.SpringConfigService;
+
+import java.util.logging.Logger;
+
+/**
+ * 注册插件拦截点
+ *
+ * @author provenceee
+ * @since 2022-10-13
+ */
+public class DiscoveryManagerInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private final SpringConfigService configService;
+
+    /**
+     * 构造方法
+     */
+    public DiscoveryManagerInterceptor() {
+        configService = ServiceManager.getService(SpringConfigService.class);
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments != null && arguments.length > 0) {
+            Object obj = arguments[0];
+            Object serviceName = ReflectUtils.getFieldValue(obj, "serviceName").orElse(null);
+            if (serviceName instanceof String) {
+                AppCache.INSTANCE.setAppName((String) serviceName);
+            } else {
+                LOGGER.warning("Service name is null or not instanceof string.");
+            }
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        configService.init(RouterConstant.SPRING_CACHE_NAME, AppCache.INSTANCE.getAppName());
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,6 +1,7 @@
 com.huaweicloud.sermant.router.spring.declarer.AbstractHandlerMappingDeclarer
 com.huaweicloud.sermant.router.spring.declarer.BaseLoadBalancerDeclarer
 com.huaweicloud.sermant.router.spring.declarer.ClientHttpRequestDeclarer
+com.huaweicloud.sermant.router.spring.declarer.DiscoveryManagerDeclarer
 com.huaweicloud.sermant.router.spring.declarer.EurekaHttpClientDeclarer
 com.huaweicloud.sermant.router.spring.declarer.FeignClientDeclarer
 com.huaweicloud.sermant.router.spring.declarer.HandlerExecutionChainDeclarer

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/test/java/com/huaweicloud/sermant/router/spring/interceptor/DiscoveryManagerInterceptorTest.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/test/java/com/huaweicloud/sermant/router/spring/interceptor/DiscoveryManagerInterceptorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.spring.cache.AppCache;
+import com.huaweicloud.sermant.router.spring.service.SpringConfigService;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * 测试DiscoveryManagerInterceptor
+ *
+ * @author provenceee
+ * @since 2022-10-13
+ */
+public class DiscoveryManagerInterceptorTest {
+    private final DiscoveryManagerInterceptor interceptor;
+
+    private final ExecuteContext context;
+
+    private static TestSpringConfigService configService;
+
+    private static MockedStatic<ServiceManager> mockServiceManager;
+
+    /**
+     * UT执行前进行mock
+     */
+    @BeforeClass
+    public static void before() {
+        configService = new TestSpringConfigService();
+        mockServiceManager = Mockito.mockStatic(ServiceManager.class);
+        mockServiceManager.when(() -> ServiceManager.getService(SpringConfigService.class)).thenReturn(configService);
+    }
+
+    /**
+     * UT执行后释放mock对象
+     */
+    @AfterClass
+    public static void after() {
+        mockServiceManager.close();
+    }
+
+    public DiscoveryManagerInterceptorTest() {
+        interceptor = new DiscoveryManagerInterceptor();
+        Object[] arguments = new Object[1];
+        arguments[0] = new TestObject("foo");
+        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+
+    /**
+     * 测试before方法
+     */
+    @Test
+    public void testBefore() {
+        interceptor.before(context);
+        Assert.assertEquals("foo", AppCache.INSTANCE.getAppName());
+
+        context.getArguments()[0] = new TestObject(null);
+        interceptor.before(context);
+        Assert.assertEquals("foo", AppCache.INSTANCE.getAppName());
+    }
+
+    /**
+     * 测试after方法
+     */
+    @Test
+    public void testAfter() {
+        AppCache.INSTANCE.setAppName("foo");
+        interceptor.after(context);
+        Assert.assertEquals(RouterConstant.SPRING_CACHE_NAME, configService.getCacheName());
+        Assert.assertEquals("foo", configService.getServiceName());
+    }
+
+    private static class TestObject {
+        private final String serviceName;
+
+        /**
+         * 构造方法
+         *
+         * @param serviceName 服务名
+         */
+        public TestObject(String serviceName) {
+            this.serviceName = serviceName;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+    }
+}


### PR DESCRIPTION
【修复issue】Fixes #820 

【修改内容】新增注册插件拦截点

【用例描述】不涉及

【自测情况】纯springboot应用使用注册插件时，路由插件正常监听配置

【影响范围】纯springboot应用使用注册插件时，路由插件正常监听配置
