### PR TITLE
[feat]okhttp,httpclient插件,将header中流量标识放入threadlocal.

### DIFF
--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/utils/FlowContextUtils.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/utils/FlowContextUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.common.utils;
+
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 流量标识解码工具类.
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class FlowContextUtils {
+    private static final Base64.Decoder DECODER = Base64.getDecoder();
+    private static final int TAG_PART_NUM = 2;
+
+    private FlowContextUtils() {
+    }
+
+    /**
+     * sw8-correlation流量标识解码.
+     *
+     * @param encodeTagsString encodeTagsString
+     * @return 解密后的流量标识
+     */
+    public static Map<String, List<String>> decodeTags(String encodeTagsString) {
+        if (StringUtils.isEmpty(encodeTagsString)) {
+            return Collections.emptyMap();
+        }
+        String[] tags = encodeTagsString.split(",");
+        Map<String, List<String>> tagMapping = new HashMap<>();
+        for (String tag : tags) {
+            final String[] parts = tag.split(":");
+            if (parts.length != TAG_PART_NUM) {
+                continue;
+            }
+            List<String> list = new ArrayList<>();
+            list.add(new String(DECODER.decode(parts[1]), StandardCharsets.UTF_8));
+            tagMapping.put(new String(DECODER.decode(parts[0]), StandardCharsets.UTF_8), list);
+        }
+        return tagMapping;
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/pom.xml
+++ b/sermant-plugins/sermant-router/spring-router-plugin/pom.xml
@@ -22,6 +22,9 @@
         <zuul.version>1.3.1</zuul.version>
         <spring.test.version>5.2.0.RELEASE</spring.test.version>
         <tomcat.version>9.0.43</tomcat.version>
+        <okhttp.version>4.1.0</okhttp.version>
+        <okhttp.sq.version>2.7.5</okhttp.sq.version>
+        <apache-httpclient.version>4.3</apache-httpclient.version>
     </properties>
 
     <dependencies>
@@ -95,6 +98,24 @@
                     <artifactId>mockito-all</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.sq.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${apache-httpclient.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.huaweicloud.sermant</groupId>

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HttpClient4xDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HttpClient4xDeclarer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.router.spring.interceptor.HttpClient4xInterceptor;
+
+/**
+ * 针对http请求方式，从注册中心获取实例列表拦截, <h1>仅针对4.x版本</h1>
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class HttpClient4xDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名 http请求
+     */
+    private static final String[] ENHANCE_CLASSES = {
+        "org.apache.http.impl.client.AbstractHttpClient",
+        "org.apache.http.impl.client.DefaultRequestDirector",
+        "org.apache.http.impl.client.InternalHttpClient",
+        "org.apache.http.impl.client.MinimalHttpClient"
+    };
+
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = HttpClient4xInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameContains(ENHANCE_CLASSES);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameContains("doExecute", "execute")
+                                .and(MethodMatcher.paramTypesEqual(
+                                        "org.apache.http.HttpHost",
+                                        "org.apache.http.HttpRequest",
+                                        "org.apache.http.protocol.HttpContext")),
+                        INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/OkHttp3ClientDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/OkHttp3ClientDeclarer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.router.spring.interceptor.OkHttp3ClientInterceptor;
+
+/**
+ * 针对okhttp请求方式，从注册中心获取实例列表拦截
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class OkHttp3ClientDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名 okhttp请求
+     */
+    private static final String[] ENHANCE_CLASSES = {
+        "okhttp3.RealCall"
+    };
+
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = OkHttp3ClientInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameContains(ENHANCE_CLASSES);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {
+                InterceptDeclarer.build(MethodMatcher.nameContains("execute", "getResponseWithInterceptorChain"),
+                        INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/OkHttpClientDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/OkHttpClientDeclarer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.router.spring.interceptor.OkHttpClientInterceptor;
+
+/**
+ * 针对okhttp请求方式，从注册中心获取实例列表拦截
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class OkHttpClientDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名 okhttp请求
+     */
+    private static final String[] ENHANCE_CLASSES = {
+        "com.squareup.okhttp.Call"
+    };
+
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = OkHttpClientInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameContains(ENHANCE_CLASSES);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {
+                InterceptDeclarer.build(MethodMatcher.nameContains("execute", "getResponseWithInterceptorChain"),
+                        INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpClient4xInterceptor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.router.common.request.RequestData;
+import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
+import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
+import com.huaweicloud.sermant.router.spring.utils.RequestInterceptorUtils;
+
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 仅针对4.x版本得http拦截
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class HttpClient4xInterceptor extends AbstractInterceptor {
+    /**
+     * 前置触发点
+     *
+     * @param context 执行上下文
+     * @return 执行上下文
+     * @throws Exception 执行异常
+     */
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        Object httpRequestObject = context.getArguments()[1];
+        if (httpRequestObject instanceof HttpRequest) {
+            final HttpRequest httpRequest = (HttpRequest) httpRequestObject;
+            final Optional<URI> optionalUri = RequestInterceptorUtils.formatUri(httpRequest.getRequestLine().getUri());
+            if (!optionalUri.isPresent()) {
+                return context;
+            }
+            URI uri = optionalUri.get();
+            Header[] headers = httpRequest.getHeaders("sw8-correlation");
+            Map<String, List<String>> flowTags = new HashMap<>();
+            if (headers != null && headers.length > 0) {
+                for (Header header : headers) {
+                    String headerValue = header.getValue();
+                    Map<String, List<String>> stringListMap = FlowContextUtils.decodeTags(headerValue);
+                    flowTags.putAll(stringListMap);
+                }
+            }
+            if (flowTags.size() > 0) {
+                ThreadLocalUtils.setRequestData(new RequestData(
+                        flowTags, uri.getPath(), httpRequest.getRequestLine().getMethod()));
+            }
+        }
+        return context;
+    }
+
+    /**
+     * 后置触发点
+     *
+     * @param context 执行上下文
+     * @return 执行上下文
+     * @throws Exception 执行异常
+     */
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttp3ClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttp3ClientInterceptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.router.common.request.RequestData;
+import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
+import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
+
+import okhttp3.Headers;
+import okhttp3.Request;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 针对okHttp3.x版本以上的拦截
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class OkHttp3ClientInterceptor extends AbstractInterceptor {
+    private static final String FIELD_NAME = "originalRequest";
+
+    /**
+     * 前置触发点
+     *
+     * @param context 执行上下文
+     * @return 执行上下文
+     * @throws Exception 执行异常
+     */
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        final Optional<Request> rawRequest = getRequest(context);
+        if (!rawRequest.isPresent()) {
+            return context;
+        }
+        Request request = rawRequest.get();
+        URI uri = request.url().uri();
+        Headers headers = request.headers();
+        String str = headers.get("sw8-correlation");
+        Map<String, List<String>> decodeTags = FlowContextUtils.decodeTags(str);
+        if (decodeTags.size() > 0) {
+            ThreadLocalUtils.setRequestData(new RequestData(decodeTags, uri.getPath(), request.method()));
+        }
+        return context;
+    }
+
+    /**
+     * 后置触发点
+     *
+     * @param context 执行上下文
+     * @return 执行上下文
+     * @throws Exception 执行异常
+     */
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    private Optional<Request> getRequest(ExecuteContext context) {
+        final Optional<Object> originalRequest = ReflectUtils.getFieldValue(context.getObject(), FIELD_NAME);
+        if (originalRequest.isPresent() && originalRequest.get() instanceof Request) {
+            return Optional.of((Request) originalRequest.get());
+        }
+        return Optional.empty();
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttpClientInterceptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.router.common.request.RequestData;
+import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
+import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
+
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.Request;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 针对okHttp3.1以下版本拦截
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class OkHttpClientInterceptor extends AbstractInterceptor {
+    private static final String FIELD_NAME = "originalRequest";
+
+    /**
+     * 前置触发点
+     *
+     * @param context 执行上下文
+     * @return 执行上下文
+     * @throws Exception 执行异常
+     */
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        final Optional<Request> rawRequest = getRequest(context);
+        if (!rawRequest.isPresent()) {
+            return context;
+        }
+        Request request = rawRequest.get();
+        URI uri = request.uri();
+        Headers headers = request.headers();
+        String str = headers.get("sw8-correlation");
+        Map<String, List<String>> decodeTags = FlowContextUtils.decodeTags(str);
+        if (decodeTags.size() > 0) {
+            ThreadLocalUtils.setRequestData(new RequestData(decodeTags, uri.getPath(), request.method()));
+        }
+        return context;
+    }
+
+    /**
+     * 后置触发点
+     *
+     * @param context 执行上下文
+     * @return 执行上下文
+     * @throws Exception 执行异常
+     */
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    private Optional<Request> getRequest(ExecuteContext context) {
+        final Optional<Object> originalRequest = ReflectUtils.getFieldValue(context.getObject(), FIELD_NAME);
+        if (originalRequest.isPresent() && originalRequest.get() instanceof Request) {
+            return Optional.of((Request) originalRequest.get());
+        }
+        return Optional.empty();
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/utils/RequestInterceptorUtils.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/utils/RequestInterceptorUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.utils;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * 解析url参数、构建公共方法相关工具类
+ *
+ * @author yangrh
+ * @since 2022-10-25
+ */
+public class RequestInterceptorUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private RequestInterceptorUtils() {
+    }
+
+    /**
+     * 格式化uri
+     *
+     * @param uri 目标uri
+     * @return URI
+     */
+    public static Optional<URI> formatUri(String uri) {
+        if (!isValidUrl(uri)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(new URI(uri));
+        } catch (URISyntaxException e) {
+            LOGGER.fine(String.format(Locale.ENGLISH, "%s is not valid uri!", uri));
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isValidUrl(String url) {
+        final String lowerCaseUrl = url.toLowerCase(Locale.ROOT);
+        return lowerCaseUrl.startsWith("http") || lowerCaseUrl.startsWith("https");
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -10,3 +10,6 @@ com.huaweicloud.sermant.router.spring.declarer.LoadBalancerClientFilterDeclarer
 com.huaweicloud.sermant.router.spring.declarer.NopInstanceFilterDeclarer
 com.huaweicloud.sermant.router.spring.declarer.ServiceInstanceListSupplierDeclarer
 com.huaweicloud.sermant.router.spring.declarer.ServiceRegistryDeclarer
+com.huaweicloud.sermant.router.spring.declarer.OkHttp3ClientDeclarer
+com.huaweicloud.sermant.router.spring.declarer.OkHttpClientDeclarer
+com.huaweicloud.sermant.router.spring.declarer.HttpClient4xDeclarer


### PR DESCRIPTION
【issue】#879

【修改内容】1、增加okhttp插件，拦截点com.squareup.okhttp.Call.execute，拦截header中流量标识，解密存入threadlocal,提供给后面标签路由
                      2、增加okhttp3插件，拦截点okhttp3.RealCall.execute，拦截header中流量标识，解密存入threadlocal,提供给后面标签路由
                     3、增加httpclient插件，拦截点org.apache.http.impl.client.AbstractHttpClient.doExecute
                                                                       org.apache.http.impl.client.DefaultRequestDirector.doExecute
                                                                       org.apache.http.impl.client.InternalHttpClient.doExecute
                                                                       org.apache.http.impl.client.MinimalHttpClient.doExecute
拦截header中流量标识，解密存入threadlocal,提供给后面标签路由

【用例描述】本地自测通过

【自测情况】1、本地自测通过

【影响范围】1、sermant-route插件