### PR TITLE
【test】add auto test for springcloud registry plugin and flowcontrol plugin

### DIFF
--- a/.github/actions/scenarios/spring/spring-common/action.yml
+++ b/.github/actions/scenarios/spring/spring-common/action.yml
@@ -52,6 +52,8 @@ runs:
         bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8005/lb/ping 60
         bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8004/rateLimiting 60
         bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8014/rateLimiting 60
+        echo "==========check processor========"
+        jps -l
     - name: integration test module FLOW_CONTROL
       shell: bash
       run: mvn test -Dsermant.integration.test.type=FLOW_CONTROL --file sermant-integration-tests/spring-test/pom.xml

--- a/sermant-integration-tests/dubbo-test/dubbo-2-6-integration-consumer/src/main/resources/rule.yaml
+++ b/sermant-integration-tests/dubbo-test/dubbo-2-6-integration-consumer/src/main/resources/rule.yaml
@@ -26,6 +26,18 @@ servicecomb:
       matches:
         - apiPath:
             exact: "com.huaweicloud.integration.service.FlowControlService.rateLimiting"
+    demo-rateLimiting-prefix: |
+      matches:
+        - apiPath:
+            prefix: "com.huaweicloud.integration.service.FlowControlService.rateLimitingPref"
+    demo-rateLimiting-suffix: |
+      matches:
+        - apiPath:
+            suffix: "rateLimitingSuffix"
+    demo-rateLimiting-contains: |
+      matches:
+        - apiPath:
+            contains: "rateLimitingContains"
     demo-rateLimiting-version: |
       matches:
         - apiPath:
@@ -42,7 +54,47 @@ servicecomb:
           serviceName: dubbo-integration-provider
           headers:
             key:
-              prefix: attachement
+              prefix: attachment
+    demo-rateLimiting-match-attachement-exact: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              exact: flowControlExact
+    demo-rateLimiting-match-attachement-prefix: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              prefix: flowControlPr
+    demo-rateLimiting-match-attachement-suffix: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              suffix: Suffix
+    demo-rateLimiting-match-attachement-contains: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              contains: Contains
+    demo-rateLimiting-match-attachement-compare: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              compare: ">100"
     demo-circuitBreaker-timed: |
       matches:
         - apiPath:
@@ -66,11 +118,27 @@ servicecomb:
   rateLimiting:
     demo-rateLimiting: |
       rate: 1
+    demo-rateLimiting-prefix: |
+      rate: 1
+    demo-rateLimiting-suffix: |
+      rate: 1
+    demo-rateLimiting-contains: |
+      rate: 1
     demo-rateLimiting-version: |
       rate: 1
     demo-rateLimiting-match-application: |
       rate: 1
     demo-rateLimiting-match-attachement: |
+      rate: 1
+    demo-rateLimiting-match-attachement-exact: |
+      rate: 1
+    demo-rateLimiting-match-attachement-prefix: |
+      rate: 1
+    demo-rateLimiting-match-attachement-suffix: |
+      rate: 1
+    demo-rateLimiting-match-attachement-contains: |
+      rate: 1
+    demo-rateLimiting-match-attachement-compare: |
       rate: 1
   retry:
     demo-retry: |

--- a/sermant-integration-tests/dubbo-test/dubbo-2-7-integration-consumer/src/main/resources/rule.yaml
+++ b/sermant-integration-tests/dubbo-test/dubbo-2-7-integration-consumer/src/main/resources/rule.yaml
@@ -26,6 +26,18 @@ servicecomb:
       matches:
         - apiPath:
             exact: "com.huaweicloud.integration.service.FlowControlService.rateLimiting"
+    demo-rateLimiting-prefix: |
+      matches:
+        - apiPath:
+            prefix: "com.huaweicloud.integration.service.FlowControlService.rateLimitingPref"
+    demo-rateLimiting-suffix: |
+      matches:
+        - apiPath:
+            suffix: "rateLimitingSuffix"
+    demo-rateLimiting-contains: |
+      matches:
+        - apiPath:
+            contains: "rateLimitingContains"
     demo-rateLimiting-version: |
       matches:
         - apiPath:
@@ -42,7 +54,57 @@ servicecomb:
           serviceName: dubbo-integration-provider
           headers:
             key:
