### PR TITLE
【fix】当负载均衡使用spring cloud loadlancer，注册中心使用cse，使用域名进行访问时，优雅下线通知失效

### DIFF
--- a/.github/actions/scenarios/spring/graceful/action.yml
+++ b/.github/actions/scenarios/spring/graceful/action.yml
@@ -21,7 +21,6 @@ runs:
       shell: bash
       env:
         servicecomb.service.enableSpringRegister: true
-        servicecomb.service.preferIpAddress: true
       run: |
         nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -Dservice.meta.application=feign -Dserver.port=8014 \
         -Dsermant_log_dir=${{ env.logDir }}/feign-provider-8014${{ env.tailVersion }} -jar \
@@ -38,7 +37,6 @@ runs:
         grace.rule.enableOfflineNotify: true
         grace.rule.warmUpTime: 600
         servicecomb.service.enableSpringRegister: true
-        servicecomb.service.preferIpAddress: true
       # graceful-rest-provider service port 8443 do not change, it special for springCloud Edgware.SR2 test ssl feature.
       run: |
         cp sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign${{ env.tailVersion }}/feign-provider${{ env.tailVersion }}/target/feign-provider${{ env.tailVersion }}.jar graceful-feign-provider${{ env.tailVersion }}.jar
@@ -46,7 +44,7 @@ runs:
         -Dsermant_log_dir=${{ env.logDir }}/feign-provider${{ env.tailVersion }} -Dgrace.rule.httpServerPort=16777 \
         graceful-feign-provider${{ env.tailVersion }}.jar > ${{ env.logDir }}/feign-provider.log 2>&1 &
         nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -Dservice.meta.application=feign -Dserver.port=8015 -jar \
-        -Dsermant_log_dir=${{ env.logDir }}/feign-consumer${{ env.tailVersion }} -Dgrace.rule.httpServerPort=16778 \
+        -Dsermant_log_dir=${{ env.logDir }}/feign-consumer${{ env.tailVersion }} -Dgrace.rule.httpServerPort=16778 -Dservicecomb.service.preferIpAddress=true \
         sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign${{ env.tailVersion }}/feign-consumer${{ env.tailVersion }}/target/feign-consumer${{ env.tailVersion }}.jar > ${{ env.logDir }}/feign-consumer.log 2>&1 &
 
         cp sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-provider/target/rest-provider.jar graceful-rest-provider.jar

