### PR TITLE
【fix】修复一些bug

### DIFF
--- a/.github/actions/scenarios/dubbo/dubbo-common/action.yml
+++ b/.github/actions/scenarios/dubbo/dubbo-common/action.yml
@@ -7,6 +7,13 @@ runs:
       uses: ./.github/actions/common/entry
       with:
         log-dir: ./logs/dubbo-common
+    - name: delete dubbo.registry.address in configuration file to test dubbo registry address with system property
+      shell: bash
+      run: |
+        sed -i '/dubbo:registry/d' sermant-integration-tests/dubbo-test/dubbo-2-6-integration-consumer/src/main/resources/dubbo/dubbo.xml
+        sed -i '/registry:/d' sermant-integration-tests/dubbo-test/dubbo-2-7-integration-consumer/src/main/resources/application.yaml
+        sed -i '/address:/d' sermant-integration-tests/dubbo-test/dubbo-2-7-integration-consumer/src/main/resources/application.yaml
+        sed -i '/protocol: zookeeper/d' sermant-integration-tests/dubbo-test/dubbo-2-7-integration-consumer/src/main/resources/application.yaml
     - name: package dubbo 2.6.0 tests
       shell: bash
       if: matrix.dubbo-version == '2-6' && matrix.dubbo-versions == '0'
@@ -79,7 +86,7 @@ runs:
         SERVER_PORT: 18020
         DUBBO_PROTOCOL_PORT: 18820
       run: |
-        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=dubbo-integration-consumer -jar \
+        nohup java -Ddubbo.registry.address=zookeeper://127.0.0.1:2181 -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=dubbo-integration-consumer -jar \
         sermant-integration-tests/dubbo-test/dubbo-${{ matrix.dubbo-version }}-integration-consumer/target/dubbo-integration-consumer.jar > ${{ env.logDir }}/spring-and-dubbo-consumer.log 2>&1 &
     - name: start consumer service
       shell: bash
@@ -89,7 +96,7 @@ runs:
         SERVER_PORT: 28020
         DUBBO_PROTOCOL_PORT: 28820
       run: |
-        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=dubbo-integration-consumer -jar \
+        nohup java -Ddubbo.registry.address=zookeeper://127.0.0.1:2181 -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=dubbo-integration-consumer -jar \
         sermant-integration-tests/dubbo-test/dubbo-${{ matrix.dubbo-version }}-integration-consumer/target/dubbo-integration-consumer.jar > ${{ env.logDir }}/dubbo-consumer.log 2>&1 &
     - name: waiting for consumers start
       shell: bash

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/template/CommonBaseAdviser.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/template/CommonBaseAdviser.java
@@ -16,10 +16,14 @@
 
 package com.huaweicloud.sermant.core.plugin.agent.template;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
 
 import java.util.ListIterator;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * 通用的基础Adviser
