### PR TITLE
【feature】流控插件增加系统规则策略和负载自适应流控能力

### DIFF
--- a/sermant-integration-tests/scripts/tryDownloadMidware.sh
+++ b/sermant-integration-tests/scripts/tryDownloadMidware.sh
@@ -22,7 +22,7 @@ CSE_ADDRESS=https://cse-bucket.obs.cn-north-1.myhuaweicloud.com/LocalCSE/Local-C
 CSE_FILE_NAME=Local-CSE-2.1.3-linux-amd64.zip
 
 #======================================ZK配置======================================
-ZK_ADDRESS=https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
+ZK_ADDRESS=https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
 ZK_FILE_NAME=apache-zookeeper-3.6.3-bin.tar.gz
 
 #======================================Nacos server配置======================================

--- a/sermant-plugins/sermant-flowcontrol/config/config.yaml
+++ b/sermant-plugins/sermant-flowcontrol/config/config.yaml
@@ -2,3 +2,5 @@
 flow.control.plugin:
   useCseRule: true # 是否使用cse规则配置
   enable-start-monitor: false # 是否启动指标监控
+  enable-system-adaptive: false # 是否开启系统自适应流控
+  enable-system-rule: false # 是否开启系统规则流控

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/config/CommonConst.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/config/CommonConst.java
@@ -260,6 +260,11 @@ public class CommonConst {
      */
     public static final double RATE_DIV_POINT = 1000.0d;
 
+    /**
+     * 记录请求时间key
+     */
+    public static final String REQUEST_START_TIME = "requestStartTime";
+
     private CommonConst() {
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/config/FlowControlConfig.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/config/FlowControlConfig.java
@@ -284,6 +284,18 @@ public class FlowControlConfig implements PluginConfig {
     @ConfigFieldKey("enable-start-monitor")
     private boolean enableStartMonitor;
 
+    /**
+     * 系统自适应流控开关
+     */
+    @ConfigFieldKey("enable-system-adaptive")
+    private boolean enableSystemAdaptive;
+
+    /**
+     * 系统规则流控开关
+     */
+    @ConfigFieldKey("enable-system-rule")
+    private boolean enableSystemRule;
+
     public boolean isUseOriginInvoker() {
         return useOriginInvoker;
     }
@@ -682,5 +694,21 @@ public class FlowControlConfig implements PluginConfig {
 
     public void setEnableStartMonitor(boolean enableStartMonitor) {
         this.enableStartMonitor = enableStartMonitor;
+    }
+
+    public void setEnableSystemAdaptive(boolean isSystemAdaptive) {
+        this.enableSystemAdaptive = isSystemAdaptive;
+    }
+
+    public boolean isEnableSystemAdaptive() {
+        return enableSystemAdaptive;
+    }
+
+    public void setEnableSystemRule(boolean isSystemRule) {
+        this.enableSystemRule = isSystemRule;
+    }
+
+    public boolean isEnableSystemRule() {
+        return enableSystemRule;
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/core/resolver/SystemRuleResolver.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/core/resolver/SystemRuleResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.common.core.resolver;
+
+import com.huawei.flowcontrol.common.core.rule.SystemRule;
+
+/**
+ * 系统流控解析类
+ *
+ * @author xuezechao1
+ * @since 2022-12-05
+ */
+public class SystemRuleResolver extends AbstractResolver<SystemRule> {
+
+    /**
+     * 系统规则流控配置键
+     */
+    public static final String CONFIG_KEY = "servicecomb.system";
+
+    /**
+     * 系统流控解析构造器
+     */
+    public SystemRuleResolver() {
+        super(CONFIG_KEY);
+    }
+
+    @Override
+    protected Class<SystemRule> getRuleClass() {
+        return SystemRule.class;
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/core/rule/SystemRule.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/main/java/com/huawei/flowcontrol/common/core/rule/SystemRule.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.common.core.rule;
+
+import com.huawei.flowcontrol.common.config.CommonConst;
+
+/**
+ * 系统规则
+ *
+ * @author xuezechao1
+ * @since 2022-12-05
+ */
+public class SystemRule extends AbstractRule {
+    /**
+     * 默认系统负载
+     */
+    private static final double DEFAULT_SYSTEM_LOAD = Double.MAX_VALUE;
+
+    /**
+     * 默认CPU使用率 [0, 1]
+     */
+    private static final double DEFAULT_CPU_USAGE = 1.0D;
+
+    /**
+     * 默认qps
+     */
+    private static final double DEFAULT_QPS = Double.MAX_VALUE;
+
+    /**
+     * 默认平均响应时间
+     */
+    private static final long DEFAULT_AVE_RT = Long.MAX_VALUE;
+
+    /**
+     * 默认并发线程
+     */
+    private static final long DEFAULT_THREAD_NUM = Long.MAX_VALUE;
+
+    /**
+     * 默认限流错误码
+     */
+    private static final int DEFAULT_ERROR_CODE = CommonConst.INTERVAL_SERVER_ERROR;
+
+    /**
+     * 系统负载
+     */
+    private double systemLoad = DEFAULT_SYSTEM_LOAD;
+
+    /**
+     * CPU使用率 [0, 1]
+     */
+    private double cpuUsage = DEFAULT_CPU_USAGE;
+
+    /**
+     * qps
+     */
+    private double qps = DEFAULT_QPS;
+
+    /**
+     * 平均响应时间
+     */
+    private long aveRt = DEFAULT_AVE_RT;
+
+    /**
+     * 并发线程
+     */
+    private long threadNum = DEFAULT_THREAD_NUM;
+
+    /**
+     * 限流错误码
+     */
+    private int errorCode = DEFAULT_ERROR_CODE;
+
+    @Override
+    public boolean isInValid() {
+        if (systemLoad < 0) {
+            return true;
+        }
+
+        if (cpuUsage < 0 || cpuUsage > 1) {
+            return true;
+        }
+
+        if (qps < 0) {
+            return true;
+        }
+
+        if (aveRt < 0) {
+            return true;
+        }
+
+        if (threadNum < 0) {
+            return true;
+        }
+        return super.isInValid();
+    }
+
+    public void setSystemLoad(double systemLoad) {
+        this.systemLoad = systemLoad;
+    }
+
+    public double getSystemLoad() {
+        return systemLoad;
+    }
+
+    public void setCpuUsage(double cpuUsage) {
+        this.cpuUsage = cpuUsage;
+    }
+
+    public double getCpuUsage() {
+        return cpuUsage;
+    }
+
+    public void setQps(double qps) {
+        this.qps = qps;
+    }
+
+    public double getQps() {
+        return qps;
+    }
+
+    public void setAveRt(long aveRt) {
+        this.aveRt = aveRt;
+    }
+
+    public long getAveRt() {
+        return aveRt;
+    }
+
+    public void setThreadNum(long threadNum) {
+        this.threadNum = threadNum;
+    }
+
+    public long getThreadNum() {
+        return threadNum;
+    }
+
+    public void setErrorCode(int errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/test/java/com/huawei/flowcontrol/common/core/ResolverManagerTest.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/test/java/com/huawei/flowcontrol/common/core/ResolverManagerTest.java
@@ -31,6 +31,8 @@ import com.huawei.flowcontrol.common.core.resolver.RateLimitingRuleResolver;
 import com.huawei.flowcontrol.common.core.resolver.RateLimitingRuleResolverTest;
 import com.huawei.flowcontrol.common.core.resolver.RetryResolver;
 import com.huawei.flowcontrol.common.core.resolver.RetryResolverTest;
+import com.huawei.flowcontrol.common.core.resolver.SystemRuleResolver;
+import com.huawei.flowcontrol.common.core.resolver.SystemRuleResolverTest;
 import com.huawei.flowcontrol.common.core.rule.AbstractRule;
 
 import com.huaweicloud.sermant.core.operation.OperationManager;
@@ -70,6 +72,7 @@ public class ResolverManagerTest {
         resolversMap.put(FaultRuleResolver.CONFIG_KEY + ".", new FaultRuleResolver());
         resolversMap.put(RateLimitingRuleResolver.CONFIG_KEY + ".", new RateLimitingRuleResolver());
         resolversMap.put(RetryResolver.CONFIG_KEY + ".", new RetryResolver());
+        resolversMap.put(SystemRuleResolver.CONFIG_KEY + ".", new SystemRuleResolver());
     }
 
     @After
@@ -98,6 +101,7 @@ public class ResolverManagerTest {
         testTargetResolver(new FaultRuleResolverTest());
         testTargetResolver(new RetryResolverTest());
         testTargetResolver(new RateLimitingRuleResolverTest());
+        testTargetResolver(new SystemRuleResolverTest());
     }
 
     private <T extends AbstractRule> void testTargetResolver(AbstractRuleResolverTest<T> resolverTest) {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/test/java/com/huawei/flowcontrol/common/core/RuleUtilsTest.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/test/java/com/huawei/flowcontrol/common/core/RuleUtilsTest.java
@@ -31,6 +31,8 @@ import com.huawei.flowcontrol.common.core.resolver.RateLimitingRuleResolver;
 import com.huawei.flowcontrol.common.core.resolver.RateLimitingRuleResolverTest;
 import com.huawei.flowcontrol.common.core.resolver.RetryResolver;
 import com.huawei.flowcontrol.common.core.resolver.RetryResolverTest;
+import com.huawei.flowcontrol.common.core.resolver.SystemRuleResolver;
+import com.huawei.flowcontrol.common.core.resolver.SystemRuleResolverTest;
 import com.huawei.flowcontrol.common.core.rule.AbstractRule;
 import com.huawei.flowcontrol.common.core.rule.BulkheadRule;
 
@@ -71,6 +73,7 @@ public class RuleUtilsTest {
         resolversMap.put(FaultRuleResolver.CONFIG_KEY + ".", new FaultRuleResolver());
         resolversMap.put(RateLimitingRuleResolver.CONFIG_KEY + ".", new RateLimitingRuleResolver());
         resolversMap.put(RetryResolver.CONFIG_KEY + ".", new RetryResolver());
+        resolversMap.put(SystemRuleResolver.CONFIG_KEY + "." , new SystemRuleResolver());
     }
 
     @After
@@ -99,6 +102,7 @@ public class RuleUtilsTest {
         testTargetResolver(new FaultRuleResolverTest());
         testTargetResolver(new RetryResolverTest());
         testTargetResolver(new RateLimitingRuleResolverTest());
+        testTargetResolver(new SystemRuleResolverTest());
     }
 
     private <T extends AbstractRule> void testTargetResolver(AbstractRuleResolverTest<T> resolverTest) {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/test/java/com/huawei/flowcontrol/common/core/resolver/SystemRuleResolverTest.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-common/src/test/java/com/huawei/flowcontrol/common/core/resolver/SystemRuleResolverTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.common.core.resolver;
+
+import com.huawei.flowcontrol.common.core.rule.SystemRule;
+import org.junit.Assert;
+
+/**
+ * 系统规则解析测试
+ *
+ * @author xuezechao1
+ * @since 2022-12-13
+ */
+public class SystemRuleResolverTest extends AbstractRuleResolverTest<SystemRule> {
+
+    private static final double SYSTEM_LOAD = 1.0;
+
+    private static final double CPU_USAGE = 0.6;
+
+    private static final double QPS = 500;
+
+    private static final long AVE_RT = 200;
+
+    private static final long THREAD_NUM = 20;
+
+    private static final double DELTA = 1 >> 6;
+
+    @Override
+    public AbstractResolver<SystemRule> getResolver() {
+        return new SystemRuleResolver();
+    }
+
+    @Override
+    public String getConfigKey() {
+        return SystemRuleResolver.CONFIG_KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return "systemLoad: 1.0\n"
+                + "cpuUsage: 0.6\n"
+                + "qps: 500\n"
+                + "aveRt: 200\n"
+                + "threadNum: 20";
+    }
+
+    @Override
+    public void checkAttrs(SystemRule rule) {
+        Assert.assertEquals(SYSTEM_LOAD, rule.getSystemLoad(), DELTA);
+        Assert.assertEquals(CPU_USAGE, rule.getCpuUsage(), DELTA);
+        Assert.assertEquals(QPS, rule.getQps(), DELTA);
+        Assert.assertEquals(AVE_RT, rule.getAveRt(), DELTA);
+        Assert.assertEquals(THREAD_NUM, rule.getThreadNum(), DELTA);
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.huawei.flowcontrol.common.core.resolver.AbstractResolver
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.huawei.flowcontrol.common.core.resolver.AbstractResolver
@@ -22,3 +22,4 @@ com.huawei.flowcontrol.common.core.resolver.InstanceIsolationRuleResolver
 com.huawei.flowcontrol.common.core.resolver.RateLimitingRuleResolver
 com.huawei.flowcontrol.common.core.resolver.RetryResolver
 com.huawei.flowcontrol.common.core.resolver.FaultRuleResolver
+com.huawei.flowcontrol.common.core.resolver.SystemRuleResolver

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/chain/HandlerConstants.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/chain/HandlerConstants.java
@@ -60,6 +60,11 @@ public class HandlerConstants {
     public static final int CIRCUIT_BREAKER_ORDER = 10000;
 
     /**
+     * 系统规则流控优先级
+     */
+    public static final int SYSTEM_RULE_FLOW_CONTROL = 11000;
+
+    /**
      * 标记当前线程是否发生流控异常
      */
     public static final String OCCURRED_FLOW_EXCEPTION = "__OCCURRED_FLOW_EXCEPTION__";

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/chain/context/RequestContext.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/chain/context/RequestContext.java
@@ -47,7 +47,7 @@ public class RequestContext {
      * 构造函数
      *
      * @param threadLocal 线程变量
-     * @param sourceName 源名称
+     * @param sourceName  源名称
      */
     public RequestContext(ThreadLocal<Map<String, RequestContext>> threadLocal, String sourceName) {
         this.threadLocal = threadLocal;
@@ -57,7 +57,7 @@ public class RequestContext {
     /**
      * 保存线程变量
      *
-     * @param name 变量名称
+     * @param name   变量名称
      * @param target 保存对象
      */
     public void save(String name, Object target) {
@@ -71,8 +71,8 @@ public class RequestContext {
     /**
      * 获取线程变量
      *
-     * @param name 名称
-     * @param <T>  返回类型
+     * @param name  名称
+     * @param <T>   返回类型
      * @param clazz 指定类型
      * @return 结果
      */
@@ -124,5 +124,15 @@ public class RequestContext {
 
     public String getSourceName() {
         return sourceName;
+    }
+
+    /**
+     * 线程变量中是否存在指定key
+     *
+     * @param key 线程变量key
+     * @return 是否存在
+     */
+    public boolean hasKey(String key) {
+        return localMap.containsKey(key);
     }
 }

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/chain/handler/SystemServerReqHandler.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/chain/handler/SystemServerReqHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.chain.handler;
+
+import com.huawei.flowcontrol.common.config.CommonConst;
+import com.huawei.flowcontrol.common.core.rule.fault.Fault;
+import com.huawei.flowcontrol.common.entity.RequestEntity.RequestType;
+import com.huawei.flowcontrol.res4j.chain.HandlerConstants;
+import com.huawei.flowcontrol.res4j.chain.context.RequestContext;
+import com.huawei.flowcontrol.res4j.exceptions.SystemRuleFault;
+import com.huawei.flowcontrol.res4j.handler.SystemRuleHandler;
+import com.huawei.flowcontrol.res4j.util.SystemRuleUtils;
+import com.huawei.flowcontrol.res4j.windows.WindowsArray;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 系统规则流控处理
+ *
+ * @author xuezechao1
+ * @since 2022-12-05
+ */
+public class SystemServerReqHandler extends FlowControlHandler<Fault> {
+    private final SystemRuleHandler systemRuleHandler = new SystemRuleHandler();
+
+    private final String contextName = SystemServerReqHandler.class.getName();
+
+    @Override
+    public void onBefore(RequestContext context, Set<String> businessNames) {
+        if (SystemRuleUtils.isEnableSystemRule()) {
+
+            // 流控检测
+            final List<SystemRuleFault> faults = systemRuleHandler.createOrGetHandlers(businessNames);
+            if (!faults.isEmpty()) {
+                faults.forEach(Fault::acquirePermission);
+            }
+
+            // 记录请求时间
+            context.save(CommonConst.REQUEST_START_TIME, System.currentTimeMillis());
+            WindowsArray.INSTANCE.addThreadNum(context.get(CommonConst.REQUEST_START_TIME, long.class));
+        }
+        super.onBefore(context, businessNames);
+    }
+
+    @Override
+    public void onThrow(RequestContext context, Set<String> businessNames, Throwable throwable) {
+        context.remove(getContextName());
+        context.remove(CommonConst.REQUEST_START_TIME);
+        super.onThrow(context, businessNames, throwable);
+    }
+
+    @Override
+    public void onResult(RequestContext context, Set<String> businessNames, Object result) {
+        if (SystemRuleUtils.isEnableSystemRule() && context.hasKey(CommonConst.REQUEST_START_TIME)) {
+            long startTime = context.get(CommonConst.REQUEST_START_TIME, long.class);
+            WindowsArray.INSTANCE.addSuccess(startTime);
+            WindowsArray.INSTANCE.decreaseThreadNum(startTime);
+            WindowsArray.INSTANCE.addRt(startTime, System.currentTimeMillis() - startTime);
+            context.remove(CommonConst.REQUEST_START_TIME);
+        }
+        context.remove(getContextName());
+        super.onResult(context, businessNames, result);
+    }
+
+    @Override
+    protected RequestType direct() {
+        return RequestType.SERVER;
+    }
+
+    @Override
+    public int getOrder() {
+        return HandlerConstants.SYSTEM_RULE_FLOW_CONTROL;
+    }
+
+    @Override
+    public String getContextName() {
+        return contextName;
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/exceptions/SystemRuleException.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/exceptions/SystemRuleException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.exceptions;
+
+import com.huawei.flowcontrol.common.core.rule.SystemRule;
+
+/**
+ * 系统流控异常
+ *
+ * @author xuezechao1
+ * @since 2022-12-06
+ */
+public class SystemRuleException extends RuntimeException {
+    private final String msg;
+    private final SystemRule systemRule;
+
+    /**
+     * 系统策略异常
+     *
+     * @param msg 异常信息
+     * @param systemRule 系统规则
+     */
+    public SystemRuleException(String msg, SystemRule systemRule) {
+        this.msg = msg;
+        this.systemRule = systemRule;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public SystemRule getSystemRule() {
+        return systemRule;
+    }
+
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/exceptions/SystemRuleFault.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/exceptions/SystemRuleFault.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.exceptions;
+
+import com.huawei.flowcontrol.common.config.CommonConst;
+import com.huawei.flowcontrol.common.core.rule.SystemRule;
+import com.huawei.flowcontrol.common.core.rule.fault.Fault;
+import com.huawei.flowcontrol.res4j.util.SystemRuleUtils;
+
+/**
+ * 处理限流异常
+ *
+ * @author xuezechao1
+ * @since 2022-12-07
+ */
+public class SystemRuleFault implements Fault {
+    private SystemRule rule;
+
+    /**
+     * 系统流控错误
+     *
+     * @param systemRule 系统规则
+     */
+    public SystemRuleFault(SystemRule systemRule) {
+        this.rule = systemRule;
+    }
+
+    @Override
+    public void acquirePermission() {
+        // check qps
+        if (SystemRuleUtils.getQps() > rule.getQps()) {
+            throw new SystemRuleException("Trigger qps flow control", rule);
+        }
+
+        // check threadNum
+        if (SystemRuleUtils.getThreadNum() > rule.getThreadNum()) {
+            throw new SystemRuleException("Trigger threadNum flow control", rule);
+        }
+
+        // check rt
+        if (SystemRuleUtils.getAveRt() > rule.getAveRt()) {
+            throw new SystemRuleException("Trigger rt flow control", rule);
+        }
+
+        // check load
+        if (SystemRuleUtils.getCurrentLoad() > rule.getSystemLoad()) {
+            if (!SystemRuleUtils.isEnableSystemAdaptive() || checkHistoryData()) {
+                throw new SystemRuleException("Trigger load flow control", rule);
+            }
+        }
+
+        // check cpu
+        if (SystemRuleUtils.getCurrentCpuUsage() > rule.getCpuUsage()) {
+            throw new SystemRuleException("Trigger cpu flow control", rule);
+        }
+    }
+
+    /**
+     * 系统负载自适应检测
+     *
+     * @return 是否流控
+     */
+    private boolean checkHistoryData() {
+        long threadNum = SystemRuleUtils.getThreadNum();
+        if (threadNum > 1 && threadNum > SystemRuleUtils.getMaxThreadNum()
+                * SystemRuleUtils.getMinRt() / CommonConst.S_MS_UNIT) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/handler/SystemRuleHandler.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/handler/SystemRuleHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.handler;
+
+import com.huawei.flowcontrol.common.core.resolver.SystemRuleResolver;
+import com.huawei.flowcontrol.common.core.rule.SystemRule;
+import com.huawei.flowcontrol.common.handler.AbstractRequestHandler;
+import com.huawei.flowcontrol.res4j.exceptions.SystemRuleFault;
+
+import java.util.Optional;
+
+/**
+ * 系统流控处理器
+ *
+ * @author xuezechao1
+ * @since 2022-12-06
+ */
+public class SystemRuleHandler extends AbstractRequestHandler<SystemRuleFault, SystemRule> {
+
+    @Override
+    protected Optional<SystemRuleFault> createProcessor(String businessName, SystemRule rule) {
+        return Optional.of(new SystemRuleFault(rule));
+    }
+
+    @Override
+    protected String configKey() {
+        return SystemRuleResolver.CONFIG_KEY;
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/handler/exception/SystemRuleExceptionHandler.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/handler/exception/SystemRuleExceptionHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.handler.exception;
+
+import com.huawei.flowcontrol.common.entity.FlowControlResponse;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
+import com.huawei.flowcontrol.res4j.exceptions.SystemRuleException;
+
+/**
+ * 系统流控异常处理
+ *
+ * @author xuezechao1
+ * @since 2022-12-06
+ */
+public class SystemRuleExceptionHandler extends AbstractExceptionHandler<SystemRuleException> {
+
+    @Override
+    protected FlowControlResponse getFlowControlResponse(SystemRuleException ex, FlowControlResult flowControlResult) {
+        return new FlowControlResponse(ex.getMsg(), ex.getSystemRule().getErrorCode());
+    }
+
+    @Override
+    public Class<SystemRuleException> targetException() {
+        return SystemRuleException.class;
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/service/SystemStatusSlidingWindow.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/service/SystemStatusSlidingWindow.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.service;
+
+import com.huawei.flowcontrol.common.config.CommonConst;
+import com.huawei.flowcontrol.res4j.windows.SystemStatusTask;
+import com.huawei.flowcontrol.res4j.windows.WindowsArray;
+
+import com.huaweicloud.sermant.core.plugin.service.PluginService;
+
+import java.util.Timer;
+
+/**
+ * 系统状态滑动窗口服务
+ *
+ * @author xuezechao1
+ * @since 2022-12-05
+ */
+public class SystemStatusSlidingWindow implements PluginService {
+
+    private final Timer systemStatus = new Timer();
+    private final SystemStatusTask systemStatusTask = new SystemStatusTask();
+
+    @Override
+    public void start() {
+        /**
+         * 初始化滑动窗口
+         */
+        WindowsArray.INSTANCE.initWindowsArray();
+
+        /**
+         * 定时任务 更新系统状态
+         */
+        systemStatus.scheduleAtFixedRate(systemStatusTask, getDelay(), CommonConst.S_MS_UNIT);
+    }
+
+    private long getDelay() {
+        return CommonConst.S_MS_UNIT - System.currentTimeMillis() % CommonConst.S_MS_UNIT;
+    }
+
+    @Override
+    public void stop() {
+        systemStatus.cancel();
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/util/SystemRuleUtils.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/util/SystemRuleUtils.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.util;
+
+import com.huawei.flowcontrol.common.config.FlowControlConfig;
+import com.huawei.flowcontrol.res4j.windows.SystemStatus;
+import com.huawei.flowcontrol.res4j.windows.WindowsArray;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+/**
+ * 配置工具类
+ *
+ * @author xuezechao1
+ * @since 2022-12-12
+ */
+public class SystemRuleUtils {
+    private static final FlowControlConfig CONFIG = PluginConfigManager.getPluginConfig(FlowControlConfig.class);
+
+    private SystemRuleUtils() {
+    }
+
+    /**
+     * 获取系统自适应开关情况
+     *
+     * @return 开关
+     */
+    public static boolean isEnableSystemAdaptive() {
+        return CONFIG.isEnableSystemAdaptive();
+    }
+
+    /**
+     * 获取系统规则流控开关情况
+     *
+     * @return 开发
+     */
+    public static boolean isEnableSystemRule() {
+        return CONFIG.isEnableSystemRule();
+    }
+
+    /**
+     * 获取qps
+     *
+     * @return qps
+     */
+    public static double getQps() {
+        return SystemStatus.getInstance().getQps();
+    }
+
+    /**
+     * 获取线程数
+     *
+     * @return 线程数
+     */
+    public static long getThreadNum() {
+        return WindowsArray.INSTANCE.getThreadNum();
+    }
+
+    /**
+     * 获取平均响应时间
+     *
+     * @return 平均响应时间
+     */
+    public static double getAveRt() {
+        return SystemStatus.getInstance().getAveRt();
+    }
+
+    /**
+     * 获取系统负载
+     *
+     * @return 系统负载
+     */
+    public static double getCurrentLoad() {
+        return SystemStatus.getInstance().getCurrentLoad();
+    }
+
+    /**
+     * 获取cpu使用率
+     *
+     * @return cpu使用率
+     */
+    public static double getCurrentCpuUsage() {
+        return SystemStatus.getInstance().getCurrentCpuUsage();
+    }
+
+    /**
+     * 获取最大线程数
+     *
+     * @return 最大线程数
+     */
+    public static double getMaxThreadNum() {
+        return SystemStatus.getInstance().getMaxThreadNum();
+    }
+
+    /**
+     * 获取最小响应时间
+     *
+     * @return 最小响应时间
+     */
+    public static double getMinRt() {
+        return SystemStatus.getInstance().getMinRt();
+    }
+
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/SystemStatus.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/SystemStatus.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.windows;
+
+/**
+ * 系统状态
+ *
+ * @author xuezechao1
+ * @since 2022-12-06
+ */
+public class SystemStatus {
+
+    private static final SystemStatus INSTANCE = new SystemStatus();
+
+    /**
+     * 当前系统负载
+     */
+    private double currentLoad = -1;
+
+    /**
+     * 当前系统CPU使用率
+     */
+    private double currentCpuUsage = -1;
+
+    /**
+     * qps
+     */
+    private double qps = 0;
+
+    /**
+     * 平均响应时间
+     */
+    private double aveRt = 0;
+
+    /**
+     * 最小响应时间
+     */
+    private double minRt = Long.MAX_VALUE;
+
+    /**
+     * 最大线程数
+     */
+    private long maxThreadNum = Long.MIN_VALUE;
+
+    private SystemStatus() {
+
+    }
+
+    public void setCurrentLoad(double load) {
+        this.currentLoad = load;
+    }
+
+    public double getCurrentLoad() {
+        return currentLoad;
+    }
+
+    public void setCurrentCpuUsage(double cpuUsage) {
+        this.currentCpuUsage = cpuUsage;
+    }
+
+    public double getCurrentCpuUsage() {
+        return currentCpuUsage;
+    }
+
+    public void setQps(double qps) {
+        this.qps = qps;
+    }
+
+    public double getQps() {
+        return qps;
+    }
+
+    public void setAveRt(double aveRt) {
+        this.aveRt = aveRt;
+    }
+
+    public double getAveRt() {
+        return aveRt;
+    }
+
+    public void setMinRt(double minRt) {
+        this.minRt = minRt;
+    }
+
+    public double getMinRt() {
+        return minRt;
+    }
+
+    public void setMaxThreadNum(long threadNum) {
+        this.maxThreadNum = threadNum;
+    }
+
+    public long getMaxThreadNum() {
+        return maxThreadNum;
+    }
+
+    public static SystemStatus getInstance() {
+        return INSTANCE;
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/SystemStatusTask.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/SystemStatusTask.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.windows;
+
+import com.huawei.flowcontrol.common.config.CommonConst;
+
+import com.sun.management.OperatingSystemMXBean;
+
+import java.lang.management.ManagementFactory;
+import java.util.TimerTask;
+
+/**
+ * 滑动窗口定时任务
+ *
+ * @author xuezechao1
+ * @since 2022-12-07
+ */
+public class SystemStatusTask extends TimerTask {
+
+    private final SystemStatus systemStatus = SystemStatus.getInstance();
+
+    @Override
+    public void run() {
+        // 新一轮窗口初始化数据
+        if (WindowsArray.INSTANCE.calculateCurrentWindowsIndex() == 0) {
+            initMinRtAndMaxThreadNum();
+        }
+
+        // 更新系统负载和CPU使用率
+        OperatingSystemMXBean operatingSystemMxBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
+        systemStatus.setCurrentLoad(operatingSystemMxBean.getSystemLoadAverage());
+        systemStatus.setCurrentCpuUsage(operatingSystemMxBean.getSystemCpuLoad());
+
+        // 更新最小响应时间 最大线程数
+        updateMinRtAndMaxThreadNum();
+
+        // 更新qps 平均响应时间
+        updateQpsAndAveRt();
+
+        // 重置下一秒数据
+        WindowsArray.INSTANCE.resetNextWindows();
+    }
+
+    /**
+     * 检查数据项
+     *
+     * @param windowsBucket 数据窗口
+     * @return 窗口是否有效
+     */
+    private boolean checkBucket(WindowsBucket windowsBucket) {
+        if (windowsBucket == null || windowsBucket.success.sum() == 0
+                || windowsBucket.rt.sum() == 0) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * 初始化最小响应时间 最大线程数
+     */
+    private void initMinRtAndMaxThreadNum() {
+        systemStatus.setMinRt(Double.MAX_VALUE);
+        systemStatus.setMaxThreadNum(Long.MIN_VALUE);
+    }
+
+    /**
+     * 更新最小响应时间 最大线程数
+     */
+    private void updateMinRtAndMaxThreadNum() {
+        WindowsBucket windowsBucket = WindowsArray.INSTANCE.getCurrentWindow();
+
+        // 调用成功总数
+        long successNum = windowsBucket.success.sum();
+
+        // 响应时间总数
+        double rt = windowsBucket.rt.sum();
+
+        // 现存线程数
+        double threadNum = windowsBucket.threadNum.sum();
+        if (0 != successNum) {
+            systemStatus.setMinRt(Math.min(systemStatus.getMinRt(), rt / successNum));
+        }
+        systemStatus.setMaxThreadNum((long) Math.max(systemStatus.getMaxThreadNum(), threadNum + successNum));
+    }
+
+    /**
+     * 更新qps 平均响应时间
+     */
+    private void updateQpsAndAveRt() {
+        WindowsBucket previousWindowsBucket = WindowsArray.INSTANCE.getPreviousWindow();
+        if (checkBucket(previousWindowsBucket)) {
+            systemStatus.setQps(previousWindowsBucket.success.sum());
+            systemStatus.setAveRt(previousWindowsBucket.rt.sum() / systemStatus.getQps());
+            return;
+        }
+        WindowsBucket currentWindowsBucket = WindowsArray.INSTANCE.getCurrentWindow();
+        if (checkBucket(currentWindowsBucket)) {
+            long currentMillis = System.currentTimeMillis() % CommonConst.S_MS_UNIT;
+            if (currentMillis != 0) {
+                systemStatus.setQps(
+                        (double) CommonConst.S_MS_UNIT * currentWindowsBucket.success.sum() / currentMillis);
+                systemStatus.setAveRt(
+                        (double) currentWindowsBucket.rt.sum() / currentWindowsBucket.success.sum());
+            }
+        }
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/WindowsArray.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/WindowsArray.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.windows;
+
+import com.huawei.flowcontrol.common.config.CommonConst;
+
+import java.util.Calendar;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.stream.Stream;
+
+/**
+ * 滑动窗口
+ *
+ * @author xuezechao1
+ * @since 2022-12-07
+ */
+public enum WindowsArray {
+
+    /**
+     * 单例
+     */
+    INSTANCE;
+
+    /**
+     * 默认窗口大小
+     */
+    private static final int DEFAULT_WINDOWS_SIZE = 60;
+
+    /**
+     * 滑动窗口数组
+     */
+    private static AtomicReferenceArray<WindowsBucket> windowsArray = null;
+
+    /**
+     * 初始化
+     */
+    public void initWindowsArray() {
+        windowsArray = new AtomicReferenceArray<>(DEFAULT_WINDOWS_SIZE);
+        Stream.iterate(0, n -> n + 1).limit(DEFAULT_WINDOWS_SIZE)
+                .forEach(a -> windowsArray.set(a, new WindowsBucket()));
+    }
+
+    /**
+     * 获取当前时间点窗口
+     *
+     * @return 当前时间点窗口
+     */
+    public WindowsBucket getCurrentWindow() {
+        return windowsArray.get(calculateCurrentWindowsIndex());
+    }
+
+    /**
+     * 获取当前时间点前一个窗口
+     *
+     * @return 当前时间点前一个窗口
+     */
+    public WindowsBucket getPreviousWindow() {
+        return windowsArray.get(calculatePreviousWindowsIndex());
+    }
+
+    /**
+     * 获取指定索引窗口
+     *
+     * @param index 索引
+     * @return 指定索引窗口
+     */
+    public WindowsBucket getWindow(int index) {
+        return windowsArray.get(index);
+    }
+
+    /**
+     * 获取当前线程数
+     *
+     * @return 当前线程数
+     */
+    public long getThreadNum() {
+        return getCurrentWindow().threadNum.sum();
+    }
+
+    /**
+     * 增加成功数
+     *
+     * @param startTime 请求时间
+     */
+    public void addSuccess(long startTime) {
+        windowsArray.get(calculateWindowsIndex(startTime)).success.increment();
+    }
+
+    /**
+     * 增加响应时间
+     *
+     * @param startTime 请求时间
+     * @param responseTime 响应时间
+     */
+    public void addRt(long startTime, long responseTime) {
+        windowsArray.get(calculateWindowsIndex(startTime)).rt.add(responseTime);
+    }
+
+    /**
+     * 增加线程数
+     *
+     * @param startTime 请求时间
+     */
+    public void addThreadNum(long startTime) {
+        windowsArray.get(calculateWindowsIndex(startTime)).threadNum.increment();
+    }
+
+    /**
+     * 减少线程数
+     *
+     * @param startTime 请求时间
+     */
+    public void decreaseThreadNum(long startTime) {
+        windowsArray.get(calculateWindowsIndex(startTime)).threadNum.decrement();
+    }
+
+    /**
+     * 计算当前时间点窗口索引
+     *
+     * @return 当前时间点窗口索引
+     */
+    public int calculateCurrentWindowsIndex() {
+        return Calendar.getInstance().get(Calendar.SECOND) % DEFAULT_WINDOWS_SIZE;
+    }
+
+    /**
+     * 重置下一个窗口数据
+     */
+    public void resetNextWindows() {
+        WindowsBucket windowsBucket = getWindow(calculateNextWindowsIndex());
+        windowsBucket.success.reset();
+        windowsBucket.rt.reset();
+        windowsBucket.threadNum.reset();
+    }
+
+    /**
+     * 计算当前时间点下一个窗口索引
+     *
+     * @return 当前时间点下一个窗口索引
+     */
+    public int calculateNextWindowsIndex() {
+        int nextIndex = calculateCurrentWindowsIndex() + 1;
+        if (nextIndex >= DEFAULT_WINDOWS_SIZE) {
+            nextIndex = 0;
+        }
+        return nextIndex;
+    }
+
+    /**
+     * 计算窗口索引
+     *
+     * @param startTime 请求时间
+     * @return 窗口索引
+     */
+    public int calculateWindowsIndex(long startTime) {
+        if (System.currentTimeMillis() - startTime > DEFAULT_WINDOWS_SIZE * CommonConst.S_MS_UNIT) {
+            return -1;
+        }
+        return (int) (startTime / CommonConst.S_MS_UNIT % DEFAULT_WINDOWS_SIZE);
+    }
+
+    /**
+     * 计算当前时间前一个窗口索引
+     *
+     * @return 当前时间前一个窗口索引
+     */
+    public int calculatePreviousWindowsIndex() {
+        int previousIndex = calculateCurrentWindowsIndex() - 1;
+        if (previousIndex < 0) {
+            previousIndex = DEFAULT_WINDOWS_SIZE - 1;
+        }
+        return previousIndex;
+    }
+
+    /**
+     * 获取滑动窗口数组
+     *
+     * @return 滑动窗口
+     */
+    public AtomicReferenceArray<WindowsBucket> getWindowsArray() {
+        return windowsArray;
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/WindowsBucket.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/java/com/huawei/flowcontrol/res4j/windows/WindowsBucket.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.windows;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * 滑动窗口元素
+ *
+ * @author xuezechao1
+ * @since 2022-12-07
+ */
+class WindowsBucket {
+
+    /**
+     * 响应时间
+     */
+    LongAdder rt = new LongAdder();
+
+    /**
+     * 线程数
+     */
+    LongAdder threadNum = new LongAdder();
+
+    /**
+     * 成功数
+     */
+    LongAdder success = new LongAdder();
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/resources/META-INF/services/com.huawei.flowcontrol.res4j.chain.AbstractChainHandler
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/resources/META-INF/services/com.huawei.flowcontrol.res4j.chain.AbstractChainHandler
@@ -23,3 +23,4 @@ com.huawei.flowcontrol.res4j.chain.handler.CircuitBreakerClientReqHandler
 com.huawei.flowcontrol.res4j.chain.handler.CircuitBreakerServerReqHandler
 com.huawei.flowcontrol.res4j.chain.handler.InstanceIsolationRequestHandler
 com.huawei.flowcontrol.res4j.chain.handler.FaultRequestHandler
+com.huawei.flowcontrol.res4j.chain.handler.SystemServerReqHandler

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/resources/META-INF/services/com.huawei.flowcontrol.res4j.handler.exception.ExceptionHandler
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/resources/META-INF/services/com.huawei.flowcontrol.res4j.handler.exception.ExceptionHandler
@@ -20,3 +20,4 @@ com.huawei.flowcontrol.res4j.handler.exception.BulkheadExceptionHandler
 com.huawei.flowcontrol.res4j.handler.exception.CircuitExceptionHandler
 com.huawei.flowcontrol.res4j.handler.exception.InstanceIsolationExceptionHandler
 com.huawei.flowcontrol.res4j.handler.exception.RateLimitingExceptionHandler
+com.huawei.flowcontrol.res4j.handler.exception.SystemRuleExceptionHandler

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
@@ -18,4 +18,5 @@
 com.huawei.flowcontrol.res4j.service.HttpRest4jServiceImpl
 com.huawei.flowcontrol.res4j.service.DubboRest4jServiceImpl
 com.huawei.flowcontrol.res4j.service.ServiceCollectorService
+com.huawei.flowcontrol.res4j.service.SystemStatusSlidingWindow
 

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/flowcontrol/res4j/chain/handler/RequestHandlerTest.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/flowcontrol/res4j/chain/handler/RequestHandlerTest.java
@@ -22,12 +22,11 @@ import com.huawei.flowcontrol.common.core.ResolverManager;
 import com.huawei.flowcontrol.common.core.match.MatchGroupResolver;
 import com.huawei.flowcontrol.res4j.chain.HandlerChainEntry;
 import com.huawei.flowcontrol.res4j.chain.context.ChainContext;
-
+import com.huawei.flowcontrol.res4j.windows.WindowsArray;
 import com.huaweicloud.sermant.core.operation.OperationManager;
 import com.huaweicloud.sermant.core.operation.converter.api.YamlConverter;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.implement.operation.converter.YamlConverterImpl;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,6 +48,8 @@ public class RequestHandlerTest {
 
     private MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
 
+    private WindowsArray windowsArray;
+
     private final String sourceName = this.getClass().getName();
 
     private final List<RequestTest> testList = new ArrayList<>();
@@ -65,12 +66,19 @@ public class RequestHandlerTest {
         pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class);
         FlowControlConfig flowControlConfig = new FlowControlConfig();
         flowControlConfig.setEnableStartMonitor(true);
+        flowControlConfig.setEnableSystemAdaptive(true);
+        flowControlConfig.setEnableSystemRule(true);
         pluginConfigManagerMockedStatic
                 .when(() -> PluginConfigManager.getPluginConfig(FlowControlConfig.class))
                 .thenReturn(flowControlConfig);
         publishMatchGroup();
         loadTests();
         entry = HandlerChainEntry.INSTANCE;
+        setUpSystemRule();
+    }
+
+    private void setUpSystemRule() {
+        WindowsArray.INSTANCE.initWindowsArray();
     }
 
     private void loadTests() {

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/flowcontrol/res4j/chain/handler/SystemRuleRequestHandlerTest.java
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/java/com/huawei/flowcontrol/res4j/chain/handler/SystemRuleRequestHandlerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huawei.flowcontrol.res4j.chain.handler;
+
+import com.huawei.flowcontrol.common.core.ResolverManager;
+import com.huawei.flowcontrol.common.core.resolver.SystemRuleResolver;
+import com.huawei.flowcontrol.common.entity.FlowControlResult;
+import com.huawei.flowcontrol.common.entity.RequestEntity;
+import com.huawei.flowcontrol.res4j.chain.HandlerChainEntry;
+import com.huawei.flowcontrol.res4j.windows.SystemStatus;
+import org.junit.Assert;
+
+public class SystemRuleRequestHandlerTest extends BaseEntityTest implements RequestTest {
+
+    private HandlerChainEntry entry;
+    private String sourceName;
+
+    /**
+     * 测试限流
+     *
+     * @author xuezechao1
+     * @since 2022-12-12
+     */
+    @Override
+    public void test(HandlerChainEntry entry, String sourceName) {
+        this.entry = entry;
+        this.sourceName = sourceName;
+        SystemStatus.getInstance().setQps(20D);
+        Assert.assertEquals(checkHttp(httpServerEntity).buildResponseMsg(), "Trigger qps flow control");
+        SystemStatus.getInstance().setQps(5D);
+        SystemStatus.getInstance().setCurrentCpuUsage(0.8D);
+        Assert.assertEquals(checkHttp(httpServerEntity).buildResponseMsg(), "Trigger cpu flow control");
+        SystemStatus.getInstance().setCurrentCpuUsage(0.5D);
+        SystemStatus.getInstance().setAveRt(20D);
+        Assert.assertEquals(checkHttp(httpServerEntity).buildResponseMsg(), "Trigger rt flow control");
+    }
+
+    @Override
+    public void publishRule() {
+        ResolverManager.INSTANCE.resolve(buildKey(SystemRuleResolver.CONFIG_KEY), getQpsRule(), false);
+    }
+
+    @Override
+    public void clear() {
+        ResolverManager.INSTANCE.resolve(buildKey(SystemRuleResolver.CONFIG_KEY), null, true);
+    }
+
+    private FlowControlResult checkHttp(RequestEntity requestEntity) {
+        final FlowControlResult flowControlResult = new FlowControlResult();
+        entry.onBefore(sourceName, requestEntity, flowControlResult);
+        entry.onThrow(sourceName, new Exception("error"));
+        entry.onResult(sourceName, new Object());
+        return flowControlResult;
+    }
+
+    private String getQpsRule() {
+        return "systemLoad: 1.0\n"
+                + "cpuUsage: 0.6\n"
+                + "qps: 10\n"
+                + "aveRt: 10\n"
+                + "threadNum: 10";
+    }
+}

--- a/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/resources/META-INF/services/com.huawei.flowcontrol.res4j.chain.handler.RequestTest
+++ b/sermant-plugins/sermant-flowcontrol/flowcontrol-service/src/test/resources/META-INF/services/com.huawei.flowcontrol.res4j.chain.handler.RequestTest
@@ -20,3 +20,4 @@ com.huawei.flowcontrol.res4j.chain.handler.FaultRequestHandlerTest
 com.huawei.flowcontrol.res4j.chain.handler.CircuitRequestHandlerTest
 com.huawei.flowcontrol.res4j.chain.handler.InstanceIsolationRequestHandlerTest
 com.huawei.flowcontrol.res4j.chain.handler.BulkheadRequestHandlerTest
+com.huawei.flowcontrol.res4j.chain.handler.SystemRuleRequestHandlerTest


### PR DESCRIPTION
【修复issue】#992

【修改内容】

1. 流控插件增加系统规则流控策略和负载自适应能力
(1) 流控插件配置文件支持开启或关闭系统规则策略和负载自适应能力
(2) 流控插件service模块增加滑动窗口windows子模块，统计系统和请求流量的信息，包括并发线程数，qps，响应时间，系统CPU使用率，系统负载。统计任务为单独线程运行，不会阻塞请求。
(3) 流控责任链增加系统规则检测，系统规则策略处于最低优先级，即兜底策略。
(4) 增加系统规则解析ut
(5) 增加系统规则流控ut

【用例描述】

1. 前置条件
服务提供者携带sermant(流控插件，注册插件)运行，成功注册到CSE，流控插件开启系统规则流控和自适应流控开关
2. 测试步骤及预期结果
(1) CSE界面下发系统规则配置，qps阈值设置较低
(2) 配置下发生效后，jmeter对服务提供者暴露的接口进行调用
(3) 测试结束后，部分调用失败，错误信息为"Trigger qps flow control"
(4) CSE界面更改系统规则配置，线程数阈值设置较低
(5) 重复步骤(2) (3) 部分调用失败，错误信息为"Trigger threadNum flow control"
(6) CSE界面更改系统规则配置，平均响应时间阈值设置较低
(7) 重复步骤(2) (3) 全部调用失败，错误信息为"Trigger rt flow control"
(8) CSE界面更改系统规则配置，系统负载阈值设置较低
(9) 重复步骤(2) 调用过程中启动其他服务提高系统负载，降低jmeter线程数执行步骤(2) 全部调用通过，自适应流控未进行限流
(10) CSE界面更改系统规则配置，CPU使用率阈值设置较低
(11) 重复步骤(2) (3) 部分调用失败，错误信息为"Trigger cpu flow control"

【自测情况】

1. 按照上述测试用例在测试环境测试通过。

【影响范围】

1、对使用流控插件的用户没有影响，若需使用系统流控策略，则需在配置文件中开启对应功能的开关
2、需要更新流控插件文档，增加系统规则策略说明