### PR TITLE
【feature】增加dubbo注册Nacos能力的服务实现

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -422,6 +422,20 @@ com/huawei/registry/grace/interceptors/SpringLoadbalancerFeignResponseIntercepto
 
 com/huawei/registry/grace/interceptors/SpringLoadbalancerRestTemplateResponseInterceptor.java in this product is copied from on org/apache/dubbo/rpc/protocol/dubbo/DubboInvoker.java of Apache Dubbo project
 
+com/huawei/dubbo/registry/utils/NacosInstanceManageUtil.java in this product is copied from on org/apache/dubbo/registry/nacos/util/NacosInstanceManageUtil.java of Apache Dubbo project
+
+com/huawei/dubbo/registry/utils/NamingServiceUtils.java in this product is copied from on org/apache/dubbo/registry/nacos/util/NacosNamingServiceUtils.java of Apache Dubbo project
+
+com/huawei/dubbo/registry/listener/NacosAggregateListener.java in this product is copied from on org/apache/dubbo/registry/nacos/NacosAggregateListener.java of Apache Dubbo project
+
+com/huawei/dubbo/registry/entity/NacosServiceName.java in this product is copied from on org/apache/dubbo/registry/nacos/NacosServiceName.java of Apache Dubbo project
+
+com/huawei/dubbo/registry/service/NacosServiceNotify.java in this product is copied from on org/apache/dubbo/registry/support/AbstractRegistry.java of Apache Dubbo project
+
+com/huawei/dubbo/registry/service/RegistryNotifier.java in this product is copied from on org/apache/dubbo/registry/RegistryNotifier.java of Apache Dubbo project
+
+com/huawei/dubbo/registry/service/NacosRegistryServiceImpl.java in this product is copied from on org/apache/dubbo/registry/nacos/NacosRegistry.java of Apache Dubbo project
+
 Apache Dubbo project is published at https://github.com/apache/dubbo and its license is Apache License Version 2.0.
 
 ====================================================================================

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/utils/ReflectUtils.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/main/java/com/huawei/dubbo/registry/utils/ReflectUtils.java
@@ -62,6 +62,10 @@ public class ReflectUtils {
     private static final String VALUE_OF_METHOD_NAME = "valueOf";
     private static final String REMOVE_PARAMETERS_METHOD_NAME = "removeParameters";
     private static final String ADD_PARAMETERS_METHOD_NAME = "addParameters";
+    private static final String GET_PARAMETER_METHOD_NAME = "getParameter";
+    private static final String GET_HOST_METHOD_NAME = "getHost";
+    private static final String GET_PORT_METHOD_NAME = "getPort";
+    private static final String GET_SERVICE_INTERFACE_METHOD_NAME = "getServiceInterface";
 
     private ReflectUtils() {
     }
@@ -169,6 +173,55 @@ public class ReflectUtils {
      */
     public static String getName(Object obj) {
         return invokeWithNoneParameterAndReturnString(obj, GET_NAME_METHOD_NAME);
+    }
+
+    /**
+     * 获取应用接口名
+     *
+     * @param obj URL
+     * @return 应用接口名
+     * @see com.alibaba.dubbo.common.URL
+     * @see org.apache.dubbo.common.URL
+     */
+    public static String getServiceInterface(Object obj) {
+        return invokeWithNoneParameterAndReturnString(obj, GET_SERVICE_INTERFACE_METHOD_NAME);
+    }
+
+    /**
+     * 获取应用主机
+     *
+     * @param obj URL
+     * @return 应用主机
+     * @see com.alibaba.dubbo.common.URL
+     * @see org.apache.dubbo.common.URL
+     */
+    public static String getHost(Object obj) {
+        return invokeWithNoneParameterAndReturnString(obj, GET_HOST_METHOD_NAME);
+    }
+
+    /**
+     * 获取应用端口
+     *
+     * @param obj URL
+     * @return 应用端口
+     * @see com.alibaba.dubbo.common.URL
+     * @see org.apache.dubbo.common.URL
+     */
+    public static int getPort(Object obj) {
+        return invokeWithNoneParameterAndReturnInteger(obj, GET_PORT_METHOD_NAME);
+    }
+
+    /**
+     * 获取url参数
+     *
+     * @param obj ApplicationConfig
+     * @param key key
+     * @return 应用名
+     * @see com.alibaba.dubbo.config.ApplicationConfig
+     * @see org.apache.dubbo.config.ApplicationConfig
+     */
+    public static String getParameter(Object obj, String key) {
+        return invokeWithStringParameter(obj, GET_PARAMETER_METHOD_NAME, key, String.class);
     }
 
     /**
@@ -357,9 +410,19 @@ public class ReflectUtils {
         return invokeWithNoneParameter(obj, name, String.class, true);
     }
 
+    private static int invokeWithNoneParameterAndReturnInteger(Object obj, String name) {
+        return invokeWithNoneParameter(obj, name, Integer.class, true);
+    }
+
     private static <T> T invokeWithNoneParameter(Object obj, String name, Class<T> returnClass, boolean isPublic) {
         InvokeParameter invokeParameter = new InvokeParameter(obj.getClass(), obj, name, null, null);
         invokeParameter.isPublic = isPublic;
+        return returnClass.cast(invoke(invokeParameter).orElse(null));
+    }
+
+    private static <T> T invokeWithStringParameter(Object obj, String name, String parameter, Class<T> returnClass) {
+        InvokeParameter invokeParameter = new InvokeParameter(obj.getClass(), obj, name, parameter, String.class);
+        invokeParameter.isPublic = true;
         return returnClass.cast(invoke(invokeParameter).orElse(null));
     }
 

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/ReflectUtilsTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/ReflectUtilsTest.java
@@ -319,6 +319,11 @@ public class ReflectUtilsTest {
         Assert.assertEquals(2, ReflectUtils.getParameters(url).size());
         Assert.assertEquals("bar", ReflectUtils.getParameters(url).get("group"));
         Assert.assertEquals("0.0.1", ReflectUtils.getParameters(url).get("version"));
+        Assert.assertEquals("localhost", ReflectUtils.getHost(url));
+        Assert.assertEquals(8080, ReflectUtils.getPort(url));
+        Assert.assertEquals("bar", ReflectUtils.getParameter(url, "group"));
+        url = ReflectUtils.addParameters(url, Collections.singletonMap("interface", "interface"));
+        Assert.assertEquals("interface", ReflectUtils.getServiceInterface(url));
 
         // 测试setHost方法
         url = ReflectUtils.setHost(url, "localhost1");
@@ -326,7 +331,7 @@ public class ReflectUtilsTest {
         Assert.assertEquals(DUBBO_PROTOCOL, ReflectUtils.getProtocol(url));
         Assert.assertEquals("localhost1:8080", ReflectUtils.getAddress(url));
         Assert.assertEquals("com.huawei.foo.BarTest", ReflectUtils.getPath(url));
-        Assert.assertEquals(2, ReflectUtils.getParameters(url).size());
+        Assert.assertEquals(3, ReflectUtils.getParameters(url).size());
         Assert.assertEquals("bar", ReflectUtils.getParameters(url).get("group"));
         Assert.assertEquals("0.0.1", ReflectUtils.getParameters(url).get("version"));
 
@@ -336,7 +341,7 @@ public class ReflectUtilsTest {
         Assert.assertEquals(DUBBO_PROTOCOL, ReflectUtils.getProtocol(url));
         Assert.assertEquals("localhost2:8081", ReflectUtils.getAddress(url));
         Assert.assertEquals("com.huawei.foo.BarTest", ReflectUtils.getPath(url));
-        Assert.assertEquals(2, ReflectUtils.getParameters(url).size());
+        Assert.assertEquals(3, ReflectUtils.getParameters(url).size());
         Assert.assertEquals("bar", ReflectUtils.getParameters(url).get("group"));
         Assert.assertEquals("0.0.1", ReflectUtils.getParameters(url).get("version"));
 
@@ -346,7 +351,7 @@ public class ReflectUtilsTest {
         Assert.assertEquals(DUBBO_PROTOCOL, ReflectUtils.getProtocol(url));
         Assert.assertEquals("localhost2:8081", ReflectUtils.getAddress(url));
         Assert.assertEquals("com.huawei.foo.FooTest", ReflectUtils.getPath(url));
-        Assert.assertEquals(2, ReflectUtils.getParameters(url).size());
+        Assert.assertEquals(3, ReflectUtils.getParameters(url).size());
         Assert.assertEquals("bar", ReflectUtils.getParameters(url).get("group"));
         Assert.assertEquals("0.0.1", ReflectUtils.getParameters(url).get("version"));
 
@@ -356,7 +361,7 @@ public class ReflectUtilsTest {
         Assert.assertEquals(DUBBO_PROTOCOL, ReflectUtils.getProtocol(url));
         Assert.assertEquals("localhost2:8081", ReflectUtils.getAddress(url));
         Assert.assertEquals("com.huawei.foo.FooTest", ReflectUtils.getPath(url));
-        Assert.assertEquals(1, ReflectUtils.getParameters(url).size());
+        Assert.assertEquals(2, ReflectUtils.getParameters(url).size());
         Assert.assertNull(ReflectUtils.getParameters(url).get("group"));
         Assert.assertEquals("0.0.1", ReflectUtils.getParameters(url).get("version"));
 
@@ -366,7 +371,7 @@ public class ReflectUtilsTest {
         Assert.assertEquals(DUBBO_PROTOCOL, ReflectUtils.getProtocol(url));
         Assert.assertEquals("localhost2:8081", ReflectUtils.getAddress(url));
         Assert.assertEquals("com.huawei.foo.FooTest", ReflectUtils.getPath(url));
-        Assert.assertEquals(2, ReflectUtils.getParameters(url).size());
+        Assert.assertEquals(3, ReflectUtils.getParameters(url).size());
         Assert.assertEquals("foo", ReflectUtils.getParameters(url).get("group"));
         Assert.assertEquals("0.0.1", ReflectUtils.getParameters(url).get("version"));
     }

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/pom.xml
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>service-center-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/entity/NacosServiceName.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/entity/NacosServiceName.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.entity;
+
+import com.huawei.dubbo.registry.utils.ReflectUtils;
+import com.huawei.registry.config.NacosRegisterConfig;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * nacos服务名管理
+ *
+ * @since 2022-10-25
+ */
+public class NacosServiceName {
+    private static final String NAME_SEPARATOR = ":";
+
+    private static final String VALUE_SEPARATOR = ",";
+
+    private static final String WILDCARD = "*";
+
+    private static final String CATEGORY_KEY = "category";
+
+    private static final String INTERFACE_KEY = "interface";
+
+    private static final int CATEGORY_INDEX = 0;
+
+    private static final int SERVICE_INTERFACE_INDEX = 1;
+
+    private static final int SERVICE_GROUP_INDEX = 2;
+
+    private static final String DEFAULT_CATEGORY = "providers";
+
+    private final String category;
+
+    private final String serviceInterface;
+
+    private final String group;
+
+    private String value;
+
+    /**
+     * url构造类
+     *
+     * @param url url
+     */
+    public NacosServiceName(Object url) {
+        serviceInterface = ReflectUtils.getParameter(url, INTERFACE_KEY);
+        category = isValid(serviceInterface) ? DEFAULT_CATEGORY : ReflectUtils.getParameter(url, CATEGORY_KEY);
+        NacosRegisterConfig nacosRegisterConfig =
+                PluginConfigManager.getPluginConfig(NacosRegisterConfig.class);
+        group = nacosRegisterConfig.getGroup();
+        value = toValue();
+    }
+
+    /**
+     * 服务名构造类
+     *
+     * @param value serviceName
+     */
+    public NacosServiceName(String value) {
+        this.value = value;
+        String[] segments = value.split(NAME_SEPARATOR, -1);
+        this.category = segments[CATEGORY_INDEX];
+        this.serviceInterface = segments[SERVICE_INTERFACE_INDEX];
+        this.group = segments[SERVICE_GROUP_INDEX];
+    }
+
+    /**
+     * 判断接口、版本、分组是否含“，”、“*”号
+     *
+     * @return 是否包含
+     */
+    public boolean isValid() {
+        return isValid(serviceInterface) && isValid(group);
+    }
+
+    private boolean isValid(String val) {
+        return !isWildcard(val) && !isRange(val);
+    }
+
+    /**
+     * 判断服务名称是否相同、包含“,”
+     *
+     * @param concreteServiceName 服务名
+     * @return boolean
+     */
+    public boolean isCompatible(NacosServiceName concreteServiceName) {
+        if (!concreteServiceName.isValid()) {
+            return false;
+        }
+        if (!StringUtils.equals(this.category, concreteServiceName.category)
+                && !matchRange(this.category, concreteServiceName.category)) {
+            return false;
+        }
+        if (!StringUtils.equals(this.serviceInterface, concreteServiceName.serviceInterface)) {
+            return false;
+        }
+        if (isWildcard(this.group)) {
+            return true;
+        }
+        return StringUtils.equals(this.group, concreteServiceName.group)
+                || matchRange(this.group, concreteServiceName.group);
+    }
+
+    private boolean matchRange(String range, String val) {
+        if (StringUtils.isBlank(range)) {
+            return true;
+        }
+        if (!isRange(range)) {
+            return false;
+        }
+        String[] values = range.split(VALUE_SEPARATOR);
+        return Arrays.asList(values).contains(val);
+    }
+
+    private boolean isWildcard(String val) {
+        return WILDCARD.equals(val);
+    }
+
+    private boolean isRange(String val) {
+        return val != null && val.contains(VALUE_SEPARATOR) && val.split(VALUE_SEPARATOR).length > 1;
+    }
+
+    /**
+     * 获取value
+     *
+     * @return value
+     */
+    public String getValue() {
+        if (value == null) {
+            value = toValue();
+        }
+        return value;
+    }
+
+    private String toValue() {
+        return category
+                + NAME_SEPARATOR + serviceInterface
+                + NAME_SEPARATOR + group;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NacosServiceName)) {
+            return false;
+        }
+        NacosServiceName that = (NacosServiceName) obj;
+        return Objects.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/factory/RegistryNotifyThreadFactory.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/factory/RegistryNotifyThreadFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.factory;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * 创建注册监听线程工厂类
+ *
+ * @author chengyouling
+ * @since 2022-11-27
+ */
+public class RegistryNotifyThreadFactory implements ThreadFactory {
+    private final String threadName;
+
+    /**
+     * 流控线程工厂
+     *
+     * @param threadName 线程名称
+     */
+    public RegistryNotifyThreadFactory(String threadName) {
+        this.threadName = threadName;
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        return new Thread(runnable, threadName);
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/listener/NacosAggregateListener.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/listener/NacosAggregateListener.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.listener;
+
+import com.alibaba.nacos.common.utils.ConcurrentHashSet;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * nacos监听服务服务
+ *
+ * @since 2022-10-25
+ */
+public class NacosAggregateListener {
+    private final Object notifyListener;
+    private final Set<String> serviceNames = new ConcurrentHashSet<>();
+
+    /**
+     * 构造方法
+     *
+     * @param notifyListener 监听
+     */
+    public NacosAggregateListener(Object notifyListener) {
+        this.notifyListener = notifyListener;
+    }
+
+    /**
+     * 设置服务名、实例信息
+     *
+     * @param serviceName 服务名
+     */
+    public void saveAndAggregateAllInstances(String serviceName) {
+        serviceNames.add(serviceName);
+    }
+
+    public Object getNotifyListener() {
+        return notifyListener;
+    }
+
+    public Set<String> getServiceNames() {
+        return serviceNames;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        NacosAggregateListener that = (NacosAggregateListener) object;
+        return Objects.equals(notifyListener, that.notifyListener)
+                && Objects.equals(serviceNames, that.serviceNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(notifyListener, serviceNames);
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/NacosRegistryServiceImpl.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/NacosRegistryServiceImpl.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.service;
+
+import com.huawei.dubbo.registry.entity.NacosServiceName;
+import com.huawei.dubbo.registry.listener.NacosAggregateListener;
+import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
+import com.huawei.dubbo.registry.utils.NacosInstanceManageUtil;
+import com.huawei.dubbo.registry.utils.NamingServiceUtils;
+import com.huawei.dubbo.registry.utils.ReflectUtils;
+import com.huawei.registry.config.NacosRegisterConfig;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.listener.Event;
+import com.alibaba.nacos.api.naming.listener.EventListener;
+import com.alibaba.nacos.api.naming.listener.NamingEvent;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * nacos注册中心注册服务
+ *
+ * @since 2022-10-25
+ */
+public class NacosRegistryServiceImpl implements NacosRegistryService {
+    private static final int SERVICE_INTERFACE_INDEX = 1;
+    private static final int SERVICE_NAME_COMPARE_LENGTH = 3;
+    private static final String PROVIDER_SIDE = "provider";
+    private static final String REGISTER_CONSUMER_URL_KEY = "register-consumer-url";
+    private static final String INTERFACE_KEY = "interface";
+    private static final String CATEGORY_KEY = "category";
+    private static final String PROTOCOL_KEY = "protocol";
+    private static final String PATH_KEY = "path";
+    private static final String VERSION_KEY = "version";
+    private static final String NAME_SEPARATOR = ":";
+    private static final String DEFAULT_CATEGORY = "providers";
+    private static final String SIDE_KEY = "side";
+    private static final String CHECK_KEY = "check";
+    private static final String APPLICATION_KEY = "application";
+    private static final String SERVICE_META_VERSION = "service.meta.version";
+    private static final String SERVICE_META_ZONE = "service.meta.zone";
+    private static final String STATUS_UP = "UP";
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+    /**
+     * key对应关系：第一个Object -> URL，第二个Object -> NotifyListener
+     */
+    private final Map<Object, Map<Object, NacosAggregateListener>> originToAggregateListener =
+            new ConcurrentHashMap<>();
+    /**
+     * key对应关系：Object -> URL，String -> serviceName
+     */
+    private final Map<Object, Map<NacosAggregateListener, Map<String, EventListener>>> nacosListeners =
+            new ConcurrentHashMap<>();
+    private NamingService namingService;
+    private NacosRegisterConfig nacosRegisterConfig;
+    private Instance registryInstance;
+    private final NacosServiceNotify nacosServiceNotify = new NacosServiceNotify();
+
+    @Override
+    public void doRegister(Object url) {
+        try {
+            if (PROVIDER_SIDE.equals(ReflectUtils.getParameter(url, SIDE_KEY))
+                    || PROVIDER_SIDE.equals(ReflectUtils.getProtocol(url))
+                    || !StringUtils.isBlank(ReflectUtils.getParameter(url, REGISTER_CONSUMER_URL_KEY))) {
+                String serviceName = getLegacySubscribedServiceName(url);
+                registryInstance = createInstance(url);
+                namingService.registerInstance(serviceName, nacosRegisterConfig.getGroup(), registryInstance);
+            }
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "register failed，url:{%s}，"
+                    + "，cause: {%s}", url, e.getErrMsg()), e);
+        }
+    }
+
+    @Override
+    public void doSubscribe(Object url, Object notifyListener) {
+        NacosAggregateListener nacosAggregateListener = new NacosAggregateListener(notifyListener);
+        originToAggregateListener.computeIfAbsent(url,
+            k -> new ConcurrentHashMap<>()).put(notifyListener, nacosAggregateListener);
+        Set<String> serviceNames = getServiceNames(url);
+        if (isServiceNamesWithCompatibleMode(url)) {
+            for (String serviceName : serviceNames) {
+                NacosInstanceManageUtil.setCorrespondingServiceNames(serviceName, serviceNames);
+            }
+        }
+        doSubscribe(url, nacosAggregateListener, serviceNames);
+    }
+
+    private void doSubscribe(final Object url, final NacosAggregateListener listener, final Set<String> serviceNames) {
+        try {
+            if (isServiceNamesWithCompatibleMode(url)) {
+                for (String serviceName : serviceNames) {
+                    List<Instance> instances = namingService.getAllInstances(serviceName,
+                        nacosRegisterConfig.getGroup());
+                    NacosInstanceManageUtil.initOrRefreshServiceInstanceList(serviceName, instances);
+                    notifySubscriber(url, serviceName, listener, instances);
+                    subscribeEventListener(serviceName, url, listener);
+                }
+            } else {
+                // 当url的serviceInterface、group中含“，”、“*”时，需要从新构建监听url
+                // serviceName示例：providers:com.huawei.dubbo.registry.service.RegistryService:default,A
+                for (String serviceName : serviceNames) {
+                    String serviceInterface = serviceName;
+                    String[] segments = serviceName.split(nacosRegisterConfig.getServiceNameSeparator(), -1);
+                    if (segments.length == SERVICE_NAME_COMPARE_LENGTH) {
+                        serviceInterface = segments[SERVICE_INTERFACE_INDEX];
+                    }
+                    Object subscriberUrl = ReflectUtils.setPath(url, serviceInterface);
+                    Map<String, String> parameters = new HashMap<>();
+                    parameters.put(INTERFACE_KEY, serviceInterface);
+                    parameters.put(CHECK_KEY, String.valueOf(false));
+                    subscriberUrl = ReflectUtils.addParameters(subscriberUrl, parameters);
+                    List<Instance> instances = new LinkedList<>(namingService.getAllInstances(serviceName,
+                        nacosRegisterConfig.getGroup()));
+                    notifySubscriber(subscriberUrl, serviceName, listener, instances);
+                    subscribeEventListener(serviceName, subscriberUrl, listener);
+                }
+            }
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "failed to subscribe to nacos, url:{%s},"
+                    + "cause:{%s}", url, e.getErrMsg()), e);
+        }
+    }
+
+    private void subscribeEventListener(String serviceName, final Object url, final NacosAggregateListener listener)
+            throws NacosException {
+        Map<NacosAggregateListener, Map<String, EventListener>> listeners = nacosListeners.computeIfAbsent(url,
+            k -> new ConcurrentHashMap<>());
+        Map<String, EventListener> eventListeners = listeners.computeIfAbsent(listener,
+            k -> new ConcurrentHashMap<>());
+        EventListener eventListener = eventListeners.computeIfAbsent(serviceName,
+            k -> new RegistryChildListenerImpl(serviceName, url, listener));
+        namingService.subscribe(serviceName, nacosRegisterConfig.getGroup(), eventListener);
+    }
+
+    @Override
+    public void doUnregister(Object url) {
+        try {
+            String serviceName = getLegacySubscribedServiceName(url);
+            namingService.deregisterInstance(serviceName, nacosRegisterConfig.getGroup(), registryInstance);
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "failed to unregister，url: {%s}"
+                    + "，cause: {%s}", url, e.getErrMsg()), e);
+        }
+    }
+
+    @Override
+    public void buildNamingService(Map<String, String> parameters) {
+        nacosRegisterConfig = PluginConfigManager.getPluginConfig(NacosRegisterConfig.class);
+        this.namingService = NamingServiceUtils.buildNamingService(parameters, nacosRegisterConfig);
+    }
+
+    @Override
+    public void doUnsubscribe(Object url, Object notifyListener) {
+        Map<Object, NacosAggregateListener> listenerMap = originToAggregateListener.get(url);
+        if (listenerMap == null) {
+            LOGGER.warning(String.format(Locale.ENGLISH, "No aggregate listener found for url: {%s},",
+                    url));
+            return;
+        }
+        NacosAggregateListener nacosAggregateListener = listenerMap.remove(notifyListener);
+        if (nacosAggregateListener != null) {
+            Set<String> serviceNames = nacosAggregateListener.getServiceNames();
+            try {
+                doUnsubscribe(url, nacosAggregateListener, serviceNames);
+                for (String serviceName : serviceNames) {
+                    NacosInstanceManageUtil.removeCorrespondingServiceNames(serviceName);
+                }
+            } catch (NacosException e) {
+                LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "Failed unsubscribe url: {%s}",
+                        url), e);
+            }
+        }
+        if (listenerMap.isEmpty()) {
+            originToAggregateListener.remove(url);
+        }
+    }
+
+    private void doUnsubscribe(final Object url, final NacosAggregateListener nacosAggregateListener,
+            final Set<String> serviceNames) throws NacosException {
+        for (String serviceName : serviceNames) {
+            unsubscribeEventListener(serviceName, url, nacosAggregateListener);
+        }
+    }
+
+    private void unsubscribeEventListener(String serviceName, final Object url,
+            final NacosAggregateListener listener) throws NacosException {
+        Map<NacosAggregateListener, Map<String, EventListener>> listenerToServiceEvent = nacosListeners.get(url);
+        if (listenerToServiceEvent == null) {
+            return;
+        }
+        Map<String, EventListener> serviceToEventMap = listenerToServiceEvent.get(listener);
+        if (serviceToEventMap == null) {
+            return;
+        }
+        EventListener eventListener = serviceToEventMap.remove(serviceName);
+        if (eventListener == null) {
+            return;
+        }
+        namingService.unsubscribe(serviceName, nacosRegisterConfig.getGroup(), eventListener);
+        if (serviceToEventMap.isEmpty()) {
+            listenerToServiceEvent.remove(listener);
+        }
+        if (listenerToServiceEvent.isEmpty()) {
+            nacosListeners.remove(url);
+        }
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return STATUS_UP.equals(namingService.getServerStatus());
+    }
+
+    private Instance createInstance(Object url) {
+        Map<String, String> metaData = new HashMap<>();
+        String category = ReflectUtils.getParameter(url, CATEGORY_KEY);
+        metaData.put(CATEGORY_KEY, category == null ? DEFAULT_CATEGORY : category);
+        metaData.put(PROTOCOL_KEY, ReflectUtils.getProtocol(url));
+        metaData.put(PATH_KEY, ReflectUtils.getPath(url));
+        metaData.put(APPLICATION_KEY, ReflectUtils.getParameter(url, APPLICATION_KEY));
+        final ServiceMeta serviceMeta = ConfigManager.getConfig(ServiceMeta.class);
+        if (serviceMeta != null) {
+            metaData.put(SERVICE_META_VERSION, serviceMeta.getVersion());
+            metaData.put(SERVICE_META_ZONE, serviceMeta.getZone());
+        }
+        Instance instance = new Instance();
+        instance.setIp(ReflectUtils.getHost(url));
+        instance.setPort(ReflectUtils.getPort(url));
+        instance.setMetadata(metaData);
+        return instance;
+    }
+
+    private void notifySubscriber(Object url, String serviceName, NacosAggregateListener listener,
+            List<Instance> instances) {
+        listener.saveAndAggregateAllInstances(serviceName);
+        List<Object> urls = buildUrls(instances);
+        notify(url, listener.getNotifyListener(), urls);
+    }
+
+    private void notify(Object url, Object listener, List<Object> urls) {
+        if (url == null) {
+            throw new IllegalArgumentException("notify url == null");
+        }
+        if (listener == null) {
+            throw new IllegalArgumentException("notify listener == null");
+        }
+        try {
+            nacosServiceNotify.doNotify(url, listener, urls);
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "failed to notify addresses for subscribe "
+                    + "url:{%s}, cause:{%s}", url, e.getMessage()), e);
+        }
+    }
+
+    private List<Object> buildUrls(Collection<Instance> instances) {
+        List<Object> urls = new LinkedList<>();
+        if (instances != null && !instances.isEmpty()) {
+            for (Instance instance : instances) {
+                urls.add(buildUrl(instance));
+            }
+        }
+        return urls;
+    }
+
+    private Object buildUrl(Instance instance) {
+        Map<String, String> metadata = instance.getMetadata();
+        String address = instance.getIp() + nacosRegisterConfig.getServiceNameSeparator() + instance.getPort();
+        Object object = ReflectUtils.valueOf(address);
+        object = ReflectUtils.setProtocol(object, metadata.get(PROTOCOL_KEY));
+        object = ReflectUtils.setPath(object, metadata.get(PATH_KEY));
+        object = ReflectUtils.setHost(object, instance.getIp());
+        return ReflectUtils.addParameters(object, instance.getMetadata());
+    }
+
+    private boolean isServiceNamesWithCompatibleMode(Object url) {
+        return new NacosServiceName(url).isValid();
+    }
+
+    private Set<String> filterServiceNames(NacosServiceName serviceName) {
+        Set<String> serviceNames = new LinkedHashSet<>();
+        try {
+            serviceNames.addAll(namingService.getServicesOfServer(1, Integer.MAX_VALUE,
+                nacosRegisterConfig.getGroup()).getData()
+                .stream()
+                .filter(this::isConformRules)
+                .map(NacosServiceName::new)
+                .filter(serviceName::isCompatible)
+                .map(NacosServiceName::toString)
+                .collect(Collectors.toList()));
+            return serviceNames;
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "filter serviceName failed"
+                + ", serviceName: {%s}，cause: {%s}", serviceName, e.getErrMsg()), e);
+        }
+        return serviceNames;
+    }
+
+    private Set<String> getServiceNames(Object url) {
+        NacosServiceName serviceName = new NacosServiceName(url);
+
+        final Set<String> serviceNames;
+
+        if (serviceName.isValid()) {
+            serviceNames = new LinkedHashSet<>();
+            serviceNames.add(serviceName.toString());
+            String legacySubscribedServiceName = getLegacySubscribedServiceName(url);
+            if (!serviceName.toString().equals(legacySubscribedServiceName)) {
+                serviceNames.add(legacySubscribedServiceName);
+            }
+        } else {
+            serviceNames = filterServiceNames(serviceName);
+        }
+        return serviceNames;
+    }
+
+    private String getLegacySubscribedServiceName(Object url) {
+        StringBuilder serviceNameBuilder = new StringBuilder(DEFAULT_CATEGORY);
+        appendIfPresent(url, serviceNameBuilder, INTERFACE_KEY);
+        appendIfPresent(url, serviceNameBuilder, VERSION_KEY);
+        serviceNameBuilder.append(nacosRegisterConfig.getServiceNameSeparator())
+                .append(nacosRegisterConfig.getGroup());
+        return serviceNameBuilder.toString();
+    }
+
+    private void appendIfPresent(Object url, StringBuilder target, String parameterName) {
+        String parameterValue = ReflectUtils.getParameter(url, parameterName);
+        if (!StringUtils.isBlank(parameterValue)) {
+            target.append(nacosRegisterConfig.getServiceNameSeparator()).append(parameterValue);
+        }
+    }
+
+    private boolean isConformRules(String serviceName) {
+        return serviceName.split(NAME_SEPARATOR, -1).length == SERVICE_NAME_COMPARE_LENGTH;
+    }
+
+    /**
+     * 注册监听子类
+     *
+     * @since 2022-10-25
+     */
+    private class RegistryChildListenerImpl implements EventListener {
+        private final RegistryNotifier notifier;
+        private final String serviceName;
+        private final Object consumerUrl;
+        private final NacosAggregateListener listener;
+
+        /**
+         * 构造方法
+         *
+         * @param serviceName 服务名
+         * @param url 客户端url
+         * @param listener 监听器
+         */
+        protected RegistryChildListenerImpl(String serviceName, Object url, NacosAggregateListener listener) {
+            this.serviceName = serviceName;
+            this.consumerUrl = url;
+            this.listener = listener;
+            this.notifier = new RegistryNotifier(nacosRegisterConfig.getNotifyDelay()) {
+                @Override
+                protected void doNotify(Object rawAddresses) {
+                    List<Instance> instances = (List<Instance>) rawAddresses;
+                    if (isServiceNamesWithCompatibleMode(consumerUrl)) {
+                        NacosInstanceManageUtil.initOrRefreshServiceInstanceList(serviceName, instances);
+                        instances = NacosInstanceManageUtil.getAllCorrespondingServiceInstanceList(serviceName);
+                    }
+                    notifySubscriber(consumerUrl, serviceName, listener, instances);
+                }
+            };
+        }
+
+        @Override
+        public void onEvent(Event event) {
+            if (event instanceof NamingEvent) {
+                NamingEvent namingEvent = (NamingEvent) event;
+                notifier.notify(namingEvent.getInstances());
+            }
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            RegistryChildListenerImpl that = (RegistryChildListenerImpl) obj;
+            return Objects.equals(serviceName, that.serviceName) && Objects.equals(consumerUrl, that.consumerUrl)
+                    && Objects.equals(listener, that.listener);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(serviceName, consumerUrl, listener);
+        }
+    }
+
+    public Instance getRegistryInstance() {
+        return registryInstance;
+    }
+
+    public Map<Object, Map<Object, NacosAggregateListener>> getOriginToAggregateListener() {
+        return originToAggregateListener;
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/NacosServiceNotify.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/NacosServiceNotify.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.service;
+
+import com.huawei.dubbo.registry.utils.ReflectUtils;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import com.alibaba.nacos.client.naming.utils.CollectionUtils;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * nacos服务名唤醒
+ *
+ * @since 2022-10-25
+ */
+public class NacosServiceNotify {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+    private static final String ANY_VALUE = "*";
+    private static final String DEFAULT_CATEGORY = "providers";
+    private static final String CATEGORY_KEY = "category";
+    private static final int DEFUALT_CAPACITY = 16;
+    private static final String ENABLED_KEY = "enabled";
+    private static final String GROUP_KEY = "group";
+    private static final String VERSION_KEY = "version";
+    private static final String CLASSIFIER_KEY = "classifier";
+    private static final String REMOVE_VALUE_PREFIX = "-";
+
+    /**
+     * 执行下游无法监听
+     *
+     * @param url url
+     * @param listener 监听
+     * @param urls url集合
+     */
+    public void doNotify(Object url, Object listener, List<Object> urls) {
+        if ((CollectionUtils.isEmpty(urls)) && !ANY_VALUE.equals(ReflectUtils.getServiceInterface(url))) {
+            LOGGER.warning(String.format(Locale.ENGLISH, "empty notify urls for subscribe url: {%s}", url));
+            return;
+        }
+        Map<String, List<Object>> result = new HashMap<>(DEFUALT_CAPACITY);
+        for (Object u : urls) {
+            if (isMatch(url, u)) {
+                String category = ReflectUtils.getParameter(u, CATEGORY_KEY) == null ? DEFAULT_CATEGORY
+                    : ReflectUtils.getParameter(u, CATEGORY_KEY);
+                List<Object> categoryList = result.computeIfAbsent(category, k -> new ArrayList<>());
+                categoryList.add(u);
+            }
+        }
+        if (result.size() == 0) {
+            return;
+        }
+        for (Map.Entry<String, List<Object>> entry : result.entrySet()) {
+            List<Object> categoryList = new ArrayList<>(entry.getValue());
+            ReflectUtils.notify(listener, categoryList);
+        }
+    }
+
+    private boolean isMatch(Object consumerUrl, Object providerUrl) {
+        String consumerInterface = ReflectUtils.getServiceInterface(consumerUrl);
+        String providerInterface = ReflectUtils.getServiceInterface(providerUrl);
+        if (!(ANY_VALUE.equals(consumerInterface)
+                || ANY_VALUE.equals(providerInterface)
+                || StringUtils.equals(consumerInterface, providerInterface))) {
+            return false;
+        }
+        String providerCategory = ReflectUtils.getParameter(providerUrl, CATEGORY_KEY) == null ? DEFAULT_CATEGORY
+                : ReflectUtils.getParameter(providerUrl, CATEGORY_KEY);
+        String consumerCategory = ReflectUtils.getParameter(providerUrl, CATEGORY_KEY) == null ? DEFAULT_CATEGORY
+                : ReflectUtils.getParameter(providerUrl, CATEGORY_KEY);
+        if (!isMatchCategory(providerCategory, consumerCategory)) {
+            return false;
+        }
+        boolean providerEnabled = ReflectUtils.getParameter(providerUrl, ENABLED_KEY) == null || Boolean
+                .parseBoolean(ReflectUtils.getParameter(providerUrl, ENABLED_KEY));
+        if (!providerEnabled && !ANY_VALUE.equals(ReflectUtils.getParameter(consumerUrl, ENABLED_KEY))) {
+            return false;
+        }
+
+        String consumerGroup = ReflectUtils.getParameter(consumerUrl, GROUP_KEY);
+        String consumerVersion = ReflectUtils.getParameter(consumerUrl, VERSION_KEY);
+        String consumerClassifier = ReflectUtils.getParameter(consumerUrl, CLASSIFIER_KEY) == null ? ANY_VALUE
+            : ReflectUtils.getParameter(consumerUrl, CLASSIFIER_KEY);
+
+        String providerGroup = ReflectUtils.getParameter(providerUrl, GROUP_KEY);
+        String providerVersion = ReflectUtils.getParameter(providerUrl, VERSION_KEY);
+        String providerClassifier = ReflectUtils.getParameter(consumerUrl, CLASSIFIER_KEY) == null ? ANY_VALUE
+                : ReflectUtils.getParameter(consumerUrl, CLASSIFIER_KEY);
+
+        boolean checkGroup = ANY_VALUE.equals(consumerGroup)
+            || StringUtils.equals(consumerGroup, providerGroup)
+            || StringUtils.contains(consumerGroup, providerGroup);
+        boolean checkVersion = ANY_VALUE.equals(consumerVersion)
+                || StringUtils.equals(consumerVersion, providerVersion);
+        boolean checkClassifier = consumerClassifier == null
+                || ANY_VALUE.equals(consumerClassifier)
+                || StringUtils.equals(consumerClassifier, providerClassifier);
+        return checkGroup && checkVersion && checkClassifier;
+    }
+
+    private boolean isMatchCategory(String category, String categories) {
+        if (StringUtils.isEmpty(categories)) {
+            return DEFAULT_CATEGORY.equals(category);
+        }
+        if (categories.contains(ANY_VALUE)) {
+            return true;
+        }
+        if (categories.contains(REMOVE_VALUE_PREFIX)) {
+            return !categories.contains(REMOVE_VALUE_PREFIX + category);
+        }
+        return categories.contains(category);
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/RegistryNotifier.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/RegistryNotifier.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.service;
+
+import com.huawei.dubbo.registry.factory.RegistryNotifyThreadFactory;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 注册监听服务
+ *
+ * @since 2022-10-25
+ */
+public abstract class RegistryNotifier {
+    private static final int DEFAULT_DELAY_EXECUTE_TIMES = 10;
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+    private static final ScheduledExecutorService SCHEDULER = new ScheduledThreadPoolExecutor(1,
+            new RegistryNotifyThreadFactory("dubbo-registry-notify-thread"));
+    private volatile long lastExecuteTime;
+    private volatile long lastEventTime;
+    private Object rawAddresses;
+    private final long delayTime;
+    private final AtomicBoolean shouldDelay = new AtomicBoolean(false);
+    private final AtomicInteger executeTime = new AtomicInteger(0);
+
+    /**
+     * 构造方法
+     *
+     * @param delayTime 延迟时间
+     */
+    public RegistryNotifier(long delayTime) {
+        this.delayTime = delayTime;
+    }
+
+    /**
+     * 监听下游实例
+     *
+     * @param rawAddress 地址
+     */
+    public synchronized void notify(Object rawAddress) {
+        this.rawAddresses = rawAddress;
+        long notifyTime = System.currentTimeMillis();
+        this.lastEventTime = notifyTime;
+        long delta = (System.currentTimeMillis() - lastExecuteTime) - delayTime;
+        boolean delay = shouldDelay.get() && delta < 0;
+        if (delay) {
+            SCHEDULER.schedule(new NotificationTask(this, notifyTime), -delta, TimeUnit.MILLISECONDS);
+        } else {
+            if (!shouldDelay.get() && executeTime.incrementAndGet() > DEFAULT_DELAY_EXECUTE_TIMES) {
+                shouldDelay.set(true);
+            }
+            SCHEDULER.submit(new NotificationTask(this, notifyTime));
+        }
+    }
+
+    /**
+     * 监听实例
+     *
+     * @param rawAddresses 地址
+     */
+    protected abstract void doNotify(Object rawAddresses);
+
+    /**
+     * 监听任务
+     *
+     * @since 2022-10-25
+     */
+    public static class NotificationTask implements Runnable {
+        private final RegistryNotifier listener;
+        private final long time;
+
+        /**
+         * 构造方法
+         *
+         * @param listener 监听
+         * @param time 时间
+         */
+        public NotificationTask(RegistryNotifier listener, long time) {
+            this.listener = listener;
+            this.time = time;
+        }
+
+        @Override
+        public void run() {
+            try {
+                if (this.time == listener.lastEventTime) {
+                    listener.doNotify(listener.rawAddresses);
+                    listener.lastExecuteTime = System.currentTimeMillis();
+                    synchronized (listener) {
+                        if (this.time == listener.lastEventTime) {
+                            listener.rawAddresses = null;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE,"Error occurred when notify directory. ", e);
+            }
+        }
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/utils/NacosInstanceManageUtil.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/utils/NacosInstanceManageUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.utils;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.shaded.com.google.common.collect.Lists;
+import com.alibaba.nacos.shaded.com.google.common.collect.Maps;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * nacos实例管理工具
+ *
+ * @since 2022-10-25
+ */
+public class NacosInstanceManageUtil {
+    private static final Map<String, List<Instance>> SERVICE_INSTANCE_LIST_MAP = Maps.newConcurrentMap();
+
+    private static final Map<String, Set<String>> CORRESPONDING_SERVICE_NAMES_MAP = Maps.newConcurrentMap();
+
+    private NacosInstanceManageUtil() {
+    }
+
+    /**
+     * 设置服务名
+     *
+     * @param serviceName 服务名
+     * @param serviceNames 服务名集合
+     */
+    public static void setCorrespondingServiceNames(String serviceName, Set<String> serviceNames) {
+        CORRESPONDING_SERVICE_NAMES_MAP.put(serviceName, serviceNames);
+    }
+
+    /**
+     * 实例化、更新服务实例信息
+     *
+     * @param serviceName 服务名
+     * @param instances 实例集合
+     */
+    public static void initOrRefreshServiceInstanceList(String serviceName, List<Instance> instances) {
+        SERVICE_INSTANCE_LIST_MAP.put(serviceName, instances);
+    }
+
+    /**
+     * 获取实例
+     *
+     * @param serviceName 服务名
+     * @return 实例集合
+     */
+    public static List<Instance> getAllCorrespondingServiceInstanceList(String serviceName) {
+        if (!CORRESPONDING_SERVICE_NAMES_MAP.containsKey(serviceName)) {
+            return Lists.newArrayList();
+        }
+        List<Instance> allInstances = Lists.newArrayList();
+        for (String correspondingServiceName : CORRESPONDING_SERVICE_NAMES_MAP.get(serviceName)) {
+            if (SERVICE_INSTANCE_LIST_MAP.containsKey(correspondingServiceName)
+                    && !CollectionUtils.isEmpty(SERVICE_INSTANCE_LIST_MAP.get(correspondingServiceName))) {
+                allInstances.addAll(SERVICE_INSTANCE_LIST_MAP.get(correspondingServiceName));
+            }
+        }
+        return allInstances;
+    }
+
+    /**
+     * 删除服务名对应实例
+     *
+     * @param serviceName 服务名
+     */
+    public static void removeCorrespondingServiceNames(String serviceName) {
+        CORRESPONDING_SERVICE_NAMES_MAP.remove(serviceName);
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/utils/NamingServiceUtils.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/utils/NamingServiceUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry.utils;
+
+import com.huawei.registry.config.NacosRegisterConfig;
+import com.huawei.registry.config.PropertyKeyConst;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * nacos注册naming服务
+ *
+ * @since 2022-10-25
+ */
+public class NamingServiceUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+    private static final String BACKUP_KEY = "backup";
+
+    private NamingServiceUtils() {
+    }
+
+    /**
+     * 构建naming服务
+     *
+     * @param parameters url
+     * @param registerConfig registerConfig
+     * @return naming服务
+     * @throws IllegalStateException 创建namingService异常
+     */
+    public static NamingService buildNamingService(Map<String, String> parameters, NacosRegisterConfig registerConfig) {
+        Properties nacosProperties = buildNacosProperties(parameters, registerConfig);
+        try {
+            return NacosFactory.createNamingService(nacosProperties);
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "create namingService failed: {%s}",
+                    e.getErrMsg()), e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Properties buildNacosProperties(Map<String, String> parameters, NacosRegisterConfig registerConfig) {
+        Properties properties = new Properties();
+        setServerAddr(parameters.get(BACKUP_KEY), properties, registerConfig);
+        setProperties(parameters, properties, registerConfig);
+        return properties;
+    }
+
+    private static void setServerAddr(String backup, Properties properties, NacosRegisterConfig registerConfig) {
+        StringBuilder serverAddrBuilder = new StringBuilder();
+        serverAddrBuilder.append(registerConfig.getAddress());
+        if (!StringUtils.isEmpty(backup)) {
+            serverAddrBuilder.append(',').append(backup);
+        }
+        String serverAddr = serverAddrBuilder.toString();
+        properties.put(PropertyKeyConst.SERVER_ADDR, serverAddr);
+    }
+
+    private static void setProperties(Map<String, String> parameters, Properties properties,
+        NacosRegisterConfig registerConfig) {
+        properties.putAll(parameters);
+        if (!StringUtils.isEmpty(registerConfig.getUsername())) {
+            properties.put(PropertyKeyConst.USERNAME, registerConfig.getUsername());
+        }
+        if (!StringUtils.isEmpty(registerConfig.getPassword())) {
+            properties.put(PropertyKeyConst.PASSWORD, registerConfig.getPassword());
+        }
+        if (!StringUtils.isEmpty(registerConfig.getLogName())) {
+            properties.put(PropertyKeyConst.NACOS_NAMING_LOG_NAME, registerConfig.getLogName());
+        }
+        if (!StringUtils.isEmpty(registerConfig.getNamingLoadCacheAtStart())) {
+            properties.put(PropertyKeyConst.NAMING_LOAD_CACHE_AT_START, registerConfig.getNamingLoadCacheAtStart());
+        }
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
@@ -2,3 +2,4 @@ com.huawei.dubbo.registry.service.ApplicationConfigServiceImpl
 com.huawei.dubbo.registry.service.GovernanceService
 com.huawei.dubbo.registry.service.RegistryConfigServiceImpl
 com.huawei.dubbo.registry.service.RegistryServiceImpl
+com.huawei.dubbo.registry.service.NacosRegistryServiceImpl

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosAggregateListenerTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosAggregateListenerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.huawei.dubbo.registry.listener.NacosAggregateListener;
+
+/**
+ * 测试NacosAggregateListener
+ *
+ * @author chengyouling
+ * @since 2022-11-29
+ */
+public class NacosAggregateListenerTest {
+
+    /**
+     * 测试equal
+     */
+    @Test
+    public void testEqual() {
+        Instance instance = new Instance();
+        instance.setIp("127.0.0.1");
+        List<Instance> instances = new ArrayList<>();
+        instances.add(instance);
+        Object object = new Object();
+        NacosAggregateListener listener1 = new NacosAggregateListener(object);
+        listener1.saveAndAggregateAllInstances("providers:interface:DEFAULT");
+        NacosAggregateListener listener2 = new NacosAggregateListener(object);
+        listener2.saveAndAggregateAllInstances("providers:interface:DEFAULT");
+        Assertions.assertEquals(listener1.equals(listener2), true);
+        Assertions.assertEquals(listener1.getNotifyListener(), object);
+        Assertions.assertEquals(listener1.getServiceNames().size(), 1);
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosInstanceManageUtilTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosInstanceManageUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.huawei.dubbo.registry.utils.NacosInstanceManageUtil;
+
+
+/**
+ * 测试NacosInstanceManageUtil
+ *
+ * @author chengyouling
+ * @since 2022-11-29
+ */
+public class NacosInstanceManageUtilTest {
+    private static final String serviceName = "SERVICE";
+    private static final String instanceServiceName1 = "service1";
+    private static final String instanceServiceName2 = "service1";
+    private static final Set<String> namesSet = new HashSet<>();
+    private static final List<Instance> instances = new ArrayList<>();
+
+    /**
+     * 构造方法
+     */
+    public NacosInstanceManageUtilTest() {
+        namesSet.add(instanceServiceName1);
+        namesSet.add(instanceServiceName2);
+        Instance instance = new Instance();
+        instance.setIp("127.0.0.1");
+        instances.add(instance);
+    }
+
+    /**
+     * 测试构建getAllCorrespondingServiceInstanceList
+     */
+    @Test
+    public void testGetAllCorrespondingServiceInstanceList() {
+        NacosInstanceManageUtil.setCorrespondingServiceNames(serviceName, namesSet);
+        NacosInstanceManageUtil.initOrRefreshServiceInstanceList(instanceServiceName1, instances);
+        List<Instance> list = NacosInstanceManageUtil.getAllCorrespondingServiceInstanceList(serviceName);
+        Assertions.assertEquals(1, list.size());
+    }
+
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosRegistryServiceImplTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosRegistryServiceImplTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.dubbo.registry.NotifyListener;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ListView;
+import com.huawei.dubbo.registry.cache.DubboCache;
+import com.huawei.dubbo.registry.service.NacosRegistryServiceImpl;
+import com.huawei.dubbo.registry.utils.ReflectUtils;
+import com.huawei.registry.config.NacosRegisterConfig;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+/**
+ * 测试NacosRegistryServiceImpl
+ *
+ * @author chengyouling
+ * @since 2022-11-29
+ */
+public class NacosRegistryServiceImplTest {
+    private NacosRegistryServiceImpl registryService = new NacosRegistryServiceImpl();
+    private NacosRegisterConfig registerConfig = new NacosRegisterConfig();
+    NamingService namingService = Mockito.mock(NamingService.class);
+
+    private MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
+
+    @BeforeEach
+    public void setUp() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        MockitoAnnotations.openMocks(this);
+        pluginConfigManagerMockedStatic = Mockito
+                .mockStatic(PluginConfigManager.class);
+        registerConfig.setAddress("127.0.0.1:8848");
+        registerConfig.setGroup("default");
+        registerConfig.setUsername("nacos");
+        registerConfig.setPassword("nacos");
+        pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(NacosRegisterConfig.class))
+                .thenReturn(registerConfig);
+        Field field = registryService.getClass().getDeclaredField("nacosRegisterConfig");
+        field.setAccessible(true);
+        field.set(registryService, registerConfig);
+        Instance instance = new Instance();
+        instance.setIp("127.0.0.1");
+        instance.setPort(8202);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("protocol", "dubbo");
+        metadata.put("path", "com.huawei.dubbo.registry.service.RegistryService");
+        instance.setMetadata(metadata);
+        List<Instance> instances = new LinkedList<>();
+        instances.add(instance);
+        Mockito.when(namingService.getAllInstances(
+            "providers:com.huawei.dubbo.registry.service.RegistryService:default", "default"))
+                .thenReturn(instances);
+        ListView<String> listView = new ListView<>();
+        List<String> list = new LinkedList<>();
+        list.add("providers:com.huawei.dubbo.registry.service.RegistryService:default");
+        listView.setData(list);
+        Mockito.when(namingService.getServicesOfServer(1, Integer.MAX_VALUE, "default,default"))
+                .thenReturn(listView);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        pluginConfigManagerMockedStatic.close();
+    }
+
+    /**
+     * 测试注册doRegister
+     *
+     * @throws NoSuchMethodException 找不到方法
+     * @throws IllegalAccessException IllegalAccessException
+     */
+    @Test
+    public void testDoRegister() throws NoSuchFieldException, IllegalAccessException {
+        Object url = buildUrl("provider");
+        Field field = registryService.getClass().getDeclaredField("namingService");
+        field.setAccessible(true);
+        field.set(registryService, namingService);
+        registryService.doRegister(url);
+        Assertions.assertEquals(registryService.getRegistryInstance().getIp(), "127.0.0.1");
+    }
+
+    /**
+     * 测试doSubscribe/doUnsubscribe
+     *
+     * @throws NoSuchMethodException 找不到方法
+     * @throws IllegalAccessException IllegalAccessException
+     */
+    @Test
+    public void testSubscribe() throws NoSuchFieldException, IllegalAccessException {
+        Object url = buildUrl("consumer");
+        NotifyListener notifyListener = Mockito.mock(NotifyListener.class);
+        Field field = registryService.getClass().getDeclaredField("namingService");
+        field.setAccessible(true);
+        field.set(registryService, namingService);
+        registryService.doSubscribe(url, notifyListener);
+        registryService.doUnsubscribe(url, notifyListener);
+        Assertions.assertEquals(registryService.getOriginToAggregateListener().size(), 0);
+    }
+
+    private Object buildUrl(String protocol) {
+        Map<String, String> paramers = new HashMap<>();
+        paramers.put("interface", "com.huawei.dubbo.registry.service.RegistryService");
+        paramers.put("category", "providers");
+        String address = "127.0.0.1" + registerConfig.getServiceNameSeparator() + "8202";
+        DubboCache.INSTANCE.setUrlClass(URL.class);
+        Object object = ReflectUtils.valueOf(address);
+        object = ReflectUtils.setProtocol(object, protocol);
+        object = ReflectUtils.setPath(object, "com.huawei.dubbo.registry.service.RegistryService");
+        object = ReflectUtils.setHost(object, "127.0.0.1");
+        return ReflectUtils.addParameters(object, paramers);
+    }
+
+    /**
+     * 测试doSubscribe
+     *
+     * @throws NoSuchMethodException 找不到方法
+     * @throws IllegalAccessException IllegalAccessException
+     */
+    @Test
+    public void testSubscribeWithCompatible() throws NoSuchFieldException, IllegalAccessException {
+        Object url = buildUrl("consumer");
+        NotifyListener notifyListener = Mockito.mock(NotifyListener.class);
+        Field field = registryService.getClass().getDeclaredField("namingService");
+        field.setAccessible(true);
+        field.set(registryService, namingService);
+        registerConfig.setGroup("default,default");
+        registryService.doSubscribe(url, notifyListener);
+        Assertions.assertEquals(registryService.getOriginToAggregateListener().size(), 1);
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosServiceNameTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NacosServiceNameTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import org.apache.dubbo.common.URL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.huawei.dubbo.registry.entity.NacosServiceName;
+import com.huawei.registry.config.NacosRegisterConfig;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+/**
+ * 测试NacosServiceName
+ *
+ * @author chengyouling
+ * @since 2022-11-29
+ */
+public class NacosServiceNameTest {
+    private final NacosRegisterConfig registerConfig = new NacosRegisterConfig();
+    public static final String HOST = "127.0.0.1";
+    public static final int PORT = 8848;
+    public static final String PROTOCOL_KEY = "dubbo";
+    private static final String CATEGORY_KEY = "category";
+    private static final String INTERFACE_KEY = "interface";
+    private MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        pluginConfigManagerMockedStatic = Mockito
+                .mockStatic(PluginConfigManager.class);
+        registerConfig.setAddress("127.0.0.1:8848");
+        registerConfig.setGroup("DEFAULT_GROUP");
+        registerConfig.setUsername("nacos");
+        registerConfig.setPassword("nacos");
+        pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(NacosRegisterConfig.class))
+                .thenReturn(registerConfig);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        pluginConfigManagerMockedStatic.close();
+    }
+
+    /**
+     * 测试NacosServiceName通过url构建
+     */
+    @Test
+    public void testBuildNacosServiceNameByUrl() {
+        URL url = new URL(PROTOCOL_KEY, HOST, PORT);
+        url = url.addParameter(CATEGORY_KEY, "providers");
+        url = url.addParameter(INTERFACE_KEY, "interface");
+        NacosServiceName nacosServiceName = new NacosServiceName(url);
+        Assertions.assertEquals(nacosServiceName.getValue(), "providers:interface:DEFAULT_GROUP");
+    }
+
+    /**
+     * 测试NacosServiceName通过serviceName构建
+     */
+    @Test
+    public void testBuildNacosServiceNameByName() {
+        String serviceName = "providers:interface:DEFAULT_GROUP";
+        NacosServiceName nacosServiceName = new NacosServiceName(serviceName);
+        Assertions.assertEquals(nacosServiceName.getValue(), serviceName);
+    }
+
+    /**
+     * 测试是否包含“，”、“*”
+     */
+    @Test
+    public void testIsCompatible() {
+        String serviceName = "providers:interface:DEFAULT_GROUP";
+        NacosServiceName nacosServiceName = new NacosServiceName(serviceName);
+        Assertions.assertEquals(nacosServiceName.isCompatible(nacosServiceName), true);
+        String serviceName2 = "providers:interface:DEFAULT";
+        NacosServiceName nacosServiceName2 = new NacosServiceName(serviceName2);
+        Assertions.assertEquals(nacosServiceName.isCompatible(nacosServiceName2), false);
+    }
+
+    /**
+     * 测试equal
+     */
+    @Test
+    public void testEqual() {
+        String serviceName = "providers:interface:DEFAULT_GROUP";
+        NacosServiceName nacosServiceName = new NacosServiceName(serviceName);
+        Assertions.assertEquals(nacosServiceName.isCompatible(nacosServiceName), true);
+        String serviceName2 = "providers:interface:DEFAULT";
+        NacosServiceName nacosServiceName2 = new NacosServiceName(serviceName2);
+        Assertions.assertEquals(nacosServiceName.equals(nacosServiceName2), false);
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NamingServiceUtilsTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/NamingServiceUtilsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.huawei.dubbo.registry.utils.NamingServiceUtils;
+import com.huawei.registry.config.NacosRegisterConfig;
+import com.huawei.registry.config.PropertyKeyConst;
+
+/**
+ * 测试NamingServiceUtils
+ *
+ * @author chengyouling
+ * @since 2022-11-29
+ */
+public class NamingServiceUtilsTest {
+    public static final String ADDRESS = "127.0.0.1:8848";
+
+    /**
+     * 测试构建NamingService
+     *
+     * @throws NoSuchMethodException 找不到方法
+     * @throws InvocationTargetException InvocationTargetException
+     * @throws IllegalAccessException IllegalAccessException
+     */
+    @Test
+    public void testBuildNacosProperties() throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
+        NacosRegisterConfig registerConfig = new NacosRegisterConfig();
+        registerConfig.setAddress("127.0.0.1:8848");
+        registerConfig.setGroup("DEFAULT_GROUP");
+        registerConfig.setUsername("nacos");
+        registerConfig.setPassword("nacos");
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("interface", "interface");
+        Method method = NamingServiceUtils.class.getDeclaredMethod("buildNacosProperties", Map.class,
+            NacosRegisterConfig.class);
+        method.setAccessible(true);
+        Properties properties = (Properties)method.invoke(NamingServiceUtils.class, parameters, registerConfig);
+        Assertions.assertEquals(properties.getProperty(PropertyKeyConst.SERVER_ADDR), ADDRESS);
+    }
+
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/RegistryNotifierTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/test/java/com/huawei/dubbo/registry/RegistryNotifierTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.dubbo.registry;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.huawei.dubbo.registry.service.RegistryNotifier;
+
+/**
+ * 测试RegistryNotifier
+ *
+ * @author chengyouling
+ * @since 2022-11-29
+ */
+public class RegistryNotifierTest {
+
+    /**
+     * 测试构建NamingService
+     *
+     * @throws NoSuchMethodException 找不到方法
+     * @throws InvocationTargetException InvocationTargetException
+     * @throws IllegalAccessException IllegalAccessException
+     */
+    @Test
+    public void testNotify() throws NoSuchFieldException {
+        RegistryNotifier notifier = new RegistryNotifier(5000) {
+            @Override
+            protected void doNotify(Object rawAddresses) {
+
+            }
+        };
+        Instance instance = new Instance();
+        instance.setIp("127.0.0.1");
+        instance.setPort(8202);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("protocol", "dubbo");
+        metadata.put("path", "com.huawei.dubbo.registry.service.RegistryService");
+        instance.setMetadata(metadata);
+        List<Instance> instances = new LinkedList<>();
+        instances.add(instance);
+        notifier.notify(instances);
+        Field field = RegistryNotifier.class.getDeclaredField("SCHEDULER");
+        field.setAccessible(true);
+        Assertions.assertNotNull(field);
+    }
+}


### PR DESCRIPTION
【修复issue】#1002
【修改内容】
1、增加dubbo微服务注册Nacos的能力

【用例描述】
1、用dubbo框架微服务，能够注册Nacos

【自测情况】
1、本地静态检查通过
2、自测通过

【影响范围】
1、dubbo框架迁移CSE的nacos用户
