### PR TITLE
【fix】心跳服务，心跳信息合并

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/heartbeat/common/HeartbeatMessage.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/heartbeat/common/HeartbeatMessage.java
@@ -21,6 +21,7 @@ import com.huaweicloud.sermant.core.utils.NetworkUtils;
 import com.huaweicloud.sermant.core.utils.TimeUtils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,35 +31,81 @@ import java.util.Map;
  * @since 2022-03-19
  */
 public class HeartbeatMessage {
-    private final Map<String, Object> message = new HashMap<>();
+    private String hostName;
+
+    private List<String> ip;
+
+    private final String appName;
+
+    private final String appType;
+
+    private long heartbeatTime;
+
+    private long lastHeartbeatTime;
+
+    private final String version;
+
+    private final long instanceId;
+
+    private final Map<String, PluginInfo> pluginInfoMap = new HashMap<>();
 
     /**
      * 构造函数
      */
     public HeartbeatMessage() {
-        message.put("hostname", NetworkUtils.getHostName());
-        message.put("ip", NetworkUtils.getAllNetworkIp());
-        message.put("app", BootArgsIndexer.getAppName());
-        message.put("appType", BootArgsIndexer.getAppType());
-        message.put("heartbeatVersion", String.valueOf(TimeUtils.currentTimeMillis()));
-        message.put("lastHeartbeat", String.valueOf(TimeUtils.currentTimeMillis()));
-        message.put("version", BootArgsIndexer.getCoreVersion());
-        message.put("instanceId", BootArgsIndexer.getInstanceId());
+        this.hostName = NetworkUtils.getHostName();
+        this.ip = NetworkUtils.getAllNetworkIp();
+        this.appName = BootArgsIndexer.getAppName();
+        this.appType = BootArgsIndexer.getAppType();
+        this.heartbeatTime = TimeUtils.currentTimeMillis();
+        this.lastHeartbeatTime = TimeUtils.currentTimeMillis();
+        this.version = BootArgsIndexer.getCoreVersion();
+        this.instanceId = BootArgsIndexer.getInstanceId();
     }
 
     /**
-     * registerInformation
-     *
-     * @param key key
-     * @param value value
-     * @return HeartbeatMessage
+     * 更新心跳数据
      */
-    public HeartbeatMessage registerInformation(String key, String value) {
-        message.put(key, value);
-        return this;
+    public void updateHeartbeatVersion() {
+        this.lastHeartbeatTime = this.heartbeatTime;
+        this.heartbeatTime = TimeUtils.currentTimeMillis();
+        this.hostName = NetworkUtils.getHostName();
+        this.ip = NetworkUtils.getAllNetworkIp();
     }
 
-    public Map<String, Object> getMessage() {
-        return message;
+    public Map<String, PluginInfo> getPluginInfoMap() {
+        return pluginInfoMap;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public List<String> getIp() {
+        return ip;
+    }
+
+    public String getAppName() {
+        return appName;
+    }
+
+    public String getAppType() {
+        return appType;
+    }
+
+    public long getHeartbeatTime() {
+        return heartbeatTime;
+    }
+
+    public long getLastHeartbeatTime() {
+        return lastHeartbeatTime;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public long getInstanceId() {
+        return instanceId;
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/heartbeat/common/PluginInfo.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/heartbeat/common/PluginInfo.java
@@ -16,23 +16,45 @@
 
 package com.huaweicloud.sermant.core.service.heartbeat.common;
 
+import java.util.Map;
+
 /**
- * 心跳发送服务涉及到的常量
+ * 插件信息
  *
  * @author luanwenfei
- * @since 2022-03-28
+ * @since 2022-10-28
  */
-public class HeartbeatConstant {
-    /**
-     * 心跳间隔
-     */
-    public static final long INTERVAL = 3000L;
+public class PluginInfo {
+    private String name;
+
+    private String version;
+
+    private Map<String, String> extInfo;
 
     /**
-     * 最小心跳间隔
+     * constructor
+     *
+     * @param name plugin name
+     * @param version plugin version
      */
-    public static final long HEARTBEAT_MINIMAL_INTERVAL = 3000L;
+    public PluginInfo(String name, String version) {
+        this.name = name;
+        this.version = version;
+    }
 
-    private HeartbeatConstant() {
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setExtInfo(Map<String, String> extInfo) {
+        this.extInfo = extInfo;
+    }
+
+    public Map<String, String> getExtInfo() {
+        return extInfo;
     }
 }


### PR DESCRIPTION
【修复issue】#892

【修改内容】将每个插件单独的message整合为整个agent的单独message并携带插件信息

【用例描述】不涉及

【自测情况】1、本地静态检查清理情况；2、本地自测通过，前端可展示心跳数据

【影响范围】1、旧版Backend未改造前无法获取心跳信息
