### PR TITLE
【feature】重构优化插件类隔离机制

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,7 @@
             <modules>
                 <module>sermant-agentcore</module>
                 <module>sermant-plugins</module>
+                <module>sermant-common-dependency</module>
                 <module>sermant-backend</module>
                 <module>sermant-backend-lite</module>
                 <module>report</module>
@@ -359,6 +360,7 @@
             <modules>
                 <module>sermant-agentcore</module>
                 <module>sermant-plugins</module>
+                <module>sermant-common-dependency</module>
                 <module>sermant-backend</module>
                 <module>sermant-backend-lite</module>
                 <module>sermant-package</module>

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/CommonClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/CommonClassLoader.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.classloader;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 公共类加载器
+ *
+ * @author lilai
+ * @since 2022-11-25
+ */
+public class CommonClassLoader extends URLClassLoader {
+
+    /**
+     * 对CommonClassLoader已经加载的类进行管理
+     */
+    private final Map<String, Class<?>> commonClassMap = new HashMap<>();
+
+    /**
+     * 构造方法，CommonClassLoader默认以AppClassloader为父类加载器
+     *
+     * @param urls Url of sermant-common-dependency
+     */
+    public CommonClassLoader(URL[] urls) {
+        super(urls);
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        return this.loadClass(name, false);
+    }
+
+    @Override
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            // 破坏双亲委派，先从自身加载，再从父类加载，保持Sermant插件服务的第三方依赖和宿主依赖隔离
+            Class<?> clazz = loadCommonClass(name);
+
+            if (clazz == null) {
+                clazz = getParent().loadClass(name);
+            }
+
+            if (resolve) {
+                resolveClass(clazz);
+            }
+            return clazz;
+        }
+    }
+
+    /**
+     * 加载公共第三方依赖目录下的类
+     *
+     * @param name 类名
+     * @return Class<?>
+     */
+    private Class<?> loadCommonClass(String name) {
+        if (!commonClassMap.containsKey(name)) {
+            try {
+                commonClassMap.put(name, findClass(name));
+            } catch (ClassNotFoundException ignored) {
+                // 若自身无法加载则把类名放入缓存，后续不再尝试加载
+                commonClassMap.put(name, null);
+            }
+        }
+        return commonClassMap.get(name);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
@@ -83,6 +83,11 @@ public class CommonConstant {
     public static final String CORE_IMPLEMENT_DIR_KEY = "core.implement.dir";
 
     /**
+     * Sermant公共第三方依赖目录
+     */
+    public static final String COMMON_DEPENDENCY_DIR_KEY = "common.dependency.dir";
+
+    /**
      * sermant的配置文件名的键
      */
     public static final String CORE_CONFIG_FILE_KEY = "core.config.file";

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
@@ -16,6 +16,7 @@
 
 package com.huaweicloud.sermant.core.plugin;
 
+import com.huaweicloud.sermant.core.classloader.ClassLoaderManager;
 import com.huaweicloud.sermant.core.common.BootArgsIndexer;
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.exception.SchemaException;
@@ -208,7 +209,7 @@ public class PluginManager {
     private static ClassLoader loadServices(String pluginName, File serviceDir) {
         final URL[] urls = toUrls(pluginName, listJars(serviceDir));
         if (urls.length > 0) {
-            return new PluginClassLoader(urls);
+            return new PluginClassLoader(urls, ClassLoaderManager.getCommonClassLoader());
         }
         return ClassLoader.getSystemClassLoader();
     }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/operation/adaptor/AdaptorManagerImpl.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/operation/adaptor/AdaptorManagerImpl.java
@@ -16,6 +16,7 @@
 
 package com.huaweicloud.sermant.implement.operation.adaptor;
 
+import com.huaweicloud.sermant.core.classloader.ClassLoaderManager;
 import com.huaweicloud.sermant.core.common.BootArgsIndexer;
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.config.ConfigManager;
@@ -239,7 +240,7 @@ public class AdaptorManagerImpl implements AdaptorManager {
                 return ClassLoader.getSystemClassLoader();
             case STAND_ALONE:
                 checkSchema(adaptorName, adaptors, null);
-                return new PluginClassLoader(toUrls(adaptors));
+                return new PluginClassLoader(toUrls(adaptors), ClassLoaderManager.getCommonClassLoader());
             default:
                 throw new UnsupportedOperationException(String.format(Locale.ROOT,
                     "Unknown adaptor type %s in setting [%s]. ", setting.getAdaptorLoadType(), setting));

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/common/BootArgsBuilder.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/common/BootArgsBuilder.java
@@ -183,5 +183,6 @@ public abstract class BootArgsBuilder {
         argsMap.put(CommonConstant.PLUGIN_SETTING_FILE_KEY, PathDeclarer.getPluginSettingPath());
         argsMap.put(CommonConstant.PLUGIN_PACKAGE_DIR_KEY, PathDeclarer.getPluginPackagePath());
         argsMap.put(CommonConstant.LOG_SETTING_FILE_KEY, PathDeclarer.getLogbackSettingPath());
+        argsMap.put(CommonConstant.COMMON_DEPENDENCY_DIR_KEY, PathDeclarer.getCommonLibPath());
     }
 }

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/common/PathDeclarer.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huawei/sermant/premain/common/PathDeclarer.java
@@ -59,6 +59,15 @@ public class PathDeclarer {
     }
 
     /**
+     * 获取公共第三方依赖目录
+     *
+     * @return 核心功能实现包目录
+     */
+    public static String getCommonLibPath() {
+        return getAgentPath() + File.separatorChar + "lib";
+    }
+
+    /**
      * 获取配置存储目录
      *
      * @return 配置存储目录

--- a/sermant-common-dependency/pom.xml
+++ b/sermant-common-dependency/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sermant-common-dependency</artifactId>
+
+    <properties>
+        <sermant.basedir>${pom.basedir}/..</sermant.basedir>
+        <package.temp.dir>${sermant.basedir}/${sermant.name}-${project.version}</package.temp.dir>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <!--公共第三方依赖，在插件服务模块或implement模块中以provided方式引入sermant-common-dependency-->
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <outputFile>
+                        ${package.agent.dir}/lib/${project.artifactId}-${project.version}.jar
+                    </outputFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
【修复issue】#995 #1005

【修改内容】
1. 新增CommonClassLoader作为PluginClassLoader和FrameWorkClassLoader的父加载器,并破坏双亲委派，统一加载implement模块和各插件服务模块抽出的公共第三方依赖
2. 新增sermant-common-dependency模块，用于将抽出的公共第三方依赖整合打包至agent/lib目录下，sermant-common-dependency-x.x.x.jar为sermant启动的必要组件
3. 各插件服务模块和implement模块若需要使用sermant-common-dependency的公共依赖，需要在pom中抽出本插件模块或implement模块中的某个第三方依赖在sermant-common-dependency中引入，并以provided方式引入sermant-common-dependency
4. 若插件服务模块引入sermant-common-dependency的同时，需使用与sermant-common-dependency中引入的不同版本的第三方依赖，则需在本模块以compile方式引入该版本依赖

【用例描述】暂无

【自测情况】1、本地静态检查通过；2、本地测试在implement中去除本身的snakeyaml后引入sermant-common-dependency的场景，验证snakeyaml的类加载器为CommonClassLoader，且FrameworkClassLoader的父类加载器为CommonClassLoader；
<img width="626" alt="image" src="https://user-images.githubusercontent.com/46025350/205577859-d8cd5ff3-c577-4c0c-9585-22126d73aec9.png">
<img width="626" alt="image" src="https://user-images.githubusercontent.com/46025350/205579649-c07c5573-55f8-484b-9dcd-7f7bcd72a051.png">
<img width="792" alt="image" src="https://user-images.githubusercontent.com/46025350/205579849-4eb964fb-0a68-47d9-ba71-2be4bd3721ef.png">
PluginClassLoader与之类似，此处不再展示自验证过程





【影响范围】1. 插件服务使用第三方依赖时可按需抽取公共依赖至sermant-common-dependency；2. Sermant启动sermant-agent/agent/lib/sermant-common-dependency-x.x.x.jar为启动必要组件，无源码开发方式需要更新使用方式；3. 后续补充相关文档