### PR TITLE
【fix】添加zookeeper的连接超时时间，预防连接时间过长导致插件使用动态配置失败

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/all/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/all/config.properties
@@ -2,7 +2,7 @@
 agent.config.isEnhanceBootStrapEnable=false
 agent.config.ignoredPrefixes=com.huawei.sermant,com.huaweicloud.sermant
 agent.config.combineStrategy=ALL
-agent.config.serviceBlackList=com.huaweicloud.sermant.core.service.heartbeat.HeartbeatServiceImpl,com.huaweicloud.sermant.core.service.send.NettyGatewayClient,com.huaweicloud.sermant.core.service.tracing.TracingServiceImpl
+agent.config.serviceBlackList=com.huaweicloud.sermant.implement.service.heartbeat.HeartbeatServiceImpl,com.huaweicloud.sermant.implement.service.send.NettyGatewayClient,com.huaweicloud.sermant.implement.service.tracing.TracingServiceImpl
 
 # adaptor config
 adaptor.config.isLoadExtAgentEnable=false
@@ -12,6 +12,8 @@ dynamic.config.timeoutValue=30000
 dynamic.config.defaultGroup=sermant
 dynamic.config.serverAddress=127.0.0.1:2181
 dynamic.config.dynamicConfigType=ZOOKEEPER
+dynamic.config.connectRetryTimes=5
+dynamic.config.connectTimeout=1000
 
 # heartbeat config
 heartbeat.interval=3000

--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -12,6 +12,8 @@ dynamic.config.timeoutValue=30000
 dynamic.config.defaultGroup=sermant
 dynamic.config.serverAddress=127.0.0.1:2181
 dynamic.config.dynamicConfigType=ZOOKEEPER
+dynamic.config.connectRetryTimes=5
+dynamic.config.connectTimeout=1000
 
 # heartbeat config
 heartbeat.interval=3000

--- a/sermant-agentcore/sermant-agentcore-config/config/example/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/example/config.properties
@@ -2,7 +2,7 @@
 agent.config.isEnhanceBootStrapEnable=false
 agent.config.ignoredPrefixes=com.huawei.sermant,com.huaweicloud.sermant
 agent.config.combineStrategy=ALL
-agent.config.serviceBlackList=com.huaweicloud.sermant.core.service.heartbeat.HeartbeatServiceImpl,com.huaweicloud.sermant.core.service.send.NettyGatewayClient,com.huaweicloud.sermant.core.service.tracing.TracingServiceImpl
+agent.config.serviceBlackList=com.huaweicloud.sermant.implement.service.heartbeat.HeartbeatServiceImpl,com.huaweicloud.sermant.implement.service.send.NettyGatewayClient,com.huaweicloud.sermant.implement.service.tracing.TracingServiceImpl
 
 # adaptor config
 adaptor.config.isLoadExtAgentEnable=false
@@ -12,6 +12,8 @@ dynamic.config.timeoutValue=30000
 dynamic.config.defaultGroup=sermant
 dynamic.config.serverAddress=127.0.0.1:2181
 dynamic.config.dynamicConfigType=ZOOKEEPER
+dynamic.config.connectRetryTimes=5
+dynamic.config.connectTimeout=1000
 
 # heartbeat config
 heartbeat.interval=3000

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
@@ -16,9 +16,13 @@
 
 package com.huaweicloud.sermant.core.plugin.service;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.service.ServiceManager;
 
+import java.util.Locale;
 import java.util.ServiceLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * 插件服务管理器，核心服务管理器{@link ServiceManager}的特化，专门用来初始化{@link PluginService}
@@ -28,6 +32,8 @@ import java.util.ServiceLoader;
  * @since 2021-11-12
  */
 public class PluginServiceManager extends ServiceManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
     private PluginServiceManager() {
         super();
     }