-              prefix: attachement
+              prefix: attachment
+            key2:
+              exact: 999
+    demo-rateLimiting-match-attachement-exact: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              exact: flowControlExact
+            key2:
+              exact: 999
+    demo-rateLimiting-match-attachement-prefix: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              prefix: flowControlPr
+            key2:
+              exact: 999
+    demo-rateLimiting-match-attachement-suffix: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              suffix: Suffix
+            key2:
+              exact: 999
+    demo-rateLimiting-match-attachement-contains: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              contains: Contains
+            key2:
+              exact: 999
+    demo-rateLimiting-match-attachement-compare: |
+      matches:
+        - apiPath:
+            exact: "com.huaweicloud.integration.service.FlowControlService.rateLimitingWithHeader"
+          serviceName: dubbo-integration-provider
+          headers:
+            key:
+              compare: ">100"
             key2:
               exact: 999
     demo-circuitBreaker-timed: |
@@ -68,11 +130,27 @@ servicecomb:
   rateLimiting:
     demo-rateLimiting: |
       rate: 1
+    demo-rateLimiting-prefix: |
+      rate: 1
+    demo-rateLimiting-suffix: |
+      rate: 1
+    demo-rateLimiting-contains: |
+      rate: 1
     demo-rateLimiting-version: |
       rate: 1
     demo-rateLimiting-match-application: |
       rate: 1
     demo-rateLimiting-match-attachement: |
