### PR TITLE
【feature】resttemplate、jdk http、dubbo标记传递增强

### DIFF
--- a/sermant-plugins/sermant-router/config/config.yaml
+++ b/sermant-plugins/sermant-router/config/config.yaml
@@ -9,3 +9,5 @@ router.plugin:
   use-request-router: false
   # 使用请求信息做路由时的tags
   request-tags: []
+  # 需要解析的请求头的tag
+  parse-header-tag: ''

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/config/RouterConfig.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/config/RouterConfig.java
@@ -82,6 +82,12 @@ public class RouterConfig implements PluginConfig {
     private Map<String, String> parameters;
 
     /**
+     * 需要解析的请求头的tag
+     */
+    @ConfigFieldKey("parse-header-tag")
+    private String parseHeaderTag;
+
+    /**
      * 构造方法
      */
     public RouterConfig() {
@@ -166,5 +172,13 @@ public class RouterConfig implements PluginConfig {
 
     public void setParameters(Map<String, String> parameters) {
         this.parameters = parameters;
+    }
+
+    public String getParseHeaderTag() {
+        return parseHeaderTag;
+    }
+
+    public void setParseHeaderTag(String parseHeaderTag) {
+        this.parseHeaderTag = parseHeaderTag;
     }
 }

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HttpUrlConnectionConnectDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HttpUrlConnectionConnectDeclarer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 定义JDK 1.8版本的java.net.HttpURLConnection的拦截点信息<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-25
+ */
+public class HttpUrlConnectionConnectDeclarer extends AbstractPluginDeclarer {
+    private static final String METHOD_NAME = "connect";
+
+    private static final String INTERCEPTOR_CLASS =
+        "com.huaweicloud.sermant.router.spring.interceptor.HttpUrlConnectionConnectInterceptor";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isExtendedFrom("java.net.HttpURLConnection");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {
+            InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPTOR_CLASS)};
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/RestTemplateDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/RestTemplateDeclarer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * org.springframework.web.client.RestTemplate的拦截点定义<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-27
+ */
+public class RestTemplateDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "org.springframework.web.client.RestTemplate";
+    private static final String ENHANCE_METHOD = "doExecute";
+    private static final String INTERCEPTOR_CLASS =
+        "com.huaweicloud.sermant.router.spring.interceptor.RestTemplateInterceptor";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {
+            InterceptDeclarer.build(MethodMatcher.nameEquals(ENHANCE_METHOD), INTERCEPTOR_CLASS)};
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/SpringBootLoadClassDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/SpringBootLoadClassDeclarer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.router.spring.interceptor.SpringBootLoadClassInterceptor;
+
+/**
+ * 增强SpringBootApplication类的main方法，用于加载一些特殊的类
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-28
+ */
+public class SpringBootLoadClassDeclarer extends AbstractPluginDeclarer {
+    private static final String[] ENHANCE_CLASS = {"org.springframework.boot.autoconfigure.SpringBootApplication"};
+
+    private static final String INTERCEPT_CLASS = SpringBootLoadClassInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "main";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isAnnotatedWith(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+            InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME).and(MethodMatcher.isStaticMethod()),
+                INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/FeignClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/FeignClientInterceptor.java
@@ -19,8 +19,10 @@ package com.huaweicloud.sermant.router.spring.interceptor;
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
 import com.huaweicloud.sermant.router.common.request.RequestHeader;
+import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
 import com.huaweicloud.sermant.router.common.utils.ReflectUtils;
 import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
 
@@ -62,7 +64,7 @@ public class FeignClientInterceptor extends AbstractInterceptor {
             String path = URI.create(request.url()).getPath();
             Map<String, List<String>> headers = getHeaders(request.headers());
             setHeaders(request, headers);
-            ThreadLocalUtils.setRequestData(new RequestData(headers, path, request.method()));
+            ThreadLocalUtils.setRequestData(new RequestData(decodeTags(headers), path, request.method()));
         }
         return context;
     }
@@ -128,5 +130,22 @@ public class FeignClientInterceptor extends AbstractInterceptor {
             }
         }
         return Optional.empty();
+    }
+
+    private Map<String, List<String>> decodeTags(Map<String, List<String>> headers) {
+        if (StringUtils.isBlank(FlowContextUtils.getTagName())) {
+            return headers;
+        }
+        Map<String, List<String>> newHeaders = new HashMap<>(headers);
+        if (headers != null && headers.size() > 0) {
+            List<String> list = headers.get(FlowContextUtils.getTagName());
+            if (list != null && list.size() > 0) {
+                String tagStr = list.get(0);
+                Map<String, List<String>> stringListMap = FlowContextUtils.decodeTags(tagStr);
+                newHeaders.putAll(stringListMap);
+                return Collections.unmodifiableMap(newHeaders);
+            }
+        }
+        return headers;
     }
 }

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpClient4xInterceptor.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.router.spring.interceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
 import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
 import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
@@ -56,7 +57,10 @@ public class HttpClient4xInterceptor extends AbstractInterceptor {
                 return context;
             }
             URI uri = optionalUri.get();
