### PR TITLE
【doc】add default zone for all env config.properties

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/all/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/all/config.properties
@@ -29,5 +29,6 @@ service.meta.application=default
 service.meta.version=1.0.0
 service.meta.project=default
 service.meta.environment=
+service.meta.zone=
 service.meta.customLabel=public
 service.meta.customLabelValue=default

--- a/sermant-agentcore/sermant-agentcore-config/config/example/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/example/config.properties
@@ -29,3 +29,4 @@ service.meta.application=default
 service.meta.version=1.0.0
 service.meta.project=default
 service.meta.environment=
+service.meta.zone=

--- a/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
@@ -30,6 +30,7 @@ service.meta.application=default
 service.meta.version=1.0.0
 service.meta.project=default
 service.meta.environment=
+service.meta.zone=
 
 #monitor config
 monitor.service.address=127.0.0.1


### PR DESCRIPTION

What type of PR is this?

/feat

Which issue(s) this PR fixes:

Fixes #857 

Use case description: add default zone for all env config.properties

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No
