### PR TITLE
【featrue】事件上报webhook

### DIFF
--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/WebhooksIdRequestEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/WebhooksIdRequestEntity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * webhook设置请求实体
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class WebhooksIdRequestEntity {
+
+    /**
+     * webhook 地址
+     */
+    private String url;
+
+    /**
+     * webhook 状态
+     */
+    private boolean enable;
+
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/WebhooksResponseEntity.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/entity/WebhooksResponseEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.entity;
+
+import com.huawei.sermant.backend.webhook.WebHookConfig;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * webhook信息查询响应实体
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+@Getter
+@Setter
+public class WebhooksResponseEntity {
+
+    /**
+     * webhook 数量
+     */
+    Integer total;
+
+    /**
+     * webhook 配置
+     */
+    List<WebHookConfig> webhooks;
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/EventPushHandler.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/EventPushHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook;
+
+import com.huawei.sermant.backend.entity.EventEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * 事件推送
+ *
+ * @author xuezechao
+ * @since 2023-03-02
+ */
+public class EventPushHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventPushHandler.class);
+
+    private List<WebHookClient> webHookClients = new ArrayList<>();
+
+    public EventPushHandler() {
+        init();
+    }
+
+    /**
+     * 初始化webhook
+     */
+    public void init() {
+        ServiceLoader<WebHookClient> loader = ServiceLoader.load(WebHookClient.class);
+        for (WebHookClient webHookClient : loader) {
+            webHookClients.add(webHookClient);
+        }
+    }
+
+    /**
+     * 推送事件
+     *
+     * @param eventEntities 事件信息
+     */
+    public void pushEvent(List<EventEntity> eventEntities) {
+        if (eventEntities.size() <= 0) {
+            LOGGER.error("push event failed, the size of event message is: 0");
+            return;
+        }
+        for (WebHookClient webHookClient : webHookClients) {
+            if (webHookClient.getConfig().getEnable()) {
+                if (!webHookClient.doNotify(eventEntities)) {
+                    // 推送失败
+                    LOGGER.error(String.format("push event to webhook:{%s} failed!", webHookClient.getConfig().getName()));
+                }
+            }
+        }
+    }
+
+    /**
+     * 获取webhook客户端
+     *
+     * @return webhook客户端
+     */
+    public List<WebHookClient> getWebHookClients() {
+        return webHookClients;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/WebHookClient.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/WebHookClient.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook;
+
+import com.huawei.sermant.backend.entity.EventEntity;
+
+import java.util.List;
+
+/**
+ * webhook客户端接口定义
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public interface WebHookClient {
+
+    /**
+     * 推送事件
+     * @param eventEntities 事件信息
+     * @return 推送成功或失败
+     */
+    boolean doNotify(List<EventEntity> eventEntities);
+
+    /**
+     * 获取webhook 配置
+     * @return 配置
+     */
+    WebHookConfig getConfig();
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/WebHookConfig.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/WebHookConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook;
+
+import java.util.UUID;
+
+/**
+ * webhook配置接口
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public interface WebHookConfig {
+
+    void setUrl(String url);
+
+    String getUrl();
+
+    void setName(String name);
+
+    String getName();
+
+    void setEnable(boolean enable);
+
+    boolean getEnable();
+
+    UUID getId();
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/WebhookConfigImpl.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/WebhookConfigImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook;
+
+import java.util.UUID;
+
+/**
+ * webhook配置
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public class WebhookConfigImpl implements WebHookConfig {
+
+    /**
+     * webhook id
+     */
+    private UUID id = UUID.randomUUID();
+
+    /**
+     * webhook 地址
+     */
+    private String url;
+
+    /**
+     * webhook 名称
+     */
+    private String name;
+
+    /**
+     * webhook 状态
+     */
+    private boolean enable;
+
+    @Override
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+
+    @Override
+    public boolean getEnable() {
+        return enable;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/dingding/DingDingHookClient.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/dingding/DingDingHookClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook.dingding;
+
+import com.alibaba.fastjson.JSONObject;
+import com.huawei.sermant.backend.common.conf.CommonConst;
+import com.huawei.sermant.backend.entity.DingDingEntity;
+import com.huawei.sermant.backend.entity.DingDingMessageType;
+import com.huawei.sermant.backend.entity.EventEntity;
+import com.huawei.sermant.backend.webhook.WebHookClient;
+import com.huawei.sermant.backend.webhook.WebHookConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * 钉钉webhook 客户端
+ *
+ * @author xuezechao
+ * @since 2023-03-02
+ */
+public class DingDingHookClient implements WebHookClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DingDingHookClient.class);
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private WebHookConfig dingDingHookConfig = DingDingHookConfig.getInstance();
+
+    public DingDingHookClient() {
+        dingDingHookConfig.setName(CommonConst.DINGDING_WEBHOOK_NAME);
+    }
+
+    @Override
+    public boolean doNotify(List<EventEntity> eventEntities) {
+
+        DingDingEntity dingDingEntity = new DingDingEntity();
+        dingDingEntity.setMsgtype(DingDingMessageType.Text.toString());
+        dingDingEntity.setText(new HashMap<String, String>() {{
+            put("content", JSONObject.toJSONString(eventEntities));
+        }});
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Accept", "application/json");
+        HttpEntity httpEntity = new HttpEntity<>(dingDingEntity, headers);
+
+        ResponseEntity<JSONObject> responseEntity = restTemplate.postForEntity(dingDingHookConfig.getUrl(), httpEntity, JSONObject.class);
+        if (responseEntity.getStatusCode() != HttpStatus.OK) {
+            LOGGER.error(String.format("do notify dingding webhook failed, error message:[%s]", responseEntity.getBody()));
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public WebHookConfig getConfig() {
+        return dingDingHookConfig;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/dingding/DingDingHookConfig.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/dingding/DingDingHookConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook.dingding;
+
+import com.huawei.sermant.backend.webhook.WebHookConfig;
+import com.huawei.sermant.backend.webhook.WebhookConfigImpl;
+
+/**
+ * 钉钉webhook 配置
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public class DingDingHookConfig extends WebhookConfigImpl {
+
+    private DingDingHookConfig() {
+    }
+
+    private static final WebHookConfig single = new WebhookConfigImpl();
+
+    public static WebHookConfig getInstance() {
+        return single;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/feishu/FeiShuHookClient.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/feishu/FeiShuHookClient.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook.feishu;
+
+
+import com.alibaba.fastjson.JSONObject;
+import com.huawei.sermant.backend.common.conf.CommonConst;
+import com.huawei.sermant.backend.entity.EventEntity;
+import com.huawei.sermant.backend.entity.FeiShuEntity;
+import com.huawei.sermant.backend.entity.FeiShuMessageType;
+import com.huawei.sermant.backend.webhook.WebHookClient;
+import com.huawei.sermant.backend.webhook.WebHookConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * 飞书webhook 客户端
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public class FeiShuHookClient implements WebHookClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FeiShuHookClient.class);
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private WebHookConfig feiShuHookConfig = FeiShuHookConfig.getInstance();
+
+    public FeiShuHookClient() {
+        feiShuHookConfig.setName(CommonConst.FEISHU_WEBHOOK_NAME);
+    }
+
+    @Override
+    public boolean doNotify(List<EventEntity> eventEntities) {
+
+        FeiShuEntity feiShuEntity = new FeiShuEntity();
+        feiShuEntity.setMsg_type(FeiShuMessageType.TEXT.toString());
+        feiShuEntity.setContent(new HashMap<String, String>() {{
+            put(FeiShuMessageType.TEXT.toString(), JSONObject.toJSONString(eventEntities));
+        }});
+
+        ResponseEntity<JSONObject> responseEntity = restTemplate.postForEntity(feiShuHookConfig.getUrl(), JSONObject.toJSONString(feiShuEntity), JSONObject.class);
+        if (responseEntity.getStatusCode() != HttpStatus.OK) {
+            LOGGER.error(String.format("do notify feishu webhook failed, error message:[%s]", responseEntity.getBody()));
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public WebHookConfig getConfig() {
+        return feiShuHookConfig;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/feishu/FeiShuHookConfig.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/feishu/FeiShuHookConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook.feishu;
+
+import com.huawei.sermant.backend.webhook.WebHookConfig;
+import com.huawei.sermant.backend.webhook.WebhookConfigImpl;
+
+/**
+ * 飞书webhook配置
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public class FeiShuHookConfig extends WebhookConfigImpl {
+
+    private FeiShuHookConfig() {
+    }
+
+    private static final WebHookConfig single = new FeiShuHookConfig();
+
+    public static WebHookConfig getInstance() {
+        return single;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/welink/WelinkHookClient.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/welink/WelinkHookClient.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook.welink;
+
+import com.huawei.sermant.backend.common.conf.CommonConst;
+import com.huawei.sermant.backend.entity.EventEntity;
+import com.huawei.sermant.backend.webhook.WebHookClient;
+import com.huawei.sermant.backend.webhook.WebHookConfig;
+
+import java.util.List;
+
+/**
+ * welink webhook 客户端
+ *
+ * @author xuezechao
+ * @since 2023-03-02
+ */
+public class WelinkHookClient implements WebHookClient {
+
+    private WebHookConfig welinkHookConfig = WelinkHookConfig.getInstance();
+
+    public WelinkHookClient() {
+        welinkHookConfig.setName(CommonConst.WELINK_WEBHOOK_NAME);
+    }
+
+    @Override
+    public boolean doNotify(List<EventEntity> eventEntities) {
+        return false;
+    }
+
+    @Override
+    public WebHookConfig getConfig() {
+        return welinkHookConfig;
+    }
+}

--- a/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/welink/WelinkHookConfig.java
+++ b/sermant-backend/src/main/java/com/huawei/sermant/backend/webhook/welink/WelinkHookConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.sermant.backend.webhook.welink;
+
+import com.huawei.sermant.backend.webhook.WebHookConfig;
+import com.huawei.sermant.backend.webhook.WebhookConfigImpl;
+
+/**
+ * welink webhook 配置
+ *
+ * @since 2023-03-02
+ * @author xuezechao
+ */
+public class WelinkHookConfig extends WebhookConfigImpl {
+
+    private WelinkHookConfig() {
+    }
+
+    private static final WebHookConfig single = new WelinkHookConfig();
+
+    public static WebHookConfig getInstance() {
+        return single;
+    }
+}


### PR DESCRIPTION
【修复issue】#1099

【修改内容】

backend模块增加webhook推送能力，支持钉钉，飞书，通过使用：**EventPushHandler**服务，可调用以下接口实现推送能力：
- 事件推送：pushEvent(List<EventEntity> eventEntities)

【用例描述】是否需要修改用例？原因？/ 不增加用例的原因?

【自测情况】1、本地静态检查清理情况；2、xxx门槛用例通过；3、UT覆盖；4、如何测试的？

【影响范围】1、对用户的使用有没有影响（比如涉及api修改，启动参数修改）2、是不是需要更新一些文档（比如用户手册）

---

What type of PR is this?

/feat

Which issue(s) this PR fixes:

Fixes #

Use case description: xxxx

Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No