@@ -40,7 +46,12 @@ public class PluginServiceManager extends ServiceManager {
     public static void initPluginService(ClassLoader classLoader) {
         for (PluginService service : ServiceLoader.load(PluginService.class, classLoader)) {
             if (loadService(service, service.getClass(), PluginService.class)) {
-                service.start();
+                try {
+                    service.start();
+                } catch (Exception ex) {
+                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "Error occurs while starting plugin service: %s",
+                            service.getClass()), ex);
+                }
             }
         }
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceManager.java
@@ -74,12 +74,7 @@ public class ServiceManager {
             ClassLoaderManager.getFrameworkClassLoader())) {
             if (!AGENT_CONFIG.getServiceBlackList().contains(service.getClass().getName())
                 && loadService(service, service.getClass(), BaseService.class)) {
-                try {
-                    service.start();
-                } catch (Exception ex) {
-                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "Error occurs while starting service: %s",
-                            service.getClass()), ex);
-                }
+                service.start();
             }
         }
         addStopHook(); // 加载完所有服务再启动服务

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/config/DynamicConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/config/DynamicConfig.java
@@ -32,11 +32,27 @@ import java.util.Locale;
 public class DynamicConfig implements BaseConfig {
     private static final int TIME_OUT_VALUE = 30000;
 
+    private static final int CONNECT_TIMEOUT = 1000;
+
+    private static final int CONNECT_RETRY_TIMES = 5;
+
     /**
      * 服务器连接超时时间
      */
     @ConfigFieldKey("timeoutValue")
     private int timeoutValue = TIME_OUT_VALUE;
+
+    /**
+     * 连接服务器超时时间
+     */
+    @ConfigFieldKey("connectTimeout")
+    private int connectTimeout = CONNECT_TIMEOUT;
+
+    /**
+     * 连接服务器重试次数
+     */
+    @ConfigFieldKey("connectRetryTimes")
+    private int connectRetryTimes = CONNECT_RETRY_TIMES;
 
     /**
      * 默认分组
@@ -86,5 +102,21 @@ public class DynamicConfig implements BaseConfig {
 
     public void setServiceType(String serviceType) {
         this.serviceType = serviceType;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getConnectRetryTimes() {
+        return connectRetryTimes;
+    }
+
+    public void setConnectRetryTimes(int connectRetryTimes) {
+        this.connectRetryTimes = connectRetryTimes;
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperBufferedClientTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperBufferedClientTest.java
@@ -16,10 +16,14 @@
 
 package com.huaweicloud.sermant.implement.service.dynamicconfig.zookeeper;
 
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.config.DynamicConfig;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,23 +35,27 @@ import java.util.List;
  * @since 2022-10-08
  */
 public class ZooKeeperBufferedClientTest {
-
     private static final String ZOOKEEPER_ADDRESS = "127.0.0.1:2181";
     private static final int SESSION_TIMEOUT = 30000;
     private static final String PARENT_PATH = "/path";
     private static final String CHILD_ONE_PATH = "/path/1";
     private static final String CHILE_TWO_PATh = "/path/2";
     private static final String NODE_CONTENT = "data";
+    private MockedStatic<ConfigManager> configManagerMockedStatic;
     ZooKeeperBufferedClient zooKeeperBufferedClient;
 
     @Before
     public void setUp() {
+        configManagerMockedStatic = Mockito.mockStatic(ConfigManager.class);
+        configManagerMockedStatic.when(() -> ConfigManager.getConfig(DynamicConfig.class))
+            .thenReturn(new DynamicConfig());
         zooKeeperBufferedClient = new ZooKeeperBufferedClient(ZOOKEEPER_ADDRESS, SESSION_TIMEOUT);
     }
 
     @After
     public void tearDown() {
         zooKeeperBufferedClient.close();
+        configManagerMockedStatic.close();
     }
 
     @Test

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/interceptors/ZookeeperLocatorInterceptorTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/interceptors/ZookeeperLocatorInterceptorTest.java
@@ -21,10 +21,12 @@ import com.huawei.dynamic.config.ConfigHolder;
 import com.huawei.dynamic.config.DynamicConfiguration;
 import com.huawei.dynamic.config.source.OriginConfigDisableSource;
 
+import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.operation.OperationManager;
 import com.huaweicloud.sermant.core.operation.converter.api.YamlConverter;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.config.DynamicConfig;
 import com.huaweicloud.sermant.implement.operation.converter.YamlConverterImpl;
 
 import org.junit.After;
@@ -47,14 +49,21 @@ public class ZookeeperLocatorInterceptorTest {
 
     private MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
 
+    private MockedStatic<ConfigManager> configManagerMockedStatic;
+
     @Before
     public void setUp() {
         operationManagerMockedStatic = Mockito.mockStatic(OperationManager.class);
-        operationManagerMockedStatic.when(() -> OperationManager.getOperation(YamlConverter.class)).thenReturn(new YamlConverterImpl());
+        operationManagerMockedStatic.when(() -> OperationManager.getOperation(YamlConverter.class))
+            .thenReturn(new YamlConverterImpl());
 
         pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class);
         pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
-                .thenReturn(new DynamicConfiguration());
+            .thenReturn(new DynamicConfiguration());
+
+        configManagerMockedStatic = Mockito.mockStatic(ConfigManager.class);
+        configManagerMockedStatic.when(() -> ConfigManager.getConfig(DynamicConfig.class))
+            .thenReturn(new DynamicConfig());
     }
 
     @After


### PR DESCRIPTION
【修复issue】#827

【修改内容】添加zookeeper的连接超时时间，预防连接时间过长导致插件使用动态配置失败

【用例描述】否

【自测情况】1、本地静态检查清理情况

【影响范围】不涉及
