### PR TITLE
【feature】支持injector通过helm模版配置环境变量

### DIFF
--- a/sermant-injector/deployment/release/injector/templates/sermant-agent-env-configmap.yaml
+++ b/sermant-injector/deployment/release/injector/templates/sermant-agent-env-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sermant-agent-env
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app: sermant-agent-env
+data:
+  {{- range $key,$value := .Values.env }}
+  {{ $key }}: "{{ $value }}"
+  {{- end }}

--- a/sermant-injector/deployment/release/injector/values.yaml
+++ b/sermant-injector/deployment/release/injector/values.yaml
@@ -32,3 +32,9 @@ config:
 registry:
   # 注册中心地址
   endpoints: http://localhost:30100
+
+# 支持配置Sermant的环境变量(key相同的情况下该处配置的优先级低于yaml中env的配置), 配置方式如下:
+# env:
+#   TEST_ENV1: abc
+#   TEST_ENV2: 123456
+env:

--- a/sermant-injector/src/main/java/com/huaweicloud/sermant/injection/controller/SermantInjectorController.java
+++ b/sermant-injector/src/main/java/com/huaweicloud/sermant/injection/controller/SermantInjectorController.java
@@ -184,7 +184,7 @@ public class SermantInjectorController {
     @Value("${sermant-agent.mount.path:/home/sermant-agent}")
     private String mountPath;
 
-    @Value("${sermant-agent.configMap:}")
+    @Value("${sermant-agent.configMap:sermant-agent-env}")
     private String envFrom;
 
     @Value("${sermant-agent.config.type:ZOOKEEPER}")

--- a/sermant-injector/src/main/resources/application.yml
+++ b/sermant-injector/src/main/resources/application.yml
@@ -30,6 +30,8 @@ sermant-agent:
   service:
     # agent注册中心地址
     address: http://localhost:30100
+  # sermant-agent 配置环境变量的configMap的名字
+  configMap: sermant-agent-env
 
 management:
   endpoint:


### PR DESCRIPTION
【修复issue】#1055

【修改内容】支持injector通过helm模版配置环境变量
1. 新增sermant-agent-env-configmap.yaml用于从values.yaml中读取自定义的环境变量
2. injector通过envFrom的方式注入sermant-agent-env-configmap.yaml中的环境变量

【用例描述】无

【自测情况】1、本地静态检查通过；2、本地搭载容器环境启动injector部署宿主应用验证环境变量生效

【影响范围】用户可从values.yaml中的env变量下自由配置Sermant所需环境变量