-            Header[] headers = httpRequest.getHeaders("sw8-correlation");
+            if (StringUtils.isBlank(FlowContextUtils.getTagName())) {
+                return context;
+            }
+            Header[] headers = httpRequest.getHeaders(FlowContextUtils.getTagName());
             Map<String, List<String>> flowTags = new HashMap<>();
             if (headers != null && headers.length > 0) {
                 for (Header header : headers) {

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpUrlConnectionConnectInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpUrlConnectionConnectInterceptor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+import com.huaweicloud.sermant.router.common.request.RequestData;
+import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
+import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 针对JDK 1.8版本的java.net.HttpURLConnection的一个增强拦截器<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-25
+ */
+public class HttpUrlConnectionConnectInterceptor extends AbstractInterceptor {
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        if (context.getObject() instanceof HttpURLConnection) {
+            HttpURLConnection connection = (HttpURLConnection) context.getObject();
+            if (StringUtils.isBlank(FlowContextUtils.getTagName())) {
+                return context;
+            }
+            String encodeTag = connection.getRequestProperty(FlowContextUtils.getTagName());
+            if (StringUtils.isBlank(encodeTag)) {
+                return context;
+            }
+            Map<String, List<String>> tags = FlowContextUtils.decodeTags(encodeTag);
+            if (!tags.isEmpty()) {
+                RequestData requestData = new RequestData(tags, getPath(connection), connection.getRequestMethod());
+                ThreadLocalUtils.setRequestData(requestData);
+            }
+        }
+        return context;
+    }
+
+    private String getPath(HttpURLConnection connection) {
+        return Optional.ofNullable(connection.getURL()).map(URL::getPath).orElse("/");
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) throws Exception {
+        ThreadLocalUtils.removeRequestData();
+        return super.onThrow(context);
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttp3ClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttp3ClientInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.router.spring.interceptor;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
 import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
 import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
@@ -50,13 +51,13 @@ public class OkHttp3ClientInterceptor extends AbstractInterceptor {
     @Override
     public ExecuteContext before(ExecuteContext context) throws Exception {
         final Optional<Request> rawRequest = getRequest(context);
-        if (!rawRequest.isPresent()) {
+        if (!rawRequest.isPresent() || StringUtils.isBlank(FlowContextUtils.getTagName())) {
             return context;
         }
         Request request = rawRequest.get();
         URI uri = request.url().uri();
         Headers headers = request.headers();
-        String str = headers.get("sw8-correlation");
+        String str = headers.get(FlowContextUtils.getTagName());
         Map<String, List<String>> decodeTags = FlowContextUtils.decodeTags(str);
         if (decodeTags.size() > 0) {
             ThreadLocalUtils.setRequestData(new RequestData(decodeTags, uri.getPath(), request.method()));

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttpClientInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.router.spring.interceptor;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
 import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
 import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
@@ -50,13 +51,13 @@ public class OkHttpClientInterceptor extends AbstractInterceptor {
     @Override
     public ExecuteContext before(ExecuteContext context) throws Exception {
         final Optional<Request> rawRequest = getRequest(context);
-        if (!rawRequest.isPresent()) {
+        if (!rawRequest.isPresent() || StringUtils.isBlank(FlowContextUtils.getTagName())) {
             return context;
         }
         Request request = rawRequest.get();
         URI uri = request.uri();
         Headers headers = request.headers();
-        String str = headers.get("sw8-correlation");
+        String str = headers.get(FlowContextUtils.getTagName());
         Map<String, List<String>> decodeTags = FlowContextUtils.decodeTags(str);
         if (decodeTags.size() > 0) {
             ThreadLocalUtils.setRequestData(new RequestData(decodeTags, uri.getPath(), request.method()));

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/RestTemplateInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/RestTemplateInterceptor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+import com.huaweicloud.sermant.router.common.request.RequestData;
+import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
+import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
+import com.huaweicloud.sermant.router.spring.wrapper.RequestCallbackWrapper;
+
+import org.springframework.http.HttpMethod;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * org.springframework.web.client.RestTemplate的增强拦截器<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-27
+ */
+public class RestTemplateInterceptor extends AbstractInterceptor {
+    private static final int CALLBACK_ARG_LENGTH = 3;
+
+    private static final int CALLBACK_ARG_POSITION = 2;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+
+        if (arguments != null && arguments.length > CALLBACK_ARG_LENGTH) {
+            Object argument = arguments[CALLBACK_ARG_POSITION];
+            if (argument instanceof RequestCallbackWrapper) {
+                RequestCallbackWrapper callback = (RequestCallbackWrapper)argument;
+                parseTags(callback, arguments[0], arguments[1]);
+            }
+        }
+        return context;
+    }
+
+    private void parseTags(RequestCallbackWrapper callback, Object url, Object method) {
+        Map<String, String> header = callback.getHeader();
+        if (StringUtils.isBlank(FlowContextUtils.getTagName())) {
+            return;
+        }
+        String encodeTag = header.get(FlowContextUtils.getTagName());
+        if (StringUtils.isBlank(encodeTag)) {
+            return;
+        }
+        Map<String, List<String>> tags = FlowContextUtils.decodeTags(encodeTag);
+        if (!tags.isEmpty()) {
+            ThreadLocalUtils.setRequestData(getRequestData(tags, url, method));
+        }
+    }
+
+    private RequestData getRequestData(Map<String, List<String>> tags, Object url, Object method) {
+        String path = "";
+        if (url instanceof URI) {
+            path = ((URI) url).getPath();
+        }
+        String httpMethod = "";
+        if (method instanceof HttpMethod) {
+            httpMethod = ((HttpMethod) method).name();
+        }
+        return new RequestData(tags, path, httpMethod);
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) throws Exception {
+        ThreadLocalUtils.removeRequestData();
+        return super.onThrow(context);
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/SpringBootLoadClassInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/SpringBootLoadClassInterceptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.ClassUtils;
+
+/**
+ * 启动时加载一些必要的类
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-26
+ */
+public class SpringBootLoadClassInterceptor extends AbstractInterceptor {
+    private static final String REQUEST_CALLBACK_WRAPPER =
+        "com.huaweicloud.sermant.router.spring.wrapper.RequestCallbackWrapper";
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        ClassUtils.defineClass(REQUEST_CALLBACK_WRAPPER, getClass().getClassLoader());
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/wrapper/RequestCallbackWrapper.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/wrapper/RequestCallbackWrapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.wrapper;
+
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.web.client.RequestCallback;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * 对于{@link RequestCallback}的一个包装类，用于传递请求头信息<br>
+ *
+ * @author yuzl 俞真龙
+ * @since 2022-10-27
+ */
+public class RequestCallbackWrapper implements RequestCallback {
+    private final RequestCallback callback;
+
+    private final Map<String, String> header;
+
+    /**
+     * 构造函数
+     *
+     * @param callback 真实需要包装的对象
+     * @param header   请求头信息
+     */
+    public RequestCallbackWrapper(RequestCallback callback, Map<String, String> header) {
+        this.callback = callback;
+        this.header = header;
+    }
+
+    @Override
+    public void doWithRequest(ClientHttpRequest request) throws IOException {
+        this.callback.doWithRequest(request);
+    }
+
+    public Map<String, String> getHeader() {
+        return header;
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -13,3 +13,6 @@ com.huaweicloud.sermant.router.spring.declarer.ServiceRegistryDeclarer
 com.huaweicloud.sermant.router.spring.declarer.OkHttp3ClientDeclarer
 com.huaweicloud.sermant.router.spring.declarer.OkHttpClientDeclarer
 com.huaweicloud.sermant.router.spring.declarer.HttpClient4xDeclarer
+com.huaweicloud.sermant.router.spring.declarer.HttpUrlConnectionConnectDeclarer
+com.huaweicloud.sermant.router.spring.declarer.RestTemplateDeclarer
+com.huaweicloud.sermant.router.spring.declarer.SpringBootLoadClassDeclarer

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/test/java/com/huaweicloud/sermant/router/spring/interceptor/FeignClientInterceptorTest.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/test/java/com/huaweicloud/sermant/router/spring/interceptor/FeignClientInterceptorTest.java
@@ -17,6 +17,8 @@
 package com.huaweicloud.sermant.router.spring.interceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.router.common.config.RouterConfig;
 import com.huaweicloud.sermant.router.common.request.RequestData;
 import com.huaweicloud.sermant.router.common.request.RequestHeader;
 import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
@@ -26,9 +28,13 @@ import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableDefault;
 
 import feign.Request;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 
 import java.nio.charset.StandardCharsets;
@@ -49,6 +55,8 @@ public class FeignClientInterceptorTest {
 
     private final ExecuteContext context;
 
+    private static MockedStatic<PluginConfigManager> mockStatic;
+
     public FeignClientInterceptorTest() {
         interceptor = new FeignClientInterceptor();
         Object[] arguments = new Object[1];
@@ -57,6 +65,18 @@ public class FeignClientInterceptorTest {
         headers.put("foo", Collections.singletonList("foo1"));
         arguments[0] = Request.create("GET", "/", headers, new byte[]{}, StandardCharsets.UTF_8);
         context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+
+    @BeforeClass
+    public static void before() {
+        mockStatic = Mockito.mockStatic(PluginConfigManager.class);
+        RouterConfig config = new RouterConfig();
+        mockStatic.when(() -> PluginConfigManager.getPluginConfig(Mockito.any())).thenReturn(config);
+    }
+
+    @AfterClass
+    public static void after() {
+        mockStatic.close();
     }
 
     /**


### PR DESCRIPTION
【修复issue】#886

【修改内容】resttemplate、jdk http、dubbo标记传递的标签header传递
新增org.springframework.web.client.RestTemplate的doExecute的拦截点
新增java.net.HttpURLConnection字类的connect的拦截点
新增dubbo附件信息解析逻辑

【用例描述】本地自测通过

【自测情况】1、本地自测通过

【影响范围】1、sermant-router插件