+      rate: 1
+    demo-rateLimiting-match-attachement-exact: |
+      rate: 1
+    demo-rateLimiting-match-attachement-prefix: |
+      rate: 1
+    demo-rateLimiting-match-attachement-suffix: |
+      rate: 1
+    demo-rateLimiting-match-attachement-contains: |
+      rate: 1
+    demo-rateLimiting-match-attachement-compare: |
       rate: 1
   retry:
     demo-retry: |

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-api/src/main/java/com/huaweicloud/integration/controller/FlowController.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-api/src/main/java/com/huaweicloud/integration/controller/FlowController.java
@@ -58,6 +58,36 @@ public class FlowController {
      *
      * @return 测试信息
      */
+    @GetMapping("/rateLimitingPrefix")
+    public String rateLimitingPrefix() {
+        return flowControlService.rateLimitingPrefix();
+    }
+
+    /**
+     * 测试限流
+     *
+     * @return 测试信息
+     */
+    @GetMapping("/rateLimitingSuffix")
+    public String rateLimitingSuffix() {
+        return flowControlService.rateLimitingSuffix();
+    }
+
+    /**
+     * 测试限流
+     *
+     * @return 测试信息
+     */
+    @GetMapping("/rateLimitingContains")
+    public String rateLimitingContains() {
+        return flowControlService.rateLimitingContains();
+    }
+
+    /**
+     * 测试限流
+     *
+     * @return 测试信息
+     */
     @GetMapping("/rateLimitingWithApplication")
     public String rateLimitingWithApplication() {
         return flowControlService.rateLimitingWithApplication();

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-api/src/main/java/com/huaweicloud/integration/service/FlowControlService.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-api/src/main/java/com/huaweicloud/integration/service/FlowControlService.java
@@ -37,6 +37,27 @@ public interface FlowControlService {
      *
      * @return 结果
      */
+    String rateLimitingPrefix();
+
+    /**
+     * 限流测试
+     *
+     * @return 结果
+     */
+    String rateLimitingSuffix();
+
+    /**
+     * 限流测试
+     *
+     * @return 结果
+     */
+    String rateLimitingContains();
+
+    /**
+     * 限流测试
+     *
+     * @return 结果
+     */
     String rateLimitingWithApplication();
 
     /**

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-api/src/main/java/com/huaweicloud/integration/service/impl/FlowControlServiceImpl.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-api/src/main/java/com/huaweicloud/integration/service/impl/FlowControlServiceImpl.java
@@ -44,6 +44,21 @@ public abstract class FlowControlServiceImpl implements FlowControlService {
     }
 
     @Override
+    public String rateLimitingPrefix() {
+        return OK;
+    }
+
+    @Override
+    public String rateLimitingSuffix() {
+        return OK;
+    }
+
+    @Override
+    public String rateLimitingContains() {
+        return OK;
+    }
+
+    @Override
     public String rateLimitingWithApplication() {
         return rateLimiting();
     }

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/flow/FlowControlTest.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/flow/FlowControlTest.java
@@ -49,6 +49,9 @@ public class FlowControlTest {
     @Test
     public void testRateLimiting() {
         rateTest("rateLimiting");
+        rateTest("rateLimitingPrefix");
+        rateTest("rateLimitingSuffix");
+        rateTest("rateLimitingContains");
     }
 
     /**
@@ -64,7 +67,12 @@ public class FlowControlTest {
      */
     @Test
     public void testRateLimitingWithHeader() {
-        rateTest("rateLimitingWithHeader?key=key&value=attachement&key2=key2&value2=999");
+        rateTest("rateLimitingWithHeader?key=key&value=attachment&key2=key2&value2=999");
+        rateTest("rateLimitingWithHeader?key=key&value=flowControlExact&key2=key2&value2=999");
+        rateTest("rateLimitingWithHeader?key=key&value=flowControlPrefix&key2=key2&value2=999");
+        rateTest("rateLimitingWithHeader?key=key&value=flowControlSuffix&key2=key2&value2=999");
+        rateTest("rateLimitingWithHeader?key=key&value=flowControlContains&key2=key2&value2=999");
+        rateTest("rateLimitingWithHeader?key=key&value=101&key2=key2&value2=999");
         final AtomicBoolean check = new AtomicBoolean();
         process("rateLimitingWithHeader?key=key&value=val&key2=key2&value2=998", RATE_LIMITING_MSG,
             RATE_LIMITING_REQUEST_COUNT, check);

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-api-1.5.x/src/main/java/com/huaweicloud/spring/feign/api/Feign15xService.java
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-api-1.5.x/src/main/java/com/huaweicloud/spring/feign/api/Feign15xService.java
@@ -76,6 +76,54 @@ public interface Feign15xService {
     String header();
 
     /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerExact")
+    String headerExact();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerPrefix")
+    String headerPrefix();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerSuffix")
+    String headerSuffix();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerContains")
+    String headerContains();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareMatch")
+    String headerCompareMatch();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareNotMatch")
+    String headerCompareNotMatch();
+
+    /**
      * 匹配服务名测试-匹配前提, 触发流控
      *
      * @return ok

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-api-1.5.x/src/main/java/com/huaweicloud/spring/feign/api/HeaderMatchConfiguration.java
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-api-1.5.x/src/main/java/com/huaweicloud/spring/feign/api/HeaderMatchConfiguration.java
@@ -27,8 +27,23 @@ import feign.RequestTemplate;
  * @since 2022-07-29
  */
 public class HeaderMatchConfiguration implements RequestInterceptor {
+    private static final String KEY = "key";
+
     @Override
     public void apply(RequestTemplate template) {
-        template.header("key", "header2");
+        final String url = template.url();
+        if (url.contains("headerExact")) {
+            template.header(KEY, "flowControlExact");
+        } else if (url.contains("headerPrefix")) {
+            template.header(KEY, "flowControlPrefix");
+        } else if (url.contains("headerSuffix")) {
+            template.header(KEY, "flowControlSuffix");
+        } else if (url.contains("headerContains")) {
+            template.header(KEY, "flowControlContains");
+        } else if (url.contains("headerCompareMatch")) {
+            template.header(KEY, "102");
+        } else if (url.contains("headerCompareNotMatch")) {
+            template.header(KEY, "100");
+        }
     }
 }

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-consumer-1.5.x/src/main/java/com/huaweicloud/spring/feign/consumer/controller/FlowController.java
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-consumer-1.5.x/src/main/java/com/huaweicloud/spring/feign/consumer/controller/FlowController.java
@@ -86,6 +86,36 @@ public class FlowController {
     }
 
     /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("prefixRateLimiting")
+    public String rateLimitingPrefix() {
+        return rateLimiting();
+    }
+
+    /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("rateLimitingContains")
+    public String rateLimitingContains() {
+        return rateLimiting();
+    }
+
+    /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("rateLimitingSuffix")
+    public String rateLimitingSuffix() {
+        return rateLimiting();
+    }
+
+    /**
      * 慢调用熔断测试
      *
      * @return ok
@@ -131,7 +161,77 @@ public class FlowController {
     @RequestMapping("header")
     public String header() {
         try {
-            return feign15xService.header();
+            return feign15xService.headerExact();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerPrefix")
+    public String headerPrefix() {
+        try {
+            return feign15xService.headerPrefix();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerSuffix")
+    public String headerSuffix() {
+        try {
+            return feign15xService.headerSuffix();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerContains")
+    public String headerContains() {
+        try {
+            return feign15xService.headerContains();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareMatch")
+    public String headerCompareMatch() {
+        try {
+            return feign15xService.headerCompareMatch();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareNotMatch")
+    public String headerCompareNotMatch() {
+        try {
+            return feign15xService.headerCompareNotMatch();
         } catch (Exception ex) {
             return convertMsg(ex);
         }

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-consumer-1.5.x/src/main/resources/rule.yaml
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign-1.5.x/feign-consumer-1.5.x/src/main/resources/rule.yaml
@@ -31,13 +31,60 @@ servicecomb:
       matches:
         - apiPath:
             exact: "/flowcontrol/rateLimiting"
+    demo-rateLimiting-prefix: |
+      matches:
+        - apiPath:
+            prefix: "/flowcontrol/prefixRate"
+    demo-rateLimiting-suffix: |
+      matches:
+        - apiPath:
+            suffix: "Suffix"
+    demo-rateLimiting-contains: |
+      matches:
+        - apiPath:
+            contains: "Contains"
     demo-header: |
       matches:
         - apiPath:
-            exact: "/header"
+            exact: "/headerExact"
           headers:
             key:
-              prefix: header
+              exact: flowControlExact
+    demo-header-prefix: |
+      matches:
+        - apiPath:
+            exact: "/headerPrefix"
+          headers:
+            key:
+              prefix: flowControlPrefix
+    demo-header-suffix: |
+      matches:
+        - apiPath:
+            exact: "/headerSuffix"
+          headers:
+            key:
+              suffix: flowControlSuffix
+    demo-header-contains: |
+      matches:
+        - apiPath:
+            exact: "/headerContains"
+          headers:
+            key:
+              contains: flowControlContains
+    demo-header-compare: |
+      matches:
+        - apiPath:
+            exact: "/headerCompareMatch"
+          headers:
+            key:
+              compare: ">100"
+    demo-header-compare-not-match: |
+      matches:
+        - apiPath:
+            exact: "/headerCompareNotMatch"
+          headers:
+            key:
+              compare: ">100"
     demo-circuitBreaker-serviceName-match: |
       matches:
         - apiPath:
@@ -62,7 +109,23 @@ servicecomb:
   rateLimiting:
     demo-rateLimiting: |
       rate: 1
+    demo-rateLimiting-prefix: |
+      rate: 1
+    demo-rateLimiting-suffix: |
+      rate: 1
+    demo-rateLimiting-contains: |
+      rate: 1
     demo-header: |
+      rate: 1
+    demo-header-prefix: |
+      rate: 1
+    demo-header-suffix: |
+      rate: 1
+    demo-header-contains: |
+      rate: 1
+    demo-header-compare: |
+      rate: 1
+    demo-header-compare-not-match: |
       rate: 1
   retry:
     demo-retry: |

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-api/src/main/java/com/huaweicloud/spring/feign/api/FeignService.java
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-api/src/main/java/com/huaweicloud/spring/feign/api/FeignService.java
@@ -77,6 +77,54 @@ public interface FeignService {
     String header();
 
     /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerExact")
+    String headerExact();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerPrefix")
+    String headerPrefix();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerSuffix")
+    String headerSuffix();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerContains")
+    String headerContains();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareMatch")
+    String headerCompareMatch();
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareNotMatch")
+    String headerCompareNotMatch();
+
+    /**
      * 匹配服务名测试-匹配前提, 触发流控
      *
      * @return ok

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-api/src/main/java/com/huaweicloud/spring/feign/api/configuration/HeaderMatchConfiguration.java
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-api/src/main/java/com/huaweicloud/spring/feign/api/configuration/HeaderMatchConfiguration.java
@@ -27,8 +27,23 @@ import feign.RequestTemplate;
  * @since 2022-07-29
  */
 public class HeaderMatchConfiguration implements RequestInterceptor {
+    private static final String KEY = "key";
+
     @Override
     public void apply(RequestTemplate template) {
-        template.header("key", "header2");
+        final String url = template.url();
+        if (url.contains("headerExact")) {
+            template.header(KEY, "flowControlExact");
+        } else if (url.contains("headerPrefix")) {
+            template.header(KEY, "flowControlPrefix");
+        } else if (url.contains("headerSuffix")) {
+            template.header(KEY, "flowControlSuffix");
+        } else if (url.contains("headerContains")) {
+            template.header(KEY, "flowControlContains");
+        } else if (url.contains("headerCompareMatch")) {
+            template.header(KEY, "102");
+        } else if (url.contains("headerCompareNotMatch")) {
+            template.header(KEY, "100");
+        }
     }
 }

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-consumer/src/main/java/com/huaweicloud/spring/feign/consumer/controller/FlowController.java
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-consumer/src/main/java/com/huaweicloud/spring/feign/consumer/controller/FlowController.java
@@ -89,6 +89,36 @@ public class FlowController {
     }
 
     /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("prefixRateLimiting")
+    public String rateLimitingPrefix() {
+        return rateLimiting();
+    }
+
+    /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("rateLimitingContains")
+    public String rateLimitingContains() {
+        return rateLimiting();
+    }
+
+    /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("rateLimitingSuffix")
+    public String rateLimitingSuffix() {
+        return rateLimiting();
+    }
+
+    /**
      * 慢调用熔断测试
      *
      * @return ok
@@ -134,7 +164,77 @@ public class FlowController {
     @RequestMapping("header")
     public String header() {
         try {
-            return feignService.header();
+            return feignService.headerExact();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerPrefix")
+    public String headerPrefix() {
+        try {
+            return feignService.headerPrefix();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerSuffix")
+    public String headerSuffix() {
+        try {
+            return feignService.headerSuffix();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerContains")
+    public String headerContains() {
+        try {
+            return feignService.headerContains();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareMatch")
+    public String headerCompareMatch() {
+        try {
+            return feignService.headerCompareMatch();
+        } catch (Exception ex) {
+            return convertMsg(ex);
+        }
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareNotMatch")
+    public String headerCompareNotMatch() {
+        try {
+            return feignService.headerCompareNotMatch();
         } catch (Exception ex) {
             return convertMsg(ex);
         }

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-consumer/src/main/resources/rule.yaml
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign/feign-consumer/src/main/resources/rule.yaml
@@ -31,13 +31,60 @@ servicecomb:
       matches:
         - apiPath:
             exact: "/flowcontrol/rateLimiting"
+    demo-rateLimiting-prefix: |
+      matches:
+        - apiPath:
+            prefix: "/flowcontrol/prefixRate"
+    demo-rateLimiting-suffix: |
+      matches:
+        - apiPath:
+            suffix: "Suffix"
+    demo-rateLimiting-contains: |
+      matches:
+        - apiPath:
+            contains: "Contains"
     demo-header: |
       matches:
         - apiPath:
-            exact: "/header"
+            exact: "/headerExact"
           headers:
             key:
-              prefix: header
+              exact: flowControlExact
+    demo-header-prefix: |
+      matches:
+        - apiPath:
+            exact: "/headerPrefix"
+          headers:
+            key:
+              prefix: flowControlPrefix
+    demo-header-suffix: |
+      matches:
+        - apiPath:
+            exact: "/headerSuffix"
+          headers:
+            key:
+              suffix: flowControlSuffix
+    demo-header-contains: |
+      matches:
+        - apiPath:
+            exact: "/headerContains"
+          headers:
+            key:
+              contains: flowControlContains
+    demo-header-compare: |
+      matches:
+        - apiPath:
+            exact: "/headerCompareMatch"
+          headers:
+            key:
+              compare: ">100"
+    demo-header-compare-not-match: |
+      matches:
+        - apiPath:
+            exact: "/headerCompareNotMatch"
+          headers:
+            key:
+              compare: ">100"
     demo-circuitBreaker-serviceName-match: |
       matches:
         - apiPath:
@@ -62,7 +109,23 @@ servicecomb:
   rateLimiting:
     demo-rateLimiting: |
       rate: 1
+    demo-rateLimiting-prefix: |
+      rate: 1
+    demo-rateLimiting-suffix: |
+      rate: 1
+    demo-rateLimiting-contains: |
+      rate: 1
     demo-header: |
+      rate: 1
+    demo-header-prefix: |
+      rate: 1
+    demo-header-suffix: |
+      rate: 1
+    demo-header-contains: |
+      rate: 1
+    demo-header-compare: |
+      rate: 1
+    demo-header-compare-not-match: |
       rate: 1
   retry:
     demo-retry: |

--- a/sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-consumer/src/main/resources/rule.yaml
+++ b/sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-consumer/src/main/resources/rule.yaml
@@ -31,13 +31,53 @@ servicecomb:
       matches:
         - apiPath:
             exact: "/flowcontrol/rateLimiting"
+    demo-rateLimiting-prefix: |
+      matches:
+        - apiPath:
+            prefix: "/flowcontrol/prefixRate"
+    demo-rateLimiting-suffix: |
+      matches:
+        - apiPath:
+            suffix: "Suffix"
+    demo-rateLimiting-contains: |
+      matches:
+        - apiPath:
+            contains: "Contains"
     demo-header: |
       matches:
         - apiPath:
             exact: "/header"
           headers:
             key:
-              prefix: header
+              exact: flowControlExact
+    demo-header-prefix: |
+      matches:
+        - apiPath:
+            exact: "/header"
+          headers:
+            key:
+              prefix: flowControlPrefix
+    demo-header-suffix: |
+      matches:
+        - apiPath:
+            exact: "/header"
+          headers:
+            key:
+              suffix: flowControlSuffix
+    demo-header-contains: |
+      matches:
+        - apiPath:
+            exact: "/header"
+          headers:
+            key:
+              contains: flowControlContains
+    demo-header-compare: |
+      matches:
+        - apiPath:
+            exact: "/header"
+          headers:
+            key:
+              compare: ">100"
     demo-circuitBreaker-serviceName-match: |
       matches:
         - apiPath:
@@ -62,7 +102,21 @@ servicecomb:
   rateLimiting:
     demo-rateLimiting: |
       rate: 1
+    demo-rateLimiting-prefix: |
+      rate: 1
+    demo-rateLimiting-suffix: |
+      rate: 1
+    demo-rateLimiting-contains: |
+      rate: 1
     demo-header: |
+      rate: 1
+    demo-header-prefix: |
+      rate: 1
+    demo-header-suffix: |
+      rate: 1
+    demo-header-contains: |
+      rate: 1
+    demo-header-compare: |
       rate: 1
   retry:
     demo-retry: |

--- a/sermant-integration-tests/spring-test/spring-common/src/main/java/com/huaweicloud/spring/common/flowcontrol/consumer/ServerController.java
+++ b/sermant-integration-tests/spring-test/spring-common/src/main/java/com/huaweicloud/spring/common/flowcontrol/consumer/ServerController.java
@@ -45,6 +45,9 @@ import javax.annotation.PostConstruct;
 @ResponseBody
 @RequestMapping("/flowcontrol")
 public class ServerController {
+    private static final String RATE_LIMITING_API = "rateLimiting";
+    private static final String HEADER_API = "header";
+
     @Value("${down.serviceName}")
     private String downServiceName;
 
@@ -66,7 +69,37 @@ public class ServerController {
      */
     @RequestMapping("rateLimiting")
     public String rateLimiting() {
-        return restTemplate.getForObject(buildUrl("rateLimiting"), String.class);
+        return restTemplate.getForObject(buildUrl(RATE_LIMITING_API), String.class);
+    }
+
+    /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("prefixRateLimiting")
+    public String rateLimitingPrefix() {
+        return restTemplate.getForObject(buildUrl(RATE_LIMITING_API), String.class);
+    }
+
+    /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("rateLimitingContains")
+    public String rateLimitingContains() {
+        return restTemplate.getForObject(buildUrl(RATE_LIMITING_API), String.class);
+    }
+
+    /**
+     * 限流测试
+     *
+     * @return ok
+     */
+    @RequestMapping("rateLimitingSuffix")
+    public String rateLimitingSuffix() {
+        return restTemplate.getForObject(buildUrl(RATE_LIMITING_API), String.class);
     }
 
     /**
@@ -106,12 +139,66 @@ public class ServerController {
      */
     @RequestMapping("header")
     public String header() {
+        return reqHeader("flowControlExact");
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerPrefix")
+    public String headerPrefix() {
+        return reqHeader("flowControlPrefix");
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerSuffix")
+    public String headerSuffix() {
+        return reqHeader("flowControlSuffix");
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerContains")
+    public String headerContains() {
+        return reqHeader("flowControlContains");
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareMatch")
+    public String headerCompareMatch() {
+        return reqHeader("101");
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareNotMatch")
+    public String headerCompareNotMatch() {
+        return reqHeader("100");
+    }
+
+    private String reqHeader(String value) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("key", "header1");
+        headers.set("key", value);
         headers.set("contentType", "application/json;charset=UTF-8");
         HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity(null, headers);
 
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(buildUrl("header"));
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(buildUrl(HEADER_API));
         return restTemplate.exchange(builder.build().toString(), HttpMethod.GET, request, String.class).getBody();
     }
 

--- a/sermant-integration-tests/spring-test/spring-common/src/main/java/com/huaweicloud/spring/common/flowcontrol/provider/ProviderController.java
+++ b/sermant-integration-tests/spring-test/spring-common/src/main/java/com/huaweicloud/spring/common/flowcontrol/provider/ProviderController.java
@@ -103,6 +103,66 @@ public class ProviderController {
     }
 
     /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerExact")
+    public String headerExact() {
+        return Constants.HTTP_OK;
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerPrefix")
+    public String headerPrefix() {
+        return Constants.HTTP_OK;
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerSuffix")
+    public String headerSuffix() {
+        return Constants.HTTP_OK;
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerContains")
+    public String headerContains() {
+        return Constants.HTTP_OK;
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareMatch")
+    public String headerCompareMatch() {
+        return Constants.HTTP_OK;
+    }
+
+    /**
+     * 请求头匹配测试
+     *
+     * @return ok
+     */
+    @RequestMapping("headerCompareNotMatch")
+    public String headerCompareNotMatch() {
+        return Constants.HTTP_OK;
+    }
+
+    /**
      * 匹配服务名
      *
      * @return ok

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/flowcontrol/FlowControlTest.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/flowcontrol/FlowControlTest.java
@@ -54,6 +54,9 @@ public abstract class FlowControlTest {
     @Test
     public void testServerRateLimiting() {
         process("/rateLimiting", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+        process("/prefixRateLimiting", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+        process("/rateLimitingContains", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+        process("/rateLimitingSuffix", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
     }
 
     /**
@@ -127,6 +130,16 @@ public abstract class FlowControlTest {
     @Test
     public void testMatchHeader() {
         process("/header", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+        process("/headerPrefix", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+        process("/headerSuffix", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+        process("/headerContains", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+        process("/headerCompareMatch", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, null);
+
+        final AtomicBoolean checkNotMatch = new AtomicBoolean();
+        process("/headerCompareNotMatch", RATE_LIMITING_MSG, RATE_LIMITING_REQUEST_COUNT, checkNotMatch);
+        if (checkNotMatch.get()) {
+            Assert.fail();
+        }
     }
 
     /**

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DynamicServerListInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DynamicServerListInterceptor.java
@@ -16,6 +16,7 @@
 
 package com.huawei.registry.interceptors;
 
+import com.huawei.registry.config.RegisterDynamicConfig;
 import com.huawei.registry.context.RegisterContext;
 import com.huawei.registry.entity.MicroServiceInstance;
 import com.huawei.registry.entity.ScServer;
@@ -61,7 +62,8 @@ public class DynamicServerListInterceptor extends RegisterSwitchSupport {
     private List<Server> convertAndMerge(DynamicServerListLoadBalancer<Server> serverListLoadBalancer,
             List<MicroServiceInstance> microServiceInstances) {
         final List<Server> result = new ArrayList<>(microServiceInstances.size());
-        if (RegisterContext.INSTANCE.isAvailable()) {
+        if (RegisterContext.INSTANCE.isAvailable()
+                && !RegisterDynamicConfig.INSTANCE.isNeedCloseOriginRegisterCenter()) {
             result.addAll(queryOriginServers(serverListLoadBalancer));
         }
         for (MicroServiceInstance microServiceInstance : microServiceInstances) {


### PR DESCRIPTION
What type of PR is this?

/feat

Which issue(s) this PR fixes:

Fixes #1049 

1. Add apiPath and header match type auto test
2. Add auto test which close springcloud origin registry center dynamically at mode migration
3. Fix the probelm that service discovery can not shield origin registry center when publish close configuration for springcloud registry migration mode

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No
