### PR TITLE
【fix】Can not check the heartbeat for nacos register in migration mode of SpringCloud registry plugin

### DIFF
--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/NacosRpcClientHealthDeclarer.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/declarers/health/NacosRpcClientHealthDeclarer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,31 +17,31 @@
 package com.huawei.registry.declarers.health;
 
 import com.huawei.registry.declarers.AbstractDoubleRegistryDeclarer;
-import com.huawei.registry.interceptors.health.NacosHealthInterceptor;
+import com.huawei.registry.interceptors.health.NacosRpcClientHealthInterceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
 
 /**
- * nacos健康检测增强  NamingProxy 1.x版本, NamingHttpClientProxy 2.x版本
+ * nacos 2.x
+ * 拦截com.alibaba.nacos.common.remote.client.RpcClient健康检查方法, 判断注册中心是否存活, 并监听注册订阅配置下发
  *
  * @author zhouss
- * @since 2021-12-17
+ * @since 2022-12-20
  */
-public class NacosHealthDeclarer extends AbstractDoubleRegistryDeclarer {
+public class NacosRpcClientHealthDeclarer extends AbstractDoubleRegistryDeclarer {
     /**
      * nacos心跳发送类
      */
     private static final String[] ENHANCE_CLASSES = new String[] {
-        "com.alibaba.nacos.client.naming.net.NamingProxy",
-        "com.alibaba.nacos.client.naming.remote.http.NamingHttpClientProxy"
+        "com.alibaba.nacos.common.remote.client.RpcClient"
     };
 
     /**
      * 拦截类的全限定名
      */
-    private static final String INTERCEPT_CLASS = NacosHealthInterceptor.class.getCanonicalName();
+    private static final String INTERCEPT_CLASS = NacosRpcClientHealthInterceptor.class.getCanonicalName();
 
     @Override
     public ClassMatcher getClassMatcher() {
@@ -51,7 +51,7 @@ public class NacosHealthDeclarer extends AbstractDoubleRegistryDeclarer {
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-            InterceptDeclarer.build(MethodMatcher.nameEquals("sendBeat"), INTERCEPT_CLASS)
+            InterceptDeclarer.build(MethodMatcher.nameEquals("healthCheck"), INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosGrpcDeRegisterInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosGrpcDeRegisterInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.registry.interceptors.health;
+
+import com.huawei.registry.support.RegisterSwitchSupport;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * 调用反注册前，判断RpcClient状态, shutdown状态不再进行反注册; 已经由{@link NacosRpcClientHealthInterceptor}关闭, 自动从注册中心下线
+ *
+ * @author zhouss
+ * @since 2022-12-20
+ */
+public class NacosGrpcDeRegisterInterceptor extends RegisterSwitchSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        final Optional<Object> rpcClient = ReflectUtils.getFieldValue(context.getObject(), "rpcClient");
+        if (!rpcClient.isPresent()) {
+            return context;
+        }
+        final Object client = rpcClient.get();
+        final Optional<Object> isShutdownRaw = ReflectUtils.invokeMethod(client, "isShutdown", null, null);
+        if (isShutdownRaw.isPresent() && isShutdownRaw.get() instanceof Boolean) {
+            boolean isShutdown = (boolean) isShutdownRaw.get();
+            if (isShutdown) {
+                LOGGER.info("RpcClient has been shutdown, skip deregister operation!");
+                context.skip(null);
+            }
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosHealthInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosHealthInterceptor.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.logging.Logger;
 
 /**
- * 注册中心健康状态变更
+ * 注册中心健康状态变更, 针对nacos1.x, nacos2.x http协议
  *
  * @author zhouss
  * @since 2021-12-13

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosRpcClientHealthInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/health/NacosRpcClientHealthInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.registry.interceptors.health;
+
+import com.huawei.registry.context.RegisterContext;
+import com.huawei.registry.handler.SingleStateCloseHandler;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import java.util.logging.Logger;
+
+/**
+ * 注册中心健康状态变更, 针对nacos2.x, Grpc协议
+ *
+ * @author zhouss
+ * @since 2022-12-20
+ */
+public class NacosRpcClientHealthInterceptor extends SingleStateCloseHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    protected void close() {
+        // 关闭nacos心跳发送
+        ReflectUtils.invokeMethod(target, "shutdown", null, null);
+        LOGGER.warning("Nacos heartbeat has been closed by user.");
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        checkState(context, null);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext doAfter(ExecuteContext context) {
+        final Object result = context.getResult();
+        if (result instanceof Boolean) {
+            boolean health = (boolean) result;
+            if (health) {
+                RegisterContext.INSTANCE.compareAndSet(false, true);
+                LOGGER.info("Nacos registry center recover healthy status!");
+            } else {
+                RegisterContext.INSTANCE.compareAndSet(true, false);
+                LOGGER.info("Nacos registry center may be unhealthy!");
+            }
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -25,6 +25,8 @@ com.huawei.registry.declarers.cloud3.x.ZookeeperInstanceSupplierDeclarer
 # health
 com.huawei.registry.declarers.health.ConsulWatchConDeclarer
 com.huawei.registry.declarers.health.NacosHealthDeclarer
+com.huawei.registry.declarers.health.NacosRpcClientHealthDeclarer
+com.huawei.registry.declarers.health.NacosGrpcProxyDeregisterDeclarer
 com.huawei.registry.declarers.health.ZookeeperHealthDeclarer
 com.huawei.registry.declarers.health.ConsulHealthDeclarer
 com.huawei.registry.declarers.health.ScheduleProcessorDeclared

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/NacosGrpcDeRegisterInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/NacosGrpcDeRegisterInterceptorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.registry.interceptors.health;
+
+import com.huawei.registry.config.RegisterConfig;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * 反注册状态判断测试
+ *
+ * @author zhouss
+ * @since 2022-12-20
+ */
+public class NacosGrpcDeRegisterInterceptorTest {
+    private final RegisterConfig registerConfig = new RegisterConfig();
+
+    private MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
+
+    @Before
+    public void setUp() throws Exception {
+        pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class);
+        pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(RegisterConfig.class))
+                .thenReturn(registerConfig);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        pluginConfigManagerMockedStatic.close();
+    }
+
+    @Test
+    public void test() throws NoSuchMethodException {
+        final NacosGrpcDeRegisterInterceptor interceptor = new NacosGrpcDeRegisterInterceptor();
+        final ExecuteContext context = buildContext(new NacosGrpcProxy1());
+        final ExecuteContext context1 = interceptor.doBefore(context);
+        Assert.assertFalse(context1.isSkip());
+        final ExecuteContext context2 = buildContext(new NacosRealGrpcProxy());
+        final ExecuteContext context3 = interceptor.doBefore(context2);
+        Assert.assertFalse(context3.isSkip());
+        final NacosRealGrpcProxy nacosRealGrpcProxy = new NacosRealGrpcProxy();
+        nacosRealGrpcProxy.rpcClient.isShutdown = true;
+        final ExecuteContext context4 = buildContext(nacosRealGrpcProxy);
+        final ExecuteContext context5 = interceptor.doBefore(context4);
+        Assert.assertTrue(context5.isSkip());
+    }
+
+    private ExecuteContext buildContext(Object target) throws NoSuchMethodException {
+        return ExecuteContext.forMemberMethod(target, String.class.getDeclaredMethod("trim"), new Object[0],
+                null, null);
+    }
+
+    static class NacosGrpcProxy1 {
+
+    }
+
+    static class NacosRealGrpcProxy {
+        RpcClient rpcClient = new RpcClient();
+    }
+
+    static class RpcClient {
+        boolean isShutdown = false;
+
+        boolean isShutdown() {
+            return isShutdown;
+        }
+    }
+}

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/NacosRpcClientHealthInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/NacosRpcClientHealthInterceptorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.registry.interceptors.health;
+
+import static org.junit.Assert.*;
+
+import com.huawei.registry.config.RegisterConfig;
+import com.huawei.registry.context.RegisterContext;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * 测试基于心跳检测注册中心状态
+ *
+ * @author zhouss
+ * @since 2022-12-20
+ */
+public class NacosRpcClientHealthInterceptorTest {
+    private final RegisterConfig registerConfig = new RegisterConfig();
+
+    private MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
+
+    @Before
+    public void setUp() throws Exception {
+        pluginConfigManagerMockedStatic = Mockito.mockStatic(PluginConfigManager.class);
+        pluginConfigManagerMockedStatic.when(() -> PluginConfigManager.getPluginConfig(RegisterConfig.class))
+                .thenReturn(registerConfig);
+        RegisterContext.INSTANCE.setAvailable(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        pluginConfigManagerMockedStatic.close();
+        RegisterContext.INSTANCE.setAvailable(true);
+    }
+
+    @Test
+    public void close() throws NoSuchMethodException {
+        final NacosRpcClientHealthInterceptor interceptor = new NacosRpcClientHealthInterceptor();
+        final RpcClient rpcClient = Mockito.mock(RpcClient.class);
+        interceptor.doBefore(buildContext(rpcClient));
+        interceptor.close();
+        Mockito.verify(rpcClient, Mockito.times(1)).shutdown();
+    }
+
+    @Test
+    public void doAfter() throws NoSuchMethodException {
+        final NacosRpcClientHealthInterceptor interceptor = new NacosRpcClientHealthInterceptor();
+        final ExecuteContext context = buildContext(new Object());
+        interceptor.doAfter(context);
+        Assert.assertFalse(context.isSkip());
+        final ExecuteContext context1 = buildContext(new Object());
+        context1.changeResult(Boolean.FALSE);
+        interceptor.doAfter(context1);
+        Assert.assertFalse(RegisterContext.INSTANCE.isAvailable());
+        final ExecuteContext context2 = buildContext(new Object());
+        context2.changeResult(Boolean.TRUE);
+        interceptor.doAfter(context2);
+        Assert.assertTrue(RegisterContext.INSTANCE.isAvailable());
+    }
+
+    private ExecuteContext buildContext(Object target) throws NoSuchMethodException {
+        return ExecuteContext.forMemberMethod(target, String.class.getDeclaredMethod("trim"), new Object[0],
+                null, null);
+    }
+
+    interface RpcClient {
+        void shutdown();
+    }
+}


### PR DESCRIPTION
What type of PR is this?

/feat

Which issue(s) this PR fixes:

Fixes #1051

Fix the problem that spring cloud registry plugin can not stop heartbeat to nacos registry center when in migration mode.

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No

Test Steps:
1. Start up a consumer and two providers, the consumer and one provider start with migration mode,  another provider just register to nacos registry center. The registry result follow:
**Nacos**
![image](https://user-images.githubusercontent.com/28865848/208633299-de7c2338-52fb-4658-9fee-289669f11451.png)
**CSE**
![image](https://user-images.githubusercontent.com/28865848/208632032-075db10b-09bf-476a-abf8-a0264f485ec0.png)

2.  Publish dynamic close config, as follow:
![image](https://user-images.githubusercontent.com/28865848/208632221-59c172bd-8d4e-4cda-b496-7a09ffcee63c.png)
3. The check the consumer and provider which started with migiration mode, we can see only origin provider keep:
![image](https://user-images.githubusercontent.com/28865848/208632491-dd0ec72d-c2e6-434f-b13c-27016d216c60.png)