@@ -29,6 +33,8 @@ import java.util.ListIterator;
  * @since 2022-01-24
  */
 public class CommonBaseAdviser {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
     private CommonBaseAdviser() {
     }
 
@@ -46,6 +52,10 @@ public class CommonBaseAdviser {
         ExecuteContext newContext = context;
         while (interceptorItr.hasNext()) {
             final Interceptor interceptor = interceptorItr.next();
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, String.format(Locale.ROOT, "Method[%s] had been entered, interceptor is [%s].",
+                    MethodKeyCreator.getMethodKey(context.getMethod()), interceptor.getClass().getName()));
+            }
             try {
                 final ExecuteContext tempContext = interceptor.before(newContext);
                 if (tempContext != null) {
@@ -79,6 +89,10 @@ public class CommonBaseAdviser {
         ExecuteContext newContext = context;
         while (interceptorItr.hasPrevious()) {
             final Interceptor interceptor = interceptorItr.previous();
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, String.format(Locale.ROOT, "Method[%s] had been exited, interceptor is [%s].",
+                    MethodKeyCreator.getMethodKey(context.getMethod()), interceptor.getClass().getName()));
+            }
             if (newContext.getThrowable() != null && onThrowHandler != null) {
                 try {
                     final ExecuteContext tempContext = interceptor.onThrow(newContext);

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/template/MethodKeyCreator.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/template/MethodKeyCreator.java
@@ -61,6 +61,9 @@ public class MethodKeyCreator {
      * @return 方法键
      */
     public static String getMethodKey(Method method) {
+        if (method == null) {
+            return "#<init>()";
+        }
         final StringBuilder sb = new StringBuilder()
                 .append(method.getDeclaringClass().getName())
                 .append('#')

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/KieDynamicConfigService.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/KieDynamicConfigService.java
@@ -47,7 +47,7 @@ public class KieDynamicConfigService extends DynamicConfigService {
      * KieDynamicConfigService
      */
     public KieDynamicConfigService() {
-        subscriberManager = new SubscriberManager(CONFIG.getServerAddress());
+        subscriberManager = new SubscriberManager(CONFIG.getServerAddress(), CONFIG.getTimeoutValue());
     }
 
     /**
@@ -57,7 +57,7 @@ public class KieDynamicConfigService extends DynamicConfigService {
      * @param project project
      */
     public KieDynamicConfigService(String serverAddress, String project) {
-        subscriberManager = new SubscriberManager(serverAddress, project);
+        subscriberManager = new SubscriberManager(serverAddress, project, CONFIG.getTimeoutValue());
     }
 
     @Override

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/AbstractClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/AbstractClient.java
@@ -26,6 +26,11 @@ import com.huaweicloud.sermant.implement.service.dynamicconfig.kie.client.http.H
  * @since 2021-11-17
  */
 public abstract class AbstractClient implements Client {
+    /**
+     * 默认超时时间
+     */
+    private static final int DEFAULT_TIMEOUT_MS = 60000;
+
     protected final ClientUrlManager clientUrlManager;
 
     protected HttpClient httpClient;
@@ -37,7 +42,7 @@ public abstract class AbstractClient implements Client {
      */
     protected AbstractClient(ClientUrlManager clientUrlManager) {
         this.clientUrlManager = clientUrlManager;
-        initDefaultClient();
+        initDefaultClient(DEFAULT_TIMEOUT_MS);
     }
 
     /**
@@ -45,17 +50,18 @@ public abstract class AbstractClient implements Client {
      *
      * @param clientUrlManager clientUrlManager
      * @param httpClient httpClient
+     * @param timeout 超时时间
      */
-    protected AbstractClient(ClientUrlManager clientUrlManager, HttpClient httpClient) {
+    protected AbstractClient(ClientUrlManager clientUrlManager, HttpClient httpClient, int timeout) {
         this.clientUrlManager = clientUrlManager;
         if (httpClient != null) {
             this.httpClient = httpClient;
         } else {
-            initDefaultClient();
+            initDefaultClient(timeout);
         }
     }
 
-    private void initDefaultClient() {
-        this.httpClient = new DefaultHttpClient();
+    private void initDefaultClient(int timeout) {
+        this.httpClient = new DefaultHttpClient(timeout);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
@@ -52,8 +52,8 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.net.ssl.HostnameVerifier;
@@ -68,10 +68,6 @@ import javax.net.ssl.SSLContext;
 public class DefaultHttpClient
     implements com.huaweicloud.sermant.implement.service.dynamicconfig.kie.client.http.HttpClient {
     private static final Logger LOGGER = LoggerFactory.getLogger();
-    /**
-     * 默认超时时间
-     */
-    private static final int DEFAULT_TIMEOUT_MS = 5000;
 
     /**
      * 最大的连接数 该值建议 > {@link SubscriberManager}最大线程数MAX_THREAD_SIZE
@@ -85,15 +81,25 @@ public class DefaultHttpClient
 
     private final HttpClient httpClient;
 
-    public DefaultHttpClient() {
+    /**
+     * 构造方法
+     *
+     * @param timeout 超时时间
+     */
+    public DefaultHttpClient(int timeout) {
         httpClient = HttpClientBuilder.create().setDefaultRequestConfig(
-            RequestConfig.custom().setConnectTimeout(DEFAULT_TIMEOUT_MS)
-                .setSocketTimeout(DEFAULT_TIMEOUT_MS)
-                .setConnectionRequestTimeout(DEFAULT_TIMEOUT_MS)
+            RequestConfig.custom().setConnectTimeout(timeout)
+                .setSocketTimeout(timeout)
+                .setConnectionRequestTimeout(timeout)
                 .build()
         ).setConnectionManager(buildConnectionManager()).build();
     }
 
+    /**
+     * 构造方法
+     *
+     * @param requestConfig 配置
+     */
     public DefaultHttpClient(RequestConfig requestConfig) {
         this.httpClient = HttpClientBuilder.create()
             .setDefaultRequestConfig(requestConfig)
@@ -126,7 +132,7 @@ public class DefaultHttpClient
             final SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(new SslTrustStrategy()).build();
             builder.register("https", new SSLConnectionSocketFactory(sslContext, hostnameVerifier));
         } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException ex) {
-            LOGGER.warning(String.format(Locale.ENGLISH, "Failed to get SSLContext, reason: %s", ex.getMessage()));
+            LOGGER.log(Level.WARNING, "Failed to get SSLContext, reason: ", ex);
         }
     }
 
@@ -215,7 +221,7 @@ public class DefaultHttpClient
             }
             result = EntityUtils.toString(entity, "UTF-8");
         } catch (IOException ex) {
-            LOGGER.warning(String.format(Locale.ENGLISH, "Execute request failed, %s", ex.getMessage()));
+            LOGGER.log(Level.WARNING, "Execute request failed.", ex);
         } finally {
             consumeEntity(entity);
         }
@@ -229,7 +235,7 @@ public class DefaultHttpClient
         try {
             EntityUtils.consume(entity);
         } catch (IOException ex) {
-            LOGGER.warning(String.format(Locale.ENGLISH, "Consumed http entity failed, %s", ex.getMessage()));
+            LOGGER.log(Level.WARNING, "Consumed http entity failed.", ex);
         }
     }
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/KieClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/KieClient.java
@@ -51,9 +51,10 @@ public class KieClient extends AbstractClient {
      * kei客户端构造器
      *
      * @param clientUrlManager kie url管理器
+     * @param timeout          超时时间
      */
-    public KieClient(ClientUrlManager clientUrlManager) {
-        this(clientUrlManager, ConfigManager.getConfig(KieDynamicConfig.class).getProject());
+    public KieClient(ClientUrlManager clientUrlManager, int timeout) {
+        this(clientUrlManager, ConfigManager.getConfig(KieDynamicConfig.class).getProject(), timeout);
     }
 
     /**
@@ -61,9 +62,10 @@ public class KieClient extends AbstractClient {
      *
      * @param clientUrlManager kie url管理器
      * @param project          命名空间
+     * @param timeout          超时时间
      */
-    public KieClient(ClientUrlManager clientUrlManager, String project) {
-        this(clientUrlManager, null, project);
+    public KieClient(ClientUrlManager clientUrlManager, String project, int timeout) {
+        this(clientUrlManager, null, project, timeout);
     }
 
     /**
@@ -72,9 +74,10 @@ public class KieClient extends AbstractClient {
      * @param clientUrlManager kie url管理器
      * @param httpClient       指定请求器
      * @param project          命名空间
+     * @param timeout          超时时间
      */
-    public KieClient(ClientUrlManager clientUrlManager, HttpClient httpClient, String project) {
-        super(clientUrlManager, httpClient);
+    public KieClient(ClientUrlManager clientUrlManager, HttpClient httpClient, String project, int timeout) {
+        super(clientUrlManager, httpClient, timeout);
         kieApi = String.format(kieApiTemplate, project);
     }
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/SubscriberManager.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/SubscriberManager.java
@@ -127,9 +127,10 @@ public class SubscriberManager {
      * 构造函数
      *
      * @param serverAddress serverAddress
+     * @param timeout       超时时间
      */
-    public SubscriberManager(String serverAddress) {
-        kieClient = new KieClient(new ClientUrlManager(serverAddress));
+    public SubscriberManager(String serverAddress, int timeout) {
+        kieClient = new KieClient(new ClientUrlManager(serverAddress), timeout);
     }
 
     /**
@@ -137,9 +138,10 @@ public class SubscriberManager {
      *
      * @param serverAddress serverAddress
      * @param project       project
+     * @param timeout       超时时间
      */
-    public SubscriberManager(String serverAddress, String project) {
-        kieClient = new KieClient(new ClientUrlManager(serverAddress), project);
+    public SubscriberManager(String serverAddress, String project, int timeout) {
+        kieClient = new KieClient(new ClientUrlManager(serverAddress), project, timeout);
     }
 
     /**

--- a/sermant-integration-tests/dubbo-test/dubbo-2-6-integration-provider/src/main/java/com/huaweicloud/integration/service/FooServiceImpl.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-2-6-integration-provider/src/main/java/com/huaweicloud/integration/service/FooServiceImpl.java
@@ -16,10 +16,12 @@
 
 package com.huaweicloud.integration.service;
 
-import com.alibaba.dubbo.config.RegistryConfig;
+import com.alibaba.dubbo.common.extension.ExtensionLoader;
+import com.alibaba.dubbo.registry.RegistryFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+
+import java.util.ArrayList;
 
 /**
  * 测试接口
@@ -28,9 +30,6 @@ import org.springframework.beans.factory.annotation.Value;
  * @since 2022-04-28
  */
 public class FooServiceImpl implements FooService {
-    @Autowired
-    private RegistryConfig registryConfig;
-
     @Value("${service_meta_zone:${SERVICE_META_ZONE:${service.meta.zone:bar}}}")
     private String zone;
 
@@ -55,7 +54,7 @@ public class FooServiceImpl implements FooService {
 
     @Override
     public String getRegistryProtocol() {
-        return registryConfig.getProtocol();
+        return new ArrayList<>(ExtensionLoader.getExtensionLoader(RegistryFactory.class).getLoadedExtensions()).get(0);
     }
 
     @Override

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpUrlConnectionConnectInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/HttpUrlConnectionConnectInterceptor.java
@@ -18,11 +18,14 @@ package com.huaweicloud.sermant.router.spring.interceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
 import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.request.RequestData;
 import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
 import com.huaweicloud.sermant.router.common.utils.FlowContextUtils;
 import com.huaweicloud.sermant.router.common.utils.ThreadLocalUtils;
+
+import sun.net.www.MessageHeader;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -41,7 +44,11 @@ public class HttpUrlConnectionConnectInterceptor extends AbstractInterceptor {
     public ExecuteContext before(ExecuteContext context) {
         if (context.getObject() instanceof HttpURLConnection) {
             HttpURLConnection connection = (HttpURLConnection) context.getObject();
-            Map<String, List<String>> headers = connection.getRequestProperties();
+            Optional<Object> requests = ReflectUtils.getFieldValue(connection, "requests");
+            if (!requests.isPresent()) {
+                return context;
+            }
+            Map<String, List<String>> headers = ((MessageHeader) requests.get()).getHeaders(null);
             String method = connection.getRequestMethod();
             if (StringUtils.isBlank(FlowContextUtils.getTagName()) || CollectionUtils
                 .isEmpty(headers.get(FlowContextUtils.getTagName()))) {

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/constants/Constant.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/constants/Constant.java
@@ -29,6 +29,11 @@ public class Constant {
     public static final String SC_REGISTRY_PROTOCOL = "sc";
 
     /**
+     * sc注册ip
+     */
+    public static final String SC_REGISTRY_IP = "localhost:30100";
+
+    /**
      * 协议分隔符
      */
     public static final String PROTOCOL_SEPARATION = "://";
@@ -41,7 +46,7 @@ public class Constant {
     /**
      * sc注册地址
      */
-    public static final String SC_REGISTRY_ADDRESS = SC_REGISTRY_PROTOCOL + PROTOCOL_SEPARATION + "localhost:30100";
+    public static final String SC_REGISTRY_ADDRESS = SC_REGISTRY_PROTOCOL + PROTOCOL_SEPARATION + SC_REGISTRY_IP;
 
     /**
      * 设置协议方法名

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/declarer/AlibabaInterfaceConfigDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/declarer/AlibabaInterfaceConfigDeclarer.java
@@ -16,35 +16,34 @@
 
 package com.huawei.dubbo.registry.declarer;
 
-import com.huawei.dubbo.registry.constants.Constant;
-
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
 
 /**
- * RegistryConfig增强类
+ * AbstractInterfaceConfig增强类
  *
  * @author provenceee
- * @since 2022-04-13
+ * @since 2022-11-24
  */
-public class RegistryConfigDeclarer extends AbstractDeclarer {
-    private static final String[] ENHANCE_CLASS = {"org.apache.dubbo.config.RegistryConfig"};
+public class AlibabaInterfaceConfigDeclarer extends AbstractDeclarer {
+    private static final String[] ENHANCE_CLASS = {"com.alibaba.dubbo.config.AbstractInterfaceConfig"};
 
-    private static final String INTERCEPT_CLASS = "com.huawei.dubbo.registry.interceptor.RegistryConfigInterceptor";
+    private static final String INTERCEPT_CLASS
+        = "com.huawei.dubbo.registry.interceptor.AlibabaInterfaceConfigInterceptor";
 
-    private static final String[] METHOD_NAME = {Constant.SET_PROTOCOL_METHOD_NAME, "setAddress"};
+    private static final String METHOD_NAME = "loadRegistries";
 
     /**
      * 构造方法
      */
-    public RegistryConfigDeclarer() {
+    public AlibabaInterfaceConfigDeclarer() {
         super(ENHANCE_CLASS);
     }
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-            InterceptDeclarer.build(MethodMatcher.nameContains(METHOD_NAME), INTERCEPT_CLASS)
+            InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/declarer/ApacheInterfaceConfigDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/declarer/ApacheInterfaceConfigDeclarer.java
@@ -25,11 +25,11 @@ import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
  * @author provenceee
  * @since 2021-11-24
  */
-public class InterfaceConfigDeclarer extends AbstractDeclarer {
-    private static final String[] ENHANCE_CLASS = {"org.apache.dubbo.config.AbstractInterfaceConfig",
-        "com.alibaba.dubbo.config.AbstractInterfaceConfig"};
+public class ApacheInterfaceConfigDeclarer extends AbstractDeclarer {
+    private static final String[] ENHANCE_CLASS = {"org.apache.dubbo.config.AbstractInterfaceConfig"};
 
-    private static final String INTERCEPT_CLASS = "com.huawei.dubbo.registry.interceptor.InterfaceConfigInterceptor";
+    private static final String INTERCEPT_CLASS
+        = "com.huawei.dubbo.registry.interceptor.ApacheInterfaceConfigInterceptor";
 
     // 增强loadRegistriesFromBackwardConfig方法是为了兼容2.7.0-2.7.4.1，其它版本主要是增强setRegistries方法
     private static final String[] METHOD_NAME = {"setRegistries", "loadRegistriesFromBackwardConfig"};
@@ -37,7 +37,7 @@ public class InterfaceConfigDeclarer extends AbstractDeclarer {
     /**
      * 构造方法
      */
-    public InterfaceConfigDeclarer() {
+    public ApacheInterfaceConfigDeclarer() {
         super(ENHANCE_CLASS);
     }
 

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/interceptor/AlibabaInterfaceConfigInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/interceptor/AlibabaInterfaceConfigInterceptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.interceptor;
+
+import com.huawei.dubbo.registry.constants.Constant;
+import com.huawei.dubbo.registry.utils.CollectionUtils;
+import com.huawei.registry.config.RegisterConfig;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+import com.alibaba.dubbo.common.URL;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 增强AbstractInterfaceConfig类的loadRegistries方法
+ *
+ * @author provenceee
+ * @since 2022-11-24
+ */
+public class AlibabaInterfaceConfigInterceptor extends AbstractInterceptor {
+    private static final String REGISTRY_PROTOCOL = "registry";
+
+    private final RegisterConfig config;
+
+    /**
+     * 构造方法
+     */
+    public AlibabaInterfaceConfigInterceptor() {
+        config = PluginConfigManager.getPluginConfig(RegisterConfig.class);
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        Object result = context.getResult();
+        if (config.isEnableDubboRegister() && (result instanceof List<?>)) {
+            List<URL> urls = (List<URL>) result;
+            if (CollectionUtils.isEmpty(urls)) {
+                return context;
+            }
+            if (config.isOpenMigration()) {
+                // 任取一个即可
+                getScRegistryUrl(urls.get(0)).ifPresent(urls::add);
+                return context;
+            }
+            List<URL> scUrls = new ArrayList<>();
+            for (URL url : urls) {
+                Optional<URL> registryUrl = getScRegistryUrl(url);
+                if (registryUrl.isPresent()) {
+                    scUrls.add(registryUrl.get());
+                } else {
+                    scUrls.add(url);
+                }
+            }
+            context.changeResult(scUrls);
+        }
+        return context;
+    }
+
+    private Optional<URL> getScRegistryUrl(URL url) {
+        if (!REGISTRY_PROTOCOL.equals(url.getProtocol())) {
+            return Optional.empty();
+        }
+        if (Constant.SC_REGISTRY_PROTOCOL.equals(url.getParameter(REGISTRY_PROTOCOL))) {
+            return Optional.empty();
+        }
+        return Optional
+            .of(url.setAddress(Constant.SC_REGISTRY_IP).addParameter(REGISTRY_PROTOCOL, Constant.SC_REGISTRY_PROTOCOL));
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/interceptor/ApacheInterfaceConfigInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/interceptor/ApacheInterfaceConfigInterceptor.java
@@ -28,13 +28,13 @@ import com.huaweicloud.sermant.core.service.ServiceManager;
  * @author provenceee
  * @since 2021-11-08
  */
-public class InterfaceConfigInterceptor extends AbstractInterceptor {
+public class ApacheInterfaceConfigInterceptor extends AbstractInterceptor {
     private final RegistryConfigService registryConfigService;
 
     /**
      * 构造方法
      */
-    public InterfaceConfigInterceptor() {
+    public ApacheInterfaceConfigInterceptor() {
         registryConfigService = ServiceManager.getService(RegistryConfigService.class);
     }
 

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,7 +1,8 @@
+com.huawei.dubbo.registry.declarer.AlibabaInterfaceConfigDeclarer
+com.huawei.dubbo.registry.declarer.ApacheInterfaceConfigDeclarer
 com.huawei.dubbo.registry.declarer.ApplicationConfigDeclarer
 com.huawei.dubbo.registry.declarer.ConfigValidationDeclarer
 com.huawei.dubbo.registry.declarer.ExtensionLoaderDeclarer
-com.huawei.dubbo.registry.declarer.InterfaceConfigDeclarer
 com.huawei.dubbo.registry.declarer.MigrationRuleDeclarer
 com.huawei.dubbo.registry.declarer.MigrationRuleHandlerDeclarer
 com.huawei.dubbo.registry.declarer.RegistryConfigDeclarer

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/AlibabaInterfaceConfigInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/AlibabaInterfaceConfigInterceptorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import com.huawei.dubbo.registry.interceptor.AlibabaInterfaceConfigInterceptor;
+import com.huawei.registry.config.RegisterConfig;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
+import com.alibaba.dubbo.common.URL;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 测试AlibabaInterfaceConfigInterceptor
+ *
+ * @author provenceee
+ * @since 2022-11-25
+ */
+public class AlibabaInterfaceConfigInterceptorTest {
+    private final AlibabaInterfaceConfigInterceptor interceptor;
+
+    private final RegisterConfig registerConfig;
+
+    private final ExecuteContext context;
+
+    private final List<URL> urls;
+
+    public AlibabaInterfaceConfigInterceptorTest()
+        throws IllegalAccessException, NoSuchFieldException, NoSuchMethodException {
+        urls = new ArrayList<>();
+        urls.add(new URL("registry", "127.0.0.1", 80).addParameter("registry", "foo"));
+        interceptor = new AlibabaInterfaceConfigInterceptor();
+        registerConfig = new RegisterConfig();
+        Field field = interceptor.getClass().getDeclaredField("config");
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(interceptor, registerConfig);
+        context = ExecuteContext.forMemberMethod(new Object(), String.class.getMethod("trim"), new Object[0], null,
+            null);
+    }
+
+    /**
+     * 初始化
+     */
+    @Before
+    public void init() {
+        registerConfig.setEnableDubboRegister(false);
+        registerConfig.setOpenMigration(false);
+        context.changeResult(urls);
+    }
+
+    /**
+     * 测试开关关闭时
+     */
+    @Test
+    public void testDisabled() {
+        interceptor.after(context);
+        Assert.assertEquals(urls, context.getResult());
+        Assert.assertEquals(1, ((List<URL>) context.getResult()).size());
+    }
+
+    /**
+     * 测试开关关闭时
+     */
+    @Test
+    public void testEnableDubboRegister() {
+        registerConfig.setEnableDubboRegister(true);
+
+        // 测试空list
+        context.changeResult(Collections.emptyList());
+        interceptor.after(context);
+        Assert.assertEquals(Collections.emptyList(), context.getResult());
+
+        // 测试合法数据
+        context.changeResult(urls);
+        interceptor.after(context);
+        List<URL> result = (List<URL>) context.getResult();
+        Assert.assertNotEquals(urls, result);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals("registry", result.get(0).getProtocol());
+        Assert.assertEquals("sc", result.get(0).getParameter("registry"));
+    }
+
+    /**
+     * 测试开关关闭时
+     */
+    @Test
+    public void testOpenMigration() {
+        registerConfig.setEnableDubboRegister(true);
+        registerConfig.setOpenMigration(true);
+
+        // 测试空list
+        context.changeResult(Collections.emptyList());
+        interceptor.after(context);
+        Assert.assertEquals(Collections.emptyList(), context.getResult());
+
+        // 测试合法数据
+        context.changeResult(urls);
+        interceptor.after(context);
+        List<URL> result = (List<URL>) context.getResult();
+        Assert.assertEquals(urls, result);
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("registry", result.get(1).getProtocol());
+        Assert.assertEquals("sc", result.get(1).getParameter("registry"));
+        urls.remove(1);
+    }
+}


### PR DESCRIPTION
【修复issue】 #976 

【修改内容】

- 修复dubbo2.6版本，使用-D参数配置注册地址时，会导致注册插件失效的问题并修改集成测试用例测试该问题
- 修复超时时间对kie客户端失效的问题
- 修复HttpUrlConnectionConnectInterceptor获取请求头时有可能会抛出异常的问题
- 增加拦截点的debug日志，方便定位问题

【用例描述】修改了集成测试用例

【自测情况】1.使用集成测试用例测试，2.nacos动态配置插件，不再报异常

【影响范围】dubbo注册插件、springboot路由插件

