### PR TITLE
修改日志配置消除冗余日志，针对日志类隔离，重写类加载器getResources方法

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/logback.xml
+++ b/sermant-agentcore/sermant-agentcore-config/config/logback.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<configuration scan="true">
+<configuration scan="true" debug="false">
+    <!--  无操作事件监听器  -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
     <!-- 定义日志文件 输出位置 -->
     <property name="log.home_dir" value="${sermant_log_dir:-./logs/sermant/core}"/>

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/FrameworkClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/FrameworkClassLoader.java
@@ -20,9 +20,11 @@ import com.huaweicloud.sermant.core.common.BootArgsIndexer;
 import com.huaweicloud.sermant.core.common.CommonConstant;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,5 +100,14 @@ public class FrameworkClassLoader extends URLClassLoader {
             url = super.getResource(name);
         }
         return url;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        // 由于类隔离的原因针对StaticLoggerBinder不再通过父类加载器获取重复资源，只返回加载器内的资源
+        if ("org/slf4j/impl/StaticLoggerBinder.class".equals(name)) {
+            return findResources(name);
+        }
+        return super.getResources(name);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/resources/logback.xml
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/resources/logback.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<configuration scan="true">
+<configuration scan="true" debug="false">
+    <!--  无操作事件监听器  -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
     <!-- 定义日志文件 输出位置 -->
     <property name="log.home_dir" value="${sermant_log_dir:-./logs/sermant/core}"/>

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/AgentPremain.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/AgentPremain.java
@@ -64,7 +64,7 @@ public class AgentPremain {
             executeFlag = true;
 
             // 添加核心库
-            LOGGER.info(String.format(Locale.ROOT, "Loading core library from [%s].", PathDeclarer.getCorePath()));
+            LOGGER.info("Loading core library... ");
             loadCoreLib(instrumentation);
 
             // 初始化启动参数


### PR DESCRIPTION
【修复issue】# 868
【修改内容】1、FrameworkClassLoader针对StaticLoggerBinder.class重写getResources方法 2、日志配置关闭logback自身debug日志 3、premain启动时不再输出agentcore包的位置
【用例描述】不涉及
【自测情况】不涉及
【影响范围】不涉及
