### PR TITLE
【fix】修改流控测试用例，修复测试失败问题

### DIFF
--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/fowcontrol/res4j/chain/handler/RequestHandlerTest.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/fowcontrol/res4j/chain/handler/RequestHandlerTest.java
@@ -63,9 +63,11 @@ public class RequestHandlerTest {
         operationManagerMockedStatic = Mockito.mockStatic(OperationManager.class);
         operationManagerMockedStatic.when(() -> OperationManager.getOperation(YamlConverter.class)).thenReturn(new YamlConverterImpl());
         pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class);
+        FlowControlConfig flowControlConfig = new FlowControlConfig();
+        flowControlConfig.setEnableStartMonitor(true);
         pluginConfigManagerMockedStatic
                 .when(() -> PluginConfigManager.getPluginConfig(FlowControlConfig.class))
-                .thenReturn(new FlowControlConfig());
+                .thenReturn(flowControlConfig);
         publishMatchGroup();
         loadTests();
         entry = HandlerChainEntry.INSTANCE;

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/fowcontrol/res4j/handler/HandlerTest.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/fowcontrol/res4j/handler/HandlerTest.java
@@ -17,6 +17,7 @@
 
 package com.huawei.fowcontrol.res4j.handler;
 
+import com.huawei.flowcontrol.common.config.FlowControlConfig;
 import com.huawei.flowcontrol.common.core.constants.RuleConstants;
 import com.huawei.flowcontrol.common.core.rule.BulkheadRule;
 import com.huawei.flowcontrol.common.core.rule.CircuitBreakerRule;
@@ -26,6 +27,7 @@ import com.huawei.flowcontrol.common.core.rule.fault.FaultRule;
 
 import com.huaweicloud.sermant.core.operation.OperationManager;
 import com.huaweicloud.sermant.core.operation.converter.api.YamlConverter;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
 import com.huaweicloud.sermant.implement.operation.converter.YamlConverterImpl;
 
@@ -65,16 +67,24 @@ public class HandlerTest {
 
     private MockedStatic<OperationManager> operationManagerMockedStatic;
 
+    private MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
+
     @Before
     public void setUp() {
         operationManagerMockedStatic = Mockito.mockStatic(OperationManager.class);
         operationManagerMockedStatic.when(() -> OperationManager.getOperation(YamlConverter.class)).thenReturn(new YamlConverterImpl());
+        FlowControlConfig flowControlConfig = new FlowControlConfig();
+        flowControlConfig.setEnableStartMonitor(true);
+        pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class);
+        pluginConfigManagerMockedStatic.when(()->PluginConfigManager.getPluginConfig(FlowControlConfig.class))
+                .thenReturn(flowControlConfig);
     }
 
     // mock 静态方法用完后需要关闭
     @After
     public void tearDown() throws Exception {
         operationManagerMockedStatic.close();
+        pluginConfigManagerMockedStatic.close();
     }
 
     /**


### PR DESCRIPTION
【修复issue】#1017

【修改内容】修改流控测试用例

【用例描述】1、修改流控指标上报相关用例

【自测情况】1、本地静态检查通过；2、测试通过；

【影响范围】1、对用户的使用没有影响