### PR TITLE
【feature】事件上报实体定义

### DIFF
--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/AgentInstanceMeta.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/AgentInstanceMeta.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 事件原数据
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class AgentInstanceMeta {
+
+    /**
+     * 实例原数据哈希
+     */
+    private String metaHash;
+
+    /**
+     * 实例ID
+     */
+    private String instanceId;
+
+    /**
+     * 应用
+     */
+    private String application;
+
+    /**
+     * 节点
+     */
+    private AgentNodeEntity node;
+
+    /**
+     * 集群
+     */
+    private String cluster;
+
+    /**
+     * 环境
+     */
+    private String environment;
+
+    /**
+     * 可用区
+     */
+    private String az;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/AgentNodeEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/AgentNodeEntity.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 实例节点数据
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class AgentNodeEntity {
+
+    /**
+     * 实例ip
+     */
+    private String ip;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/DingDingEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/DingDingEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashMap;
+
+/**
+ * 钉钉推送事件实体
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class DingDingEntity {
+    private String msgtype;
+    private HashMap<String, String> text;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/DingDingMessageType.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/DingDingMessageType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+/**
+ * 钉钉推送支持的数据类型
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public enum DingDingMessageType {
+
+    Text {
+        public String toString() {
+            return "text";
+        }
+    },
+    LINK {
+        public String toString() {
+            return "link";
+        }
+    },
+    MARKDOWN {
+        public String toString() {
+            return "markdown";
+        }
+    },
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventEntity.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 事件信息
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class EventEntity {
+    /**
+     * 实例元数据
+     */
+    private String meta;
+
+    /**
+     * 事件等级
+     */
+    private EventLevel level;
+
+    /**
+     * 事件类型
+     */
+    private EventType type;
+
+    /**
+     * 触发时间
+     */
+    private long time;
+
+    /**
+     * 事件区域
+     */
+    private String scope;
+
+    /**
+     * 事件信息
+     */
+    private EventMessageEntity info;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventLevel.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventLevel.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+/**
+ * 事件等级
+ *
+ * @author xuezechao
+ * @since 2023-03-02
+ */
+public enum EventLevel {
+
+    /**
+     * 紧急
+     */
+    EMERGENCY(100),
+
+    /**
+     * 重要
+     */
+    IMPORTANT(200),
+
+    /**
+     * 一般
+     */
+    NORMAL(300);
+
+    EventLevel(int i) {
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventMessageEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventMessageEntity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 事件信息
+ *
+ * @author xuezechao
+ * @since 2023-03-02
+ */
+@Getter
+@Setter
+public class EventMessageEntity {
+    private String eventName;
+    private String eventDetail;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventResponseCountEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventResponseCountEntity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 事件查询结果分类
+ *
+ * @author xuezechao
+ * @since 2023-03-02
+ */
+@Getter
+@Setter
+public class EventResponseCountEntity {
+    private int emergency;
+    private int important;
+    private int normal;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventType.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+/**
+ * 事件类型
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public enum EventType {
+    /**
+     * 运行事件
+     */
+    OPERATION("operation"),
+
+    /**
+     * 治理事件
+     */
+    GOVERNANCE("governance"),
+
+    /**
+     * 日志事件
+     */
+    LOG("log");
+
+    EventType(String str) {
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventsRequestEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventsRequestEntity.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 事件查询请求实体
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class EventsRequestEntity {
+
+    private String application;
+
+    private String ip;
+
+    private String scope;
+
+    private String type;
+
+    private String level;
+
+    private long startTime;
+
+    private long endTime;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventsResponseEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/EventsResponseEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 事件查询响应实体
+ *
+ * @author xuezechao
+ * @since 2023-03-02
+ */
+@Getter
+@Setter
+public class EventsResponseEntity {
+
+    private int total;
+    private List<EventEntity> eventEntities;
+    private EventResponseCountEntity eventCount;
+    private int pageNum;
+    private int pageSize;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/FeiShuEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/FeiShuEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashMap;
+
+/**
+ * 飞书推送事件实体
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class FeiShuEntity {
+    private String msg_type;
+    private HashMap<String, String> content;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/FeiShuMessageType.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/FeiShuMessageType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+/**
+ * 飞书支持的支持的数据类型
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public enum FeiShuMessageType {
+
+    /**
+     * 文本
+     */
+    TEXT {
+        public String toString() {
+            return "text";
+        }
+    },
+
+    /**
+     * 富文本
+     */
+    POST {
+        public String toString() {
+            return "post";
+        }
+    },
+
+    /**
+     * 消息卡片
+     */
+    INTERACTIVE {
+        public String toString() {
+            return "interactive";
+        }
+    },
+}


### PR DESCRIPTION
【修复issue】#1099
【修改内容】

增加以下实体定义：
- agent实例元数据：**AgentInstanceMeta**
- agent节点：**AgentNode**
- 事件：**EventEntity**
- 事件等级：**EventLevel**
- 事件信息：**EventMessage**
- 事件类型：**EventType**
- 钉钉推送：**DingDingEntity**
- 飞书推送：**FeishuEntity**
- 钉钉支持的数据类型：**DingDingMesaageType**
- 飞书支持的数据类型：**FeishuMessageType**
- 事件查询请求：**EventRequestEntity**
- 事件查询响应：**EventRsponseEntity**
- 事件查询计数：**EventResponseCountEntity**
- webhook查询响应：**WebhooksResponse**
- webhook设置请求：**WebhooksIdRequest**


【用例描述】不需测试用例

【自测情况】本地检查通过

【影响范围】1、对用户的使用无影响