### PR TITLE
异步httpclient插件,将header中流量标识放入threadlocal.

### DIFF
--- a/sermant-plugins/sermant-router/spring-router-plugin/pom.xml
+++ b/sermant-plugins/sermant-router/spring-router-plugin/pom.xml
@@ -25,6 +25,7 @@
         <okhttp.version>4.1.0</okhttp.version>
         <okhttp.sq.version>2.7.5</okhttp.sq.version>
         <apache-httpclient.version>4.3</apache-httpclient.version>
+        <http.client.async.verion>4.1.5</http.client.async.verion>
     </properties>
 
     <dependencies>
@@ -115,6 +116,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${apache-httpclient.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <version>${http.client.async.verion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HttpAsyncClient4xDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HttpAsyncClient4xDeclarer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.declarer;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.router.spring.interceptor.HttpAsyncClient4xInterceptor;
+
+/**
+ * 针对httpAsyncClient4.x处理拦截
+ *
+ * @author yangrh
+ * @since 2022-10-31
+ */
+public class HttpAsyncClient4xDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名 http请求
+     */
+    private static final String[] ENHANCE_CLASSES = {
+        "org.apache.http.impl.nio.client.InternalHttpAsyncClient",
+        "org.apache.http.impl.nio.client.MinimalHttpAsyncClient"
+    };
+
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = HttpAsyncClient4xInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameContains(ENHANCE_CLASSES);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals("execute")
+                                .and(MethodMatcher.paramTypesEqual(
+                                        "org.apache.http.nio.protocol.HttpAsyncRequestProducer",
+                                        "org.apache.http.nio.protocol.HttpAsyncResponseConsumer",
+                                        "org.apache.http.protocol.HttpContext",
+                                        "org.apache.http.concurrent.FutureCallback")),
+                        INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/MarkInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/MarkInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.spring.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+
+/**
+ * 用于标记拦截器调用
+ *
+ * @author yangrh
+ * @since 2022-11-04
+ */
+public abstract class MarkInterceptor implements Interceptor {
+    /**
+     * 多个拦截器共享
+     */
+    private static final ThreadLocal<Boolean> MARK = new ThreadLocal<>();
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        if (MARK.get() != null) {
+            return context;
+        }
+        MARK.set(Boolean.TRUE);
+        try {
+            ready();
+            return doBefore(context);
+        } finally {
+            MARK.remove();
+        }
+    }
+
+    /**
+     * 调用逻辑
+     *
+     * @param context 上下文
+     * @return 上下文
+     * @throws Exception 执行异常抛出
+     */
+    protected abstract ExecuteContext doBefore(ExecuteContext context) throws Exception;
+
+    /**
+     * 调用前的准备
+     */
+    protected void ready() {
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/NopInstanceFilterInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/NopInstanceFilterInterceptor.java
@@ -65,6 +65,13 @@ public class NopInstanceFilterInterceptor extends AbstractInterceptor {
 
     @Override
     public ExecuteContext after(ExecuteContext context) {
+        ThreadLocalUtils.removeRequestData();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        ThreadLocalUtils.removeRequestData();
         return context;
     }
 }

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttp3ClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttp3ClientInterceptor.java
@@ -17,7 +17,6 @@
 package com.huaweicloud.sermant.router.spring.interceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
-import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
 import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
@@ -38,7 +37,7 @@ import java.util.Optional;
  * @author yangrh
  * @since 2022-10-25
  */
-public class OkHttp3ClientInterceptor extends AbstractInterceptor {
+public class OkHttp3ClientInterceptor extends MarkInterceptor {
     private static final String FIELD_NAME = "originalRequest";
 
     /**
@@ -49,7 +48,7 @@ public class OkHttp3ClientInterceptor extends AbstractInterceptor {
      * @throws Exception 执行异常
      */
     @Override
-    public ExecuteContext before(ExecuteContext context) throws Exception {
+    public ExecuteContext doBefore(ExecuteContext context) throws Exception {
         final Optional<Request> rawRequest = getRequest(context);
         if (!rawRequest.isPresent() || StringUtils.isBlank(FlowContextUtils.getTagName())) {
             return context;

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/OkHttpClientInterceptor.java
@@ -17,7 +17,6 @@
 package com.huaweicloud.sermant.router.spring.interceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
-import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
 import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
@@ -38,7 +37,7 @@ import java.util.Optional;
  * @author yangrh
  * @since 2022-10-25
  */
-public class OkHttpClientInterceptor extends AbstractInterceptor {
+public class OkHttpClientInterceptor extends MarkInterceptor {
     private static final String FIELD_NAME = "originalRequest";
 
     /**
@@ -49,7 +48,7 @@ public class OkHttpClientInterceptor extends AbstractInterceptor {
      * @throws Exception 执行异常
      */
     @Override
-    public ExecuteContext before(ExecuteContext context) throws Exception {
+    public ExecuteContext doBefore(ExecuteContext context) throws Exception {
         final Optional<Request> rawRequest = getRequest(context);
         if (!rawRequest.isPresent() || StringUtils.isBlank(FlowContextUtils.getTagName())) {
             return context;

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/RestTemplateInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/RestTemplateInterceptor.java
@@ -17,7 +17,6 @@
 package com.huaweicloud.sermant.router.spring.interceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
-import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
 import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
 import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
@@ -36,13 +35,13 @@ import java.util.Map;
  * @author yuzl 俞真龙
  * @since 2022-10-27
  */
-public class RestTemplateInterceptor extends AbstractInterceptor {
+public class RestTemplateInterceptor extends MarkInterceptor {
     private static final int CALLBACK_ARG_LENGTH = 3;
 
     private static final int CALLBACK_ARG_POSITION = 2;
 
     @Override
-    public ExecuteContext before(ExecuteContext context) {
+    public ExecuteContext doBefore(ExecuteContext context) {
         Object[] arguments = context.getArguments();
 
         if (arguments != null && arguments.length > CALLBACK_ARG_LENGTH) {
@@ -91,6 +90,6 @@ public class RestTemplateInterceptor extends AbstractInterceptor {
     @Override
     public ExecuteContext onThrow(ExecuteContext context) throws Exception {
         ThreadLocalUtils.removeRequestData();
-        return super.onThrow(context);
+        return context;
     }
 }

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -17,3 +17,4 @@ com.huaweicloud.sermant.router.spring.declarer.HttpClient4xDeclarer
 com.huaweicloud.sermant.router.spring.declarer.HttpUrlConnectionConnectDeclarer
 com.huaweicloud.sermant.router.spring.declarer.RestTemplateDeclarer
 com.huaweicloud.sermant.router.spring.declarer.SpringBootLoadClassDeclarer
+com.huaweicloud.sermant.router.spring.declarer.HttpAsyncClient4xDeclarer

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/declarers/FeignInvokeDeclarer.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/declarers/FeignInvokeDeclarer.java
@@ -36,10 +36,10 @@ public class FeignInvokeDeclarer extends AbstractPluginDeclarer {
 
     @Override
     public ClassMatcher getClassMatcher() {
-        return ClassMatcher.nameContains(
+        return ClassMatcher.build(ClassMatcher.nameContains(
                 "feign.Client$Default",
                 "feign.httpclient.ApacheHttpClient",
-                "feign.okhttp.OkHttpClient");
+                "feign.okhttp.OkHttpClient"));
     }
 
     @Override


### PR DESCRIPTION
【修复issue】#910

【修改内容】增加异步httpclient插件，拦截点：org.apache.http.impl.nio.client.InternalHttpAsyncClient.execute
org.apache.http.impl.nio.client.MinimalHttpAsyncClient.execute，获取httpContext里面流量标记解析存入threadlocal

【用例描述】本地自测通过

【自测情况】本地自测通过

【影响范围】本地自测通过
