### PR TITLE
【fix】修复某些服务加载失败问题导致宿主应用无法正常提供服务

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/AbstractGroupConfigSubscriber.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/AbstractGroupConfigSubscriber.java
@@ -24,6 +24,7 @@ import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigLi
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * 配置订阅
@@ -32,7 +33,9 @@ import java.util.Map;
  * @since 2022-04-13
  */
 public abstract class AbstractGroupConfigSubscriber implements ConfigSubscriber {
-    private final DynamicConfigService dynamicConfigService;
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private DynamicConfigService dynamicConfigService;
 
     /**
      * 订阅的插件名称
@@ -56,7 +59,13 @@ public abstract class AbstractGroupConfigSubscriber implements ConfigSubscriber 
      */
     protected AbstractGroupConfigSubscriber(DynamicConfigService dynamicConfigService, String pluginName) {
         if (dynamicConfigService == null) {
-            this.dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+            try {
+                this.dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+            } catch (IllegalArgumentException e) {
+                LOGGER.severe("dynamicConfigService is not enabled!");
+                this.dynamicConfigService = null;
+            }
+
         } else {
             this.dynamicConfigService = dynamicConfigService;
         }
@@ -65,6 +74,10 @@ public abstract class AbstractGroupConfigSubscriber implements ConfigSubscriber 
 
     @Override
     public boolean subscribe() {
+        if (dynamicConfigService == null) {
+            LOGGER.severe("dynamicConfigService is null, fail to subscribe!");
+            return false;
+        }
         if (!isReady()) {
             LoggerFactory.getLogger().warning("The group subscriber is not ready, may be service name is null");
             return false;

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/auto/sc/ServiceCombRegistry.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/auto/sc/ServiceCombRegistry.java
@@ -50,12 +50,22 @@ public class ServiceCombRegistry implements ServiceRegistry<ServiceCombRegistrat
         GraceHelper.configWarmUpParams(registration.getMetadata(),
                 PluginConfigManager.getPluginConfig(GraceConfig.class));
         ZoneUtils.setZone(registration.getMetadata());
-        getRegisterCenterService().register(new FixedResult());
+        RegisterCenterService registerService = getRegisterCenterService();
+        if (registerService == null) {
+            LOGGER.severe("registerCenterService is null, fail to register!");
+            return;
+        }
+        registerService.register(new FixedResult());
     }
 
     @Override
     public void deregister(ServiceCombRegistration registration) {
-        getRegisterCenterService().unRegister();
+        RegisterCenterService registerService = getRegisterCenterService();
+        if (registerService == null) {
+            LOGGER.severe("registerCenterService is null, fail to unRegister!");
+            return;
+        }
+        registerService.unRegister();
     }
 
     @Override
@@ -65,7 +75,12 @@ public class ServiceCombRegistry implements ServiceRegistry<ServiceCombRegistrat
 
     @Override
     public void setStatus(ServiceCombRegistration registration, String status) {
-        getRegisterCenterService().updateInstanceStatus(status);
+        RegisterCenterService registerService = getRegisterCenterService();
+        if (registerService == null) {
+            LOGGER.severe("registerCenterService is null, fail to update instance status!");
+            return;
+        }
+        registerService.updateInstanceStatus(status);
     }
 
     @Override
@@ -75,7 +90,11 @@ public class ServiceCombRegistry implements ServiceRegistry<ServiceCombRegistrat
 
     private RegisterCenterService getRegisterCenterService() {
         if (registerCenterService == null) {
-            registerCenterService = PluginServiceManager.getPluginService(RegisterCenterService.class);
+            try {
+                registerCenterService = PluginServiceManager.getPluginService(RegisterCenterService.class);
+            } catch (IllegalArgumentException e) {
+                LOGGER.severe("registerCenterService is not enabled!");
+            }
         }
         return registerCenterService;
     }


### PR DESCRIPTION
【修复issue】#1059

【修改内容】针对可靠性测试结果，修复以下问题：
1. dynamicConfigService加载失败或者配置在黑名单列表中导致宿主服务无法运行，修复该问题
2. graceServcie加载失败导致宿主服务无法运行，修复该问题
3. registerCenterService加载失败导致宿主服务无法运行，修复该问题

【用例描述】1、将dynamicConfigService加入黑名单并删除graceServcie，registerCenterService服务所在jar包；2、挂载流控插件和注册插件启动应用；3、测试验证宿主应用正常提供服务

【自测情况】1、本地静态检查通过；2、本地自验通过
修复前：
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/46025350/209091350-4d230635-301f-43cb-a3af-14164d2c9fd8.png">
修复后：
<img width="1376" alt="image" src="https://user-images.githubusercontent.com/46025350/209095393-058d060a-8459-4568-b7d2-2d11a6ae8bfc.png">

【影响范围】无