### PR TITLE
【fix】插件服务第三方依赖的logback日志配置优先使用sermant配置

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
@@ -16,9 +16,13 @@
 
 package com.huaweicloud.sermant.core.plugin.classloader;
 
+import com.huaweicloud.sermant.core.common.BootArgsIndexer;
+import com.huaweicloud.sermant.core.common.CommonConstant;
 import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.plugin.agent.config.AgentConfig;
 
+import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.HashMap;
@@ -104,6 +108,29 @@ public class PluginClassLoader extends URLClassLoader {
             }
             return clazz;
         }
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL url = null;
+
+        // 针对日志配置文件，定制化getResource方法，首先获取agent/config/logback.xml,其次PluginClassloader下资源文件中的logback.xml
+        if (CommonConstant.LOG_SETTING_FILE_NAME.equals(name)) {
+            File logSettingFile = BootArgsIndexer.getLogSettingFile();
+            if (logSettingFile.exists() && logSettingFile.isFile()) {
+                try {
+                    url = logSettingFile.toURI().toURL();
+                } catch (MalformedURLException e) {
+                    url = findResource(name);
+                }
+            } else {
+                url = findResource(name);
+            }
+        }
+        if (url == null) {
+            url = super.getResource(name);
+        }
+        return url;
     }
 
     @Override


### PR DESCRIPTION
【修复issue】#1031

【修改内容】PluginClassLoader中覆写getResource方法

【用例描述】1、插件服务中的第三方依赖使用logback的场景按照Sermant的logback.xml配置输出日志

【自测情况】1、本地静态已清理；2、用例验证已通过

【影响范围】1、对用户使用无影响