### PR TITLE
PR for #1037, 容器部署场景下，希望能通过annotation的方式配置治理所需的kv属性或者标签 

### DIFF
--- a/sermant-injector/src/test/java/com/huaweicloud/sermant/injection/controller/SermantInjectorControllerTest.java
+++ b/sermant-injector/src/test/java/com/huaweicloud/sermant/injection/controller/SermantInjectorControllerTest.java
@@ -12,6 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Iterator;
 
 /**
  * controller单元测试
@@ -33,5 +36,25 @@ public class SermantInjectorControllerTest {
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(response.getResponse());
         Assertions.assertTrue(response.getResponse().isAllowed());
+
+        // Test Annotations environment feature.
+        byte[] decodedBytes = Base64.getDecoder().decode(response.getResponse().getPatch());
+        String decodedString = new String(decodedBytes);
+        JsonNode rs = mapper.readTree(decodedString);
+        Iterator<JsonNode> iter = rs.elements();
+        while ( iter.hasNext() )
+        {
+            JsonNode node = iter.next();
+            if (node.get("path").asText().equals("/spec/containers/0/env"))
+            {
+                JsonNode jn = node.findValue("value");
+                Assertions.assertTrue(jn.toString().indexOf("key1") > 0);
+                break;
+            }
+            if ( iter.hasNext() == false )
+            {
+                Assertions.fail("should not get here");
+            }
+        }
     }
 }

--- a/sermant-injector/src/test/resources/test.json
+++ b/sermant-injector/src/test/resources/test.json
@@ -46,7 +46,9 @@
           "sermant-injection": "enabled"
         },
         "annotations": {
-          "kubernetes.io/psp": "psp-global"
+          "kubernetes.io/psp": "psp-global",
+          "env.sermant.io/key1": "value1",
+          "env.sermant.io/key2": "value2"
         },
         "ownerReferences": [
           {


### PR DESCRIPTION
【修复issue】 #1037
【feature】容器部署场景下，希望能通过annotation的方式配置治理所需的kv属性或者标签 

【修改内容】
增加Controller通过识别对应annotation属性，来增加对env的支持

【用例描述】是否需要修改用例？原因？/ 不增加用例的原因?
不需要。已在单元测试中覆盖。

【自测情况】
在测试环境中增加了label属性，根据测试，发现可以将结果注入到对应环境变量中。

【影响范围】
需要增加API文档，说明该功能。
