### PR TITLE
【feature】优化发布流水线

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -6,13 +6,18 @@ on:
 name: Create Release
 
 env:
-  version: '0.7.0'
+  tag: ${{ github.ref }}
 
 jobs:
   auto-create-release:
     name: Auto Create Release
     runs-on: windows-latest
     steps:
+      - name: save env version
+        shell: bash
+        run: |
+          str=${{env.tag}}
+          echo "version=${str##*v}" >> $GITHUB_ENV
       - name: Checkout Source # 检出代码
         uses: actions/checkout@v2
       - name: Set up JDK 8 # 构建jdk运行环境

--- a/.github/workflows/publish_maven_central_warehouse.yml
+++ b/.github/workflows/publish_maven_central_warehouse.yml
@@ -1,0 +1,53 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number to be released this time'
+        required: true
+
+name: publish
+
+env:
+  version: ${{ inputs.version }}
+
+jobs:
+  publish:
+    name: publish Maven central warehouse
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source # 检出代码
+        uses: actions/checkout@v2
+      - name: Set up JDK 8 # 构建jdk运行环境
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: maven
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: set version
+        run: |
+          mvn versions:set -DnewVersion='${{ env.version }}'
+      - name: Install secret key
+        run: |
+          cat <(echo -e "${{ secrets.GPG_PRIVATE_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+      - name: publish agentCore
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        run: |
+          cd ${{ github.workspace }}/sermant-agentcore
+          mvn --batch-mode -Dgpg.passphrase=${{ secrets.GPG_SECRET_KEY_PASSWORD }} clean deploy -P release -DskipTests
+      - name: install
+        run: |
+          cd ${{ github.workspace }}
+          mvn clean install -DskipTests
+      - name: publish plugin
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        run: |
+          cd ${{ github.workspace }}
+          mvn --batch-mode -Dgpg.passphrase=${{ secrets.GPG_SECRET_KEY_PASSWORD }} clean deploy -P release -DskipTests


### PR DESCRIPTION
【修复issue】#997

【修改内容】
1、修改原先推送github的流水线，版本号从TAG标签中获取
2、增加推送maven中心仓的流水线

【用例描述】
1、不需要，不涉及代码改动

【自测情况】
1、本地静态检查通过
2、自测通过

【影响范围】1、对用户的使用没有影响