### PR TITLE
【fix】去除Sermant对宿主JUL日志的影响

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/all/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/all/config.properties
@@ -16,7 +16,7 @@ dynamic.config.connectRetryTimes=5
 dynamic.config.connectTimeout=1000
 
 # heartbeat config
-heartbeat.interval=3000
+heartbeat.interval=30000
 
 #backend config
 backend.nettyIp=127.0.0.1

--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -21,7 +21,7 @@ dynamic.config.privateKey=
 dynamic.config.enableAuth=false
 
 # heartbeat config
-heartbeat.interval=3000
+heartbeat.interval=30000
 
 #backend config
 backend.nettyIp=127.0.0.1

--- a/sermant-agentcore/sermant-agentcore-config/config/example/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/example/config.properties
@@ -16,7 +16,7 @@ dynamic.config.connectRetryTimes=5
 dynamic.config.connectTimeout=1000
 
 # heartbeat config
-heartbeat.interval=3000
+heartbeat.interval=30000
 
 #backend config
 backend.nettyIp=127.0.0.1

--- a/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
@@ -17,7 +17,7 @@ dynamic.config.connectRetryTimes=5
 dynamic.config.connectTimeout=1000
 
 # heartbeat config
-heartbeat.interval=3000
+heartbeat.interval=30000
 
 #backend config
 backend.nettyIp=127.0.0.1

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
@@ -21,7 +21,6 @@ import com.huaweicloud.sermant.core.classloader.FrameworkClassLoader;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -47,13 +46,11 @@ public class LoggerFactory {
         try {
             Method initMethod = frameworkClassLoader
                     .loadClass("com.huaweicloud.sermant.implement.LoggerFactoryImpl").getMethod("init");
-            initMethod.invoke(null);
+            logger = (Logger) initMethod.invoke(null);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
                  | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
-        logger = java.util.logging.Logger.getLogger("sermant");
-        logger.setLevel(Level.ALL);
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/LoggerFactoryImpl.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/LoggerFactoryImpl.java
@@ -18,6 +18,9 @@ package com.huaweicloud.sermant.implement;
 
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * 日志初始化的实现类
  *
@@ -30,9 +33,14 @@ public class LoggerFactoryImpl {
 
     /**
      * init
+     *
+     * @return logger logger for sermant
      */
-    public static void init() {
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
+    public static Logger init() {
+        Logger logger = java.util.logging.Logger.getLogger("sermant");
+        logger.addHandler(new SLF4JBridgeHandler());
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.ALL);
+        return logger;
     }
 }


### PR DESCRIPTION
【修复issue】#902

【修改内容】1、修改了日志初始化方式，添加自己新建的SLF4JBridgeHandler，并且关闭对父配置的继承 2、修改了心跳的默认时间为30000ms

【用例描述】否

【自测情况】1、本地静态检查已过；2、（1）测试宿主应用也使用JUL日志，其配置没有被Sermant配置覆盖（2）Sermant日志配置也未被宿主日志配置覆盖

【影响范围】1、对用户的使用有没有影响（比如涉及api修改，启动参数修改）2、是不是需要更新一些文档（比如用户手册）