### PR TITLE
【enhance】优化injector helm模板，支持挂载多个命名空间的通用环境变量

### DIFF
--- a/sermant-injector/deployment/release/injector/templates/sermant-agent-env-configmap.yaml
+++ b/sermant-injector/deployment/release/injector/templates/sermant-agent-env-configmap.yaml
@@ -1,11 +1,16 @@
+{{- if and .Values.configMap.enabled .Values.configMap.namespaces }}
+{{- range .Values.configMap.namespaces }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sermant-agent-env
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ . }}
   labels:
     app: sermant-agent-env
 data:
-  {{- range $key,$value := .Values.env }}
+  {{- range $key,$value := $.Values.configMap.env }}
   {{ $key }}: "{{ $value }}"
   {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/sermant-injector/deployment/release/injector/templates/sermant-injector-configmap.yaml
+++ b/sermant-injector/deployment/release/injector/templates/sermant-injector-configmap.yaml
@@ -16,3 +16,6 @@ data:
   SERMANT_AGENT_IMAGE_ADDR: {{ .Values.agent.image.addr }}
   # agent镜像拉取策略
   SERMANT_AGENT_IMAGE_PULLPOLICY: {{ .Values.agent.image.pullPolicy }}
+  {{- if not (and .Values.configMap.enabled .Values.configMap.namespaces) }}
+  SERMANT_AGENT_CONFIGMAP: ""
+  {{- end }}

--- a/sermant-injector/deployment/release/injector/values.yaml
+++ b/sermant-injector/deployment/release/injector/values.yaml
@@ -29,8 +29,14 @@ registry:
   # 注册中心地址
   endpoints: http://localhost:30100
 
-# 支持配置Sermant的环境变量(key相同的情况下该处配置的优先级低于yaml中env的配置), 配置方式如下:
-# env:
-#   TEST_ENV1: abc
-#   TEST_ENV2: 123456
-env:
+# 支持配置业务应用通用的环境变量(key相同的情况下该处配置的优先级低于yaml中env的配置)
+configMap:
+  # 是否开启注入configMap
+  enabled: false
+  # 注入configMap的namespace，需要与业务应用的namespace保持一致
+  namespaces: [default]
+  # 配置方式如下:
+  # env:
+  #   TEST_ENV1: abc
+  #   TEST_ENV2: 123456
+  env:


### PR DESCRIPTION
【修复issue】 #1055 

【修改内容】支持injector通过helm模版挂载多个命名空间的通用环境变量

修改sermant-agent-env-configmap.yaml用于从values.yaml中读取自定义的环境变量，并指定命名空间
injector通过envFrom的方式注入sermant-agent-env-configmap.yaml中的环境变量
【用例描述】无

【自测情况】1、本地静态检查通过；2、本地搭载容器环境启动injector部署宿主应用验证环境变量生效

【影响范围】用户可从values.yaml中的env变量下自由配置Sermant所需环境变量