### PR TITLE
【question】Nacos注册实例增加parameters作为标签路由内容

### DIFF
--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/NacosRegistryServiceImpl.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/NacosRegistryServiceImpl.java
@@ -20,6 +20,7 @@ package com.huawei.dubbo.registry.service;
 import com.huawei.dubbo.registry.entity.NacosServiceName;
 import com.huawei.dubbo.registry.listener.NacosAggregateListener;
 import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
+import com.huawei.dubbo.registry.utils.CollectionUtils;
 import com.huawei.dubbo.registry.utils.NacosInstanceManageUtil;
 import com.huawei.dubbo.registry.utils.NamingServiceUtils;
 import com.huawei.dubbo.registry.utils.ReflectUtils;
@@ -260,6 +261,9 @@ public class NacosRegistryServiceImpl implements NacosRegistryService {
         if (serviceMeta != null) {
             metaData.put(SERVICE_META_VERSION, serviceMeta.getVersion());
             metaData.put(SERVICE_META_ZONE, serviceMeta.getZone());
+            if (!CollectionUtils.isEmpty(serviceMeta.getParameters())) {
+                metaData.putAll(serviceMeta.getParameters());
+            }
         }
         Instance instance = new Instance();
         instance.setIp(ReflectUtils.getHost(url));


### PR DESCRIPTION
【修复issue】#1062

【修改内容】注册nacos实例信息增加ServiceMeta中的parameters

【用例描述】不需要修改用例。
【自测情况】1、本地静态检查清理情况；

【影响范围】1、dubbo注册Nacos实例标签路由能力