--- a/sermant-plugins/sermant-service-registry/registry-common/src/main/java/com/huawei/registry/config/grace/GraceShutDownManager.java
+++ b/sermant-plugins/sermant-service-registry/registry-common/src/main/java/com/huawei/registry/config/grace/GraceShutDownManager.java
@@ -24,6 +24,7 @@ import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.utils.ThreadFactoryUtils;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class GraceShutDownManager {
     /**
      * 最大缓存关闭endpoint数量
      */
-    private static final int MAX_SHUTDOWN_ENDPOINT_CACHE = 1000;
+    private static final int MAX_SHUTDOWN_ENDPOINT_CACHE = 2000;
 
     private static final ScheduledThreadPoolExecutor CLEAN_UP_TASK = new ScheduledThreadPoolExecutor(1,
             new ThreadFactoryUtils("ENDPOINT_CLEAN_UP_TASK"));
@@ -151,9 +152,16 @@ public class GraceShutDownManager {
     /**
      * 添加要关闭的下游ip地址
      *
-     * @param endpoint 地址，host:port
+     * @param endpoints 地址，host:port
      */
-    public void addShutdownEndpoint(String endpoint) {
+    public void addShutdownEndpoints(Collection<String> endpoints) {
+        if (endpoints == null || endpoints.isEmpty()) {
+            return;
+        }
+        endpoints.forEach(this::addShutdownEndpoint);
+    }
+
+    private void addShutdownEndpoint(String endpoint) {
         if (markShutDownEndpoints.size() < MAX_SHUTDOWN_ENDPOINT_CACHE) {
             markShutDownEndpoints.put(endpoint, System.currentTimeMillis());
             LOGGER.fine(String.format(Locale.ENGLISH, "Marked endpoint [%s] will be shutdown!", endpoint));

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringLoadbalancerFeignResponseInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringLoadbalancerFeignResponseInterceptor.java
@@ -64,16 +64,12 @@ public class SpringLoadbalancerFeignResponseInterceptor extends GraceSwitchInter
         if (response.headers() == null || response.headers().size() == 0) {
             return context;
         }
-        final Collection<String> endpoints = response.headers().get(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT);
-        if (endpoints == null || endpoints.isEmpty()) {
-            return context;
-        }
-        final String shutdownEndpoint = endpoints.iterator().next();
-        GraceContext.INSTANCE.getGraceShutDownManager().addShutdownEndpoint(shutdownEndpoint);
+        GraceContext.INSTANCE.getGraceShutDownManager()
+            .addShutdownEndpoints(response.headers().get(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT));
         Request request = (Request) requestArgument;
         final Optional<String> serviceNameFromReqUrl = GraceHelper.getServiceNameFromReqUrl(request.url());
         RefreshUtils.refreshTargetServiceInstances(serviceNameFromReqUrl.orElse(null),
-                response.headers().get(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME));
+            response.headers().get(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME));
         return context;
     }
 

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringLoadbalancerRestTemplateResponseInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringLoadbalancerRestTemplateResponseInterceptor.java
@@ -32,8 +32,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 
-import java.util.List;
-
 /**
  * 针对RestTemplate拦截
  *
@@ -57,15 +55,12 @@ public class SpringLoadbalancerRestTemplateResponseInterceptor extends GraceSwit
             return context;
         }
         ClientHttpResponse response = (ClientHttpResponse) result;
-        final List<String> endpoints = response.getHeaders().get(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT);
-        if (endpoints == null || endpoints.isEmpty()) {
-            return context;
-        }
-        GraceContext.INSTANCE.getGraceShutDownManager().addShutdownEndpoint(endpoints.get(0));
+        GraceContext.INSTANCE.getGraceShutDownManager()
+            .addShutdownEndpoints(response.getHeaders().get(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT));
         HttpRequest request = (HttpRequest) argument;
         final String host = request.getURI().getHost();
         RefreshUtils.refreshTargetServiceInstances(host,
-                response.getHeaders().get(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME));
+            response.getHeaders().get(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME));
         return context;
     }
 

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringZuulResponseInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringZuulResponseInterceptor.java
@@ -27,7 +27,6 @@ import com.huawei.registry.config.grace.GraceContext;
 import com.huawei.registry.utils.RefreshUtils;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
-import com.huaweicloud.sermant.core.utils.StringUtils;
 
 import com.netflix.zuul.context.RequestContext;
 
@@ -61,11 +60,8 @@ public class SpringZuulResponseInterceptor extends GraceSwitchInterceptor {
             return context;
         }
         HttpServletResponse response = (HttpServletResponse) rawResponse;
-        final String endpoint = response.getHeader(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT);
-        if (StringUtils.isBlank(endpoint)) {
-            return context;
-        }
-        GraceContext.INSTANCE.getGraceShutDownManager().addShutdownEndpoint(endpoint);
+        GraceContext.INSTANCE.getGraceShutDownManager()
+            .addShutdownEndpoints(response.getHeaders(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT));
         HttpServletRequest request = (HttpServletRequest) rawRequest;
         RefreshUtils.refreshTargetServiceInstances(request.getRemoteHost(),
             Collections.singleton(response.getHeader(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME)));

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/grace/SpringRequestInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/grace/SpringRequestInterceptor.java
@@ -37,8 +37,6 @@ import com.huaweicloud.sermant.core.utils.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.util.Locale;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -74,6 +72,8 @@ public class SpringRequestInterceptor implements HandlerInterceptor {
             final ClientInfo clientInfo = RegisterContext.INSTANCE.getClientInfo();
             response.addHeader(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT,
                 buildEndpoint(clientInfo.getIp(), clientInfo.getPort()));
+            response.addHeader(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT,
+                buildEndpoint(clientInfo.getHost(), clientInfo.getPort()));
             response.addHeader(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME, clientInfo.getServiceName());
         }
         return true;
@@ -91,7 +91,7 @@ public class SpringRequestInterceptor implements HandlerInterceptor {
     }
 
     private String buildEndpoint(String host, int port) {
-        return String.format(Locale.ENGLISH, "%s:%s", host, port);
+        return host + ":" + port;
     }
 
     private void addGraceAddress(HttpServletRequest request) {

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/impl/GraceServiceImpl.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/impl/GraceServiceImpl.java
@@ -32,6 +32,9 @@ import com.huaweicloud.sermant.core.utils.ReflectUtils;
 
 import com.alibaba.fastjson.JSONObject;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -66,19 +69,21 @@ public class GraceServiceImpl implements GraceService {
             checkAndCloseSc();
             GraceContext.INSTANCE.getGraceShutDownManager().setShutDown(true);
             ClientInfo clientInfo = RegisterContext.INSTANCE.getClientInfo();
-            Map<String, String> header = new HashMap<>();
-            header.put(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME, clientInfo.getServiceName());
-            header.put(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT, clientInfo.getIp() + ":"
-                    + clientInfo.getPort());
+            Map<String, Collection<String>> header = new HashMap<>();
+            header.put(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME,
+                Collections.singletonList(clientInfo.getServiceName()));
+            header.put(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT,
+                Arrays.asList(clientInfo.getIp() + ":" + clientInfo.getPort(),
+                    clientInfo.getHost() + ":" + clientInfo.getPort()));
             AddressCache.INSTANCE.getAddressSet().forEach(address -> notifyToGraceHttpServer(address, header));
         }
     }
 
-    private void notifyToGraceHttpServer(String address, Map<String, String> header) {
+    private void notifyToGraceHttpServer(String address, Map<String, Collection<String>> header) {
         EXECUTOR.execute(() -> execute(address, header));
     }
 
-    private void execute(String address, Map<String, String> header) {
+    private void execute(String address, Map<String, Collection<String>> header) {
         HttpClientUtils.INSTANCE.doPost(GRACE_HTTP_SERVER_PROTOCOL + address + GraceConstants.GRACE_NOTIFY_URL_PATH,
                 REQUEST_BODY, header);
     }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/server/NotifyHttpHandler.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/server/NotifyHttpHandler.java
@@ -70,6 +70,6 @@ public class NotifyHttpHandler implements HttpHandler {
 
     private void addMarkShutdownEndpoint(Headers headers) {
         GraceContext.INSTANCE.getGraceShutDownManager()
-                .addShutdownEndpoint(headers.getFirst(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT));
+                .addShutdownEndpoints(headers.get(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT));
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/utils/HttpClientUtils.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/utils/HttpClientUtils.java
@@ -30,6 +30,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -105,7 +106,7 @@ public enum HttpClientUtils {
      * @param header 请求头
      * @return HttpClientResult结果包装类
      */
-    public HttpClientResult doPost(String url, String json, Map<String, String> header) {
+    public HttpClientResult doPost(String url, String json, Map<String, Collection<String>> header) {
         // 创建http对象
         HttpPost httpPost = new HttpPost(url);
 
@@ -124,15 +125,18 @@ public enum HttpClientUtils {
     }
 
     private static HttpEntityEnclosingRequestBase packageParam(HttpEntityEnclosingRequestBase httpMethod, String json,
-        Map<String, String> header) throws UnsupportedEncodingException {
+        Map<String, Collection<String>> header) throws UnsupportedEncodingException {
         StringEntity entity = new StringEntity(json, Consts.UTF_8);
         entity.setContentType(new BasicHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString()));
         entity.setContentEncoding(Consts.UTF_8.name());
         httpMethod.setEntity(entity);
         if (header != null) {
-            Set<Entry<String, String>> entrySet = header.entrySet();
-            for (Entry<String, String> entry : entrySet) {
-                httpMethod.setHeader(entry.getKey(), entry.getValue());
+            Set<Entry<String, Collection<String>>> entrySet = header.entrySet();
+            for (Entry<String, Collection<String>> entry : entrySet) {
+                if (entry.getValue() == null) {
+                    continue;
+                }
+                entry.getValue().forEach(value -> httpMethod.addHeader(entry.getKey(), value));
             }
         }
         return httpMethod;

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/test/java/com/huawei/registry/service/server/GraceHttpServerTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/test/java/com/huawei/registry/service/server/GraceHttpServerTest.java
@@ -26,10 +26,11 @@ import com.huawei.registry.service.utils.HttpClientResult;
 import com.huawei.registry.service.utils.HttpClientUtils;
 import com.huawei.registry.services.GraceService;
 
-import com.alibaba.fastjson.JSONObject;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import com.alibaba.fastjson.JSONObject;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -38,6 +39,8 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -89,13 +92,14 @@ public class GraceHttpServerTest {
         graceHttpServer.start();
         try {
             checkHandlers(graceHttpServer);
-            final HashMap<String, String> notifyHeaders = new HashMap<>();
-            notifyHeaders.put(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT, "localhost:28181");
-            notifyHeaders.put(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME, "test");
+            final HashMap<String, Collection<String>> notifyHeaders = new HashMap<>();
+            notifyHeaders
+                .put(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT, Collections.singletonList("localhost:28181"));
+            notifyHeaders.put(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME, Collections.singletonList("test"));
             final GraceContext instance = GraceContext.INSTANCE;
             final HttpClientResult notifyResult = HttpClientUtils.INSTANCE
-                    .doPost("http://127.0.0.1:16688" + GraceConstants.GRACE_NOTIFY_URL_PATH,
-                            JSONObject.toJSONString(new Object()), notifyHeaders);
+                .doPost("http://127.0.0.1:16688" + GraceConstants.GRACE_NOTIFY_URL_PATH,
+                    JSONObject.toJSONString(new Object()), notifyHeaders);
             Assert.assertTrue(instance.getGraceShutDownManager().isMarkedOffline("localhost:28181"));
             Assert.assertEquals(notifyResult.getCode(), GraceConstants.GRACE_HTTP_SUCCESS_CODE);
         } finally {


### PR DESCRIPTION
【修复issue】 #1115 

【修改内容】优雅下线主动通知接口增加域名信息

【用例描述】使用spring cloud 2020.0.0、CSE进行测试，优雅下线通知正常

【自测情况】使用spring cloud 2020.0.0、CSE进行测试，搭建流水环境，运行优雅上下线的ut，ut执行成功

【影响范围】不涉及
