### PR TITLE
【feature】增加dubbo框架微服务Nacos注册能力

### DIFF
--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/alibaba/NacosRegistry.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/alibaba/NacosRegistry.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.alibaba;
+
+import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
+
+import com.huaweicloud.sermant.core.service.ServiceManager;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.registry.NotifyListener;
+import com.alibaba.dubbo.registry.support.FailbackRegistry;
+
+/**
+ * nacos注册
+ *
+ * @author chengyouling
+ * @since 2022-10-25
+ */
+public class NacosRegistry extends FailbackRegistry {
+    private final NacosRegistryService registryService;
+
+    /**
+     * 构造方法
+     *
+     * @param url 注册url
+     */
+    public NacosRegistry(URL url) {
+        super(url);
+        registryService = ServiceManager.getService(NacosRegistryService.class);
+    }
+
+    @Override
+    public void doRegister(URL url) {
+        registryService.doRegister(url);
+    }
+
+    @Override
+    public void doUnregister(URL url) {
+        registryService.doUnregister(url);
+    }
+
+    @Override
+    public void doSubscribe(URL url, NotifyListener notifyListener) {
+        registryService.doSubscribe(url, notifyListener);
+    }
+
+    @Override
+    public void doUnsubscribe(URL url, NotifyListener notifyListener) {
+        registryService.doUnsubscribe(url, notifyListener);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return registryService.isAvailable();
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/alibaba/NacosRegistryFactory.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/alibaba/NacosRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,44 +17,48 @@
 package com.huawei.dubbo.registry.alibaba;
 
 import com.huawei.dubbo.registry.cache.DubboCache;
+import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
 import com.huawei.dubbo.registry.utils.ReflectUtils;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.service.ServiceManager;
 
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.registry.Registry;
 import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * sc注册工厂
+ * nacos注册工厂
  *
- * @author provenceee
- * @since 2021-12-15
+ * @author chengyouling
+ * @since 2022-10-25
  */
-public class ServiceCenterRegistryFactory extends AbstractRegistryFactory {
-    private static final String ALIBABA_REGISTRY_CLASS_NAME = "com.huawei.dubbo.registry.alibaba.ServiceCenterRegistry";
+public class NacosRegistryFactory extends AbstractRegistryFactory {
+    private static final String ALIBABA_REGISTRY_CLASS_NAME = "com.huawei.dubbo.registry.alibaba.NacosRegistry";
     private static final Logger LOGGER = LoggerFactory.getLogger();
+    private final NacosRegistryService registryService = ServiceManager.getService(NacosRegistryService.class);
 
     @Override
     protected Registry createRegistry(URL url) {
-        // 加载了sc的注册spi的标志
-        DubboCache.INSTANCE.loadSc();
         DubboCache.INSTANCE.setUrlClass(url.getClass());
         try {
             Optional<Class<?>> registryClass = ReflectUtils.defineClass(ALIBABA_REGISTRY_CLASS_NAME);
+            Map<String, String> parameters = url.getParameters();
+            registryService.buildNamingService(parameters);
             if (registryClass.isPresent()) {
                 // 由于plugin不能直接new宿主的接口实现类，所以只能手动new出来给宿主
                 return (Registry) registryClass.get().getConstructor(URL.class).newInstance(url);
             }
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
-            | InvocationTargetException e) {
+                | InvocationTargetException e) {
             LOGGER.log(Level.WARNING, "Can not get the registry", e);
         }
-        return new com.huawei.dubbo.registry.alibaba.ServiceCenterRegistry(url);
+        return new NacosRegistry(url);
     }
 }

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/apache/NacosRegistry.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/apache/NacosRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.apache;
+
+import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
+
+import com.huaweicloud.sermant.core.service.ServiceManager;
+
+import org.apache.dubbo.registry.NotifyListener;
+import org.apache.dubbo.registry.support.FailbackRegistry;
+
+/**
+ * nacos注册
+ *
+ * @author chengyouling
+ * @since 2022-10-25
+ */
+public class NacosRegistry extends FailbackRegistry {
+    private final NacosRegistryService registryService;
+
+    /**
+     * 构造方法
+     *
+     * @param url 注册url
+     */
+    public NacosRegistry(org.apache.dubbo.common.URL url) {
+        super(url);
+        registryService = ServiceManager.getService(NacosRegistryService.class);
+    }
+
+    @Override
+    public void doRegister(org.apache.dubbo.common.URL url) {
+        registryService.doRegister(url);
+    }
+
+    @Override
+    public void doUnregister(org.apache.dubbo.common.URL url) {
+        registryService.doUnregister(url);
+    }
+
+    @Override
+    public void doSubscribe(org.apache.dubbo.common.URL url, NotifyListener listener) {
+        registryService.doSubscribe(url, listener);
+    }
+
+    @Override
+    public void doUnsubscribe(org.apache.dubbo.common.URL url, NotifyListener listener) {
+        registryService.doUnsubscribe(url, listener);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return registryService.isAvailable();
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/apache/NacosRegistryFactory.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/apache/NacosRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,47 +14,51 @@
  * limitations under the License.
  */
 
-package com.huawei.dubbo.registry.alibaba;
+package com.huawei.dubbo.registry.apache;
 
 import com.huawei.dubbo.registry.cache.DubboCache;
+import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
 import com.huawei.dubbo.registry.utils.ReflectUtils;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.service.ServiceManager;
 
-import com.alibaba.dubbo.common.URL;
-import com.alibaba.dubbo.registry.Registry;
-import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.registry.Registry;
+import org.apache.dubbo.registry.support.AbstractRegistryFactory;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * sc注册工厂
+ * nacos注册工厂
  *
- * @author provenceee
- * @since 2021-12-15
+ * @author chengyouling
+ * @since 2022-10-25
  */
-public class ServiceCenterRegistryFactory extends AbstractRegistryFactory {
-    private static final String ALIBABA_REGISTRY_CLASS_NAME = "com.huawei.dubbo.registry.alibaba.ServiceCenterRegistry";
+public class NacosRegistryFactory extends AbstractRegistryFactory {
+    private static final String APACHE_REGISTRY_CLASS_NAME = "com.huawei.dubbo.registry.apache.NacosRegistry";
     private static final Logger LOGGER = LoggerFactory.getLogger();
+    private final NacosRegistryService registryService = ServiceManager.getService(NacosRegistryService.class);
 
     @Override
     protected Registry createRegistry(URL url) {
-        // 加载了sc的注册spi的标志
-        DubboCache.INSTANCE.loadSc();
         DubboCache.INSTANCE.setUrlClass(url.getClass());
         try {
-            Optional<Class<?>> registryClass = ReflectUtils.defineClass(ALIBABA_REGISTRY_CLASS_NAME);
+            Optional<Class<?>> registryClass = ReflectUtils.defineClass(APACHE_REGISTRY_CLASS_NAME);
+            Map<String, String> parameters = url.getParameters();
+            registryService.buildNamingService(parameters);
             if (registryClass.isPresent()) {
                 // 由于plugin不能直接new宿主的接口实现类，所以只能手动new出来给宿主
                 return (Registry) registryClass.get().getConstructor(URL.class).newInstance(url);
             }
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
-            | InvocationTargetException e) {
+                | InvocationTargetException e) {
             LOGGER.log(Level.WARNING, "Can not get the registry", e);
         }
-        return new com.huawei.dubbo.registry.alibaba.ServiceCenterRegistry(url);
+        return new com.huawei.dubbo.registry.apache.NacosRegistry(url);
     }
 }

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/apache/ServiceCenterRegistryFactory.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/apache/ServiceCenterRegistryFactory.java
@@ -19,12 +19,16 @@ package com.huawei.dubbo.registry.apache;
 import com.huawei.dubbo.registry.cache.DubboCache;
 import com.huawei.dubbo.registry.utils.ReflectUtils;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.registry.Registry;
 import org.apache.dubbo.registry.support.AbstractRegistryFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * sc注册工厂
@@ -34,6 +38,7 @@ import java.util.Optional;
  */
 public class ServiceCenterRegistryFactory extends AbstractRegistryFactory {
     private static final String APACHE_REGISTRY_CLASS_NAME = "com.huawei.dubbo.registry.apache.ServiceCenterRegistry";
+    private static final Logger LOGGER = LoggerFactory.getLogger();
 
     @Override
     protected Registry createRegistry(URL url) {
@@ -46,10 +51,10 @@ public class ServiceCenterRegistryFactory extends AbstractRegistryFactory {
                 // 由于plugin不能直接new宿主的接口实现类，所以只能手动new出来给宿主
                 return (Registry) registryClass.get().getConstructor(URL.class).newInstance(url);
             }
-            return new com.huawei.dubbo.registry.apache.ServiceCenterRegistry(url);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
             | InvocationTargetException e) {
-            return new com.huawei.dubbo.registry.apache.ServiceCenterRegistry(url);
+            LOGGER.log(Level.WARNING, "Can not get the registry", e);
         }
+        return new com.huawei.dubbo.registry.apache.ServiceCenterRegistry(url);
     }
 }

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/constants/Constant.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/constants/Constant.java
@@ -29,6 +29,11 @@ public class Constant {
     public static final String SC_REGISTRY_PROTOCOL = "sc";
 
     /**
+     * nacos注册协议名
+     */
+    public static final String NACOS_REGISTRY_PROTOCOL = "nacos";
+
+    /**
      * sc注册ip
      */
     public static final String SC_REGISTRY_IP = "localhost:30100";

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/service/nacos/NacosRegistryService.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/service/nacos/NacosRegistryService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.service.nacos;
+
+import com.huaweicloud.sermant.core.plugin.service.PluginService;
+
+import java.util.Map;
+
+/**
+ * nacos注册服务
+ *
+ * @author chengyouling
+ * @since 2022-10-25
+ */
+public interface NacosRegistryService extends PluginService {
+    /**
+     * 注册实例
+     *
+     * @param url url
+     * @see com.alibaba.dubbo.common.URL
+     * @see org.apache.dubbo.common.URL
+     */
+    void doRegister(Object url);
+
+    /**
+     * 订阅接口
+     *
+     * @param notifyListener 实例通知监听器
+     * @param url url
+     * @see com.alibaba.dubbo.common.URL
+     * @see org.apache.dubbo.common.URL
+     * @see com.alibaba.dubbo.registry.NotifyListener
+     * @see org.apache.dubbo.registry.NotifyListener
+     */
+    void doSubscribe(Object url, Object notifyListener);
+
+    /**
+     * 清除实例
+     *
+     * @param url url
+     * @see com.alibaba.dubbo.common.URL
+     * @see org.apache.dubbo.common.URL
+     */
+    void doUnregister(Object url);
+
+    /**
+     * 构建naming服务
+     *
+     * @param parameters url参数
+     */
+    void buildNamingService(Map<String, String> parameters);
+
+    /**
+     * 清除订阅
+     *
+     * @param notifyListener 监听
+     * @param url url
+     * @see com.alibaba.dubbo.common.URL
+     * @see org.apache.dubbo.common.URL
+     * @see com.alibaba.dubbo.registry.NotifyListener
+     * @see org.apache.dubbo.registry.NotifyListener
+     */
+    void doUnsubscribe(Object url, Object notifyListener);
+
+    /**
+     * namingService是否可用
+     *
+     * @return 服务是否可用
+     */
+    boolean isAvailable();
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/AlibabaInterfaceConfigInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/AlibabaInterfaceConfigInterceptorTest.java
@@ -19,6 +19,7 @@ package com.huawei.dubbo.registry;
 import com.huawei.dubbo.registry.interceptor.AlibabaInterfaceConfigInterceptor;
 import com.huawei.registry.config.RegisterConfig;
 
+import com.huawei.registry.config.RegisterServiceCommonConfig;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 
 import com.alibaba.dubbo.common.URL;

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/ExtensionLoaderInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/ExtensionLoaderInterceptorTest.java
@@ -24,11 +24,13 @@ import com.huawei.dubbo.registry.utils.ReflectUtils;
 import com.alibaba.dubbo.common.extension.ExtensionLoader;
 import com.alibaba.dubbo.common.extension.SPI;
 import com.alibaba.dubbo.registry.RegistryFactory;
+import com.huawei.registry.config.RegisterServiceCommonConfig;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 
 /**
@@ -42,12 +44,18 @@ public class ExtensionLoaderInterceptorTest {
 
     private final Object[] arguments;
 
+    private final RegisterServiceCommonConfig commonConfig;
+
     /**
      * 构造方法
      */
-    public ExtensionLoaderInterceptorTest() {
+    public ExtensionLoaderInterceptorTest() throws NoSuchFieldException, IllegalAccessException {
         interceptor = new ExtensionLoaderInterceptor();
         arguments = new Object[1];
+        commonConfig = new RegisterServiceCommonConfig();
+        Field commonConfigField = interceptor.getClass().getDeclaredField("commonConfig");
+        commonConfigField.setAccessible(true);
+        commonConfigField.set(interceptor, commonConfig);
     }
 
     /**

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/NacosRegistryFactoryTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/NacosRegistryFactoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.alibaba.dubbo.common.URL;
+import com.huawei.dubbo.registry.alibaba.NacosRegistry;
+import com.huawei.dubbo.registry.alibaba.NacosRegistryFactory;
+import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
+import com.huaweicloud.sermant.core.service.BaseService;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+
+/**
+ * 测试NacosRegistryFactory
+ *
+ * @author chengyouling
+ * @since 2022-11-29
+ */
+public class NacosRegistryFactoryTest {
+    /**
+     * 构造方法
+     */
+    public NacosRegistryFactoryTest() throws NoSuchFieldException, IllegalAccessException {
+        Field field = ServiceManager.class.getDeclaredField("SERVICES");
+        field.setAccessible(true);
+        Map<String, BaseService> map = (Map<String, BaseService>) field.get(null);
+        map.put(NacosRegistryService.class.getCanonicalName(), new NacosRegistryService() {
+
+            @Override
+            public void doRegister(Object url) {
+
+            }
+
+            @Override
+            public void doSubscribe(Object url, Object notifyListener) {
+
+            }
+
+            @Override
+            public void doUnregister(Object url) {
+
+            }
+
+            @Override
+            public void buildNamingService(Map<String, String> parameters) {
+
+            }
+
+            @Override
+            public void doUnsubscribe(Object url, Object notifyListener) {
+
+            }
+
+            @Override
+            public boolean isAvailable() {
+                return true;
+            }
+        });
+    }
+
+    /**
+     * 测试Alibaba NacosRegistryFactory
+     *
+     * @throws NoSuchMethodException 找不到方法
+     * @throws InvocationTargetException InvocationTargetException
+     * @throws IllegalAccessException IllegalAccessException
+     */
+    @Test
+    public void testAlibabaNacosRegistryFactory()
+        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        NacosRegistryFactory registryFactory = new NacosRegistryFactory();
+        Method method = registryFactory.getClass().getDeclaredMethod("createRegistry", URL.class);
+        method.setAccessible(true);
+        Assert.assertEquals(NacosRegistry.class, method.invoke(registryFactory,
+            URL.valueOf(TestConstant.NACOS_ADDRESS)).getClass());
+    }
+
+    /**
+     * 测试Apache NacosRegistryFactory
+     *
+     * @throws NoSuchMethodException 找不到方法
+     * @throws InvocationTargetException InvocationTargetException
+     * @throws IllegalAccessException IllegalAccessException
+     */
+    @Test
+    public void testApacheNacosRegistryFactory()
+        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        com.huawei.dubbo.registry.apache.NacosRegistryFactory registryFactory =
+            new com.huawei.dubbo.registry.apache.NacosRegistryFactory();
+        Method method = registryFactory.getClass()
+            .getDeclaredMethod("createRegistry", org.apache.dubbo.common.URL.class);
+        method.setAccessible(true);
+        Assert.assertEquals(com.huawei.dubbo.registry.apache.NacosRegistry.class, method.invoke(registryFactory,
+            org.apache.dubbo.common.URL.valueOf(TestConstant.NACOS_ADDRESS)).getClass());
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/RegistryConfigInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/RegistryConfigInterceptorTest.java
@@ -20,6 +20,7 @@ import com.huawei.dubbo.registry.constants.Constant;
 import com.huawei.dubbo.registry.interceptor.RegistryConfigInterceptor;
 import com.huawei.registry.config.RegisterConfig;
 
+import com.huawei.registry.config.RegisterServiceCommonConfig;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 
 import com.alibaba.dubbo.config.RegistryConfig;

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/TestConstant.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/TestConstant.java
@@ -38,6 +38,11 @@ public class TestConstant {
      */
     public static final String SC_ADDRESS = "sc://localhost:30100";
 
+    /**
+     * nacos协议的注册地址
+     */
+    public static final String NACOS_ADDRESS = "nacos://127.0.0.1:8848";
+
     private TestConstant() {
     }
 }

--- a/sermant-plugins/sermant-service-registry/registry-common/src/main/java/com/huawei/registry/config/NacosRegisterConfig.java
+++ b/sermant-plugins/sermant-service-registry/registry-common/src/main/java/com/huawei/registry/config/NacosRegisterConfig.java
@@ -34,6 +34,22 @@ import java.util.Properties;
  */
 @ConfigTypeKey(value = "nacos.service")
 public class NacosRegisterConfig implements PluginConfig {
+
+    /**
+     * 默认拉取间隔时间
+     */
+    private static final long DEFAULT_NOTIFY_DELAY = 5000L;
+
+    /**
+     * 默认监控时间
+     */
+    private static final long DEFAULT_LOOKUP_INTERVAL = 30L;
+
+    /**
+     * 默认数据页大小
+     */
+    private static final int DEFAULT_PAGINATION_SIZE = 100;
+
     /**
      * spring cloud zone
      * 若未配置默认使用系统环境变量的zone, 即spring.cloud.loadbalancer.zone
@@ -131,6 +147,21 @@ public class NacosRegisterConfig implements PluginConfig {
     private String serviceNameSeparator = ":";
 
     /**
+     * 数据页大小
+     */
+    private int paginationSize = DEFAULT_PAGINATION_SIZE;
+
+    /**
+     * 监控时间
+     */
+    private long lookupInterval = DEFAULT_LOOKUP_INTERVAL;
+
+    /**
+     * 唤醒延时时间
+     */
+    private long notifyDelay = DEFAULT_NOTIFY_DELAY;
+
+    /**
      * 构造方法
      */
     public NacosRegisterConfig() {
@@ -156,6 +187,10 @@ public class NacosRegisterConfig implements PluginConfig {
 
     public void setSecure(boolean secure) {
         this.secure = secure;
+    }
+
+    public String getAddress() {
+        return address;
     }
 
     public void setAddress(String address) {
@@ -288,6 +323,30 @@ public class NacosRegisterConfig implements PluginConfig {
 
     public void setServiceNameSeparator(String serviceNameSeparator) {
         this.serviceNameSeparator = serviceNameSeparator;
+    }
+
+    public int getPaginationSize() {
+        return paginationSize;
+    }
+
+    public void setPaginationSize(int paginationSize) {
+        this.paginationSize = paginationSize;
+    }
+
+    public long getLookupInterval() {
+        return lookupInterval;
+    }
+
+    public void setLookupInterval(long lookupInterval) {
+        this.lookupInterval = lookupInterval;
+    }
+
+    public long getNotifyDelay() {
+        return notifyDelay;
+    }
+
+    public void setNotifyDelay(long notifyDelay) {
+        this.notifyDelay = notifyDelay;
     }
 
     /**


### PR DESCRIPTION
【修复issue】#1002
【修改内容】
1、增加dubbo微服务注册Nacos的能力

【用例描述】
1、用dubbo框架微服务，能够注册Nacos

【自测情况】
1、本地静态检查通过
2、自测通过

【影响范围】
1、dubbo框架迁移CSE的nacos用户
