### PR TITLE
【fix】处理因插件多次订阅初始化问题导致动态配置插件不能及时刷新宿主配置

### DIFF
--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/KvDataHolder.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/KvDataHolder.java
@@ -47,7 +47,7 @@ public class KvDataHolder {
             clear();
         }
         final Map<String, String> latestData = formatKieResponse(response);
-        final EventDataHolder eventDataHolder = new EventDataHolder(formatRevision(response.getRevision()));
+        final EventDataHolder eventDataHolder = new EventDataHolder(formatRevision(response.getRevision()), latestData);
         if (currentData != null) {
             if (latestData.isEmpty()) {
                 eventDataHolder.deleted.putAll(currentData);
@@ -119,6 +119,11 @@ public class KvDataHolder {
         private final long version;
 
         /**
+         * 最新的全量数据
+         */
+        private final Map<String, String> latestData;
+
+        /**
          * 修改的key
          */
         private Map<String, String> modified;
@@ -137,12 +142,18 @@ public class KvDataHolder {
          * Constructor.
          *
          * @param version version
+         * @param latestData 最新全量数据
          */
-        public EventDataHolder(long version) {
+        public EventDataHolder(long version, Map<String, String> latestData) {
             modified = new HashMap<String, String>();
             deleted = new HashMap<String, String>();
             added = new HashMap<String, String>();
             this.version = version;
+            this.latestData = latestData;
+        }
+
+        public Map<String, String> getLatestData() {
+            return latestData;
         }
 
         public Map<String, String> getModified() {

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/SubscriberManager.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/SubscriberManager.java
@@ -284,7 +284,7 @@ public class SubscriberManager {
         if (oldWrapper == null) {
             return firstSubscribeForGroup(key, kieRequest, dynamicConfigListener, ifNotify);
         } else {
-            oldWrapper.addKeyListener(key, dynamicConfigListener);
+            oldWrapper.addKeyListener(key, dynamicConfigListener, ifNotify);
             tryNotify(oldWrapper.getKieRequest(), oldWrapper, ifNotify);
             return true;
         }
@@ -301,7 +301,7 @@ public class SubscriberManager {
         final KieSubscriber kieSubscriber = new KieSubscriber(kieRequest);
         Task task;
         KieListenerWrapper kieListenerWrapper =
-            new KieListenerWrapper(key, dynamicConfigListener, new KvDataHolder(), kieRequest);
+            new KieListenerWrapper(key, dynamicConfigListener, new KvDataHolder(), kieRequest, ifNotify);
         if (!kieSubscriber.isLongConnectionRequest()) {
             task = new ShortTimerTask(kieSubscriber, kieListenerWrapper);
         } else {

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListener.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListener.java
@@ -22,6 +22,7 @@ import com.huawei.dynamic.config.closer.ConfigCenterCloser;
 import com.huawei.dynamic.config.entity.DynamicConstants;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -61,6 +62,9 @@ public class OriginConfigCenterDisableListener implements BeanFactoryAware {
     @Autowired
     private Environment environment;
 
+    @Autowired
+    private SpringEventPublisher springEventPublisher;
+
     private BeanFactory beanFactory;
 
     /**
@@ -84,6 +88,10 @@ public class OriginConfigCenterDisableListener implements BeanFactoryAware {
                 }
             }
             tryAddDynamicSourceToFirst(environment);
+
+            // 发布刷新事件补偿, 及时刷新禁用后的数据
+            springEventPublisher.publishRefreshEvent(DynamicConfigEvent.modifyEvent(event.getKey(), event.getGroup(),
+                    event.getContent()));
         });
     }
 

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/source/SpringEventPublisher.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/main/java/com/huawei/dynamic/config/source/SpringEventPublisher.java
@@ -49,8 +49,10 @@ public class SpringEventPublisher implements ApplicationEventPublisherAware {
 
     /**
      * 发布spring刷新事件{@link org.springframework.cloud.endpoint.event.RefreshEvent}
+     *
+     * @param event 事件
      */
-    private void publishRefreshEvent(DynamicConfigEvent event) {
+    public void publishRefreshEvent(DynamicConfigEvent event) {
         if (event.getEventType() == DynamicConfigEventType.INIT) {
             return;
         }

--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListenerTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/OriginConfigCenterDisableListenerTest.java
@@ -84,6 +84,8 @@ public class OriginConfigCenterDisableListenerTest {
             pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(DynamicConfiguration.class))
                     .thenReturn(configuration);
             final OriginConfigCenterDisableListener originConfigCenterDisableListener = new OriginConfigCenterDisableListener();
+            ReflectUtils.setFieldValue(originConfigCenterDisableListener, "springEventPublisher",
+                    Mockito.mock(SpringEventPublisher.class));
             final BeanFactory beanFactory = Mockito.mock(BeanFactory.class);
             originConfigCenterDisableListener.setBeanFactory(beanFactory);
             originConfigCenterDisableListener.addListener();


### PR DESCRIPTION
【修复issue】#971

【修改内容】在发布动态禁用事件后，及时刷新宿主配置

【用例描述】UT

【自测情况】UT覆盖，本地测试

【影响范围】动态配置插件