### PR TITLE
 Fix: Upgrade apache log4j, jackson-databind and zk-netty due to CVE vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <simpleclient.version>0.16.0</simpleclient.version>
 
         <slf4j.version>1.7.35</slf4j.version>
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.17.2</log4j2.version>
         <logback.version>1.2.9</logback.version>
 
         <junit.version>4.12</junit.version>

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/pom.xml
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <package.plugin.type>service</package.plugin.type>
         <cloud.zk.version>3.1.0</cloud.zk.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.13.4.1</jackson.version>
         <guava.version>31.1-jre</guava.version>
         <!--Curator 2.x.x兼容Zookeeper的3.4.x和3.5.x
             Curator 3.x.x只兼容Zookeeper 3.5.x-->
@@ -166,9 +166,12 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
@@ -180,6 +183,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
         </dependency>
 
         <!--测试依赖-->


### PR DESCRIPTION
What type of PR is this?

/fix

Which issue(s) this PR fixes:

Fixes #1020  

**affect springboot-registry-service plugin, upgraded components**
log4j2 version : 2.17.1->2.17.2
jackson version : 2.13.4 ->2.13.4.1
zk version : 3.4.14 switch the netty dependency to netty-all


Use case description:  not involving

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No