### PR TITLE
【fix】injector场景，在业务应用已挂载preStop节点时，injector有可能无法正确注入优雅下线的命令

### DIFF
--- a/sermant-injector/src/main/java/com/huaweicloud/sermant/injection/controller/SermantInjectorController.java
+++ b/sermant-injector/src/main/java/com/huaweicloud/sermant/injection/controller/SermantInjectorController.java
@@ -394,15 +394,7 @@ public class SermantInjectorController {
 
             // 建一个exec和command
             addExecAndCommand(preStopNode, port);
-            return;
         }
-        if (containerNode.path(LIFECYCLE_PATH).path(PRE_STOP_PATH).hasNonNull(HTTP_GET_PATH)) {
-            // lifecycle不为null, preStop不为null, 存在httpGet情况无法再织入command，直接return
-            return;
-        }
-
-        // lifecycle不为null, preStop为null, 且已存在command，需要添加command
-        addCommands(objectNode, containerPath, containerNode, port);
     }
 
     private void injectReadinessProbe(ArrayNode arrayNode, Map<String, String> env, JsonNode containerNode,
@@ -523,26 +515,6 @@ public class SermantInjectorController {
         // 注入env
         envNode.put(NAME_KEY, key);
         envNode.put(VALUE_KEY, value);
-    }
-
-    private void addCommands(ObjectNode objectNode, String containerPath, JsonNode containerNode, int port) {
-        objectNode.put(PATH_KEY, containerPath + LIFECYCLE_PATH + PATH_SEPARATOR + PRE_STOP_PATH + PATH_SEPARATOR
-                + EXEC_PATH + PATH_SEPARATOR + COMMAND_KEY);
-        JsonNode commandsPath = containerNode.path(LIFECYCLE_PATH).path(PRE_STOP_PATH).path(EXEC_PATH)
-                .path(COMMAND_KEY);
-        Iterator<JsonNode> iterator = commandsPath.elements();
-        ArrayNode commands = objectNode.putArray(VALUE_KEY);
-        int index = 0;
-        int size = commandsPath.size();
-        while (iterator.hasNext()) {
-            JsonNode next = iterator.next();
-            String command = next.asText();
-            if (index == size - 1) {
-                command += ";" + PRE_STOP_COMMAND_PREFIX + port + PRE_STOP_COMMAND_SUFFIX;
-            }
-            commands.add(command);
-            index++;
-        }
     }
 
     private void addExecAndCommand(ObjectNode preStopNode, int port) {

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/DynamicServerListInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/DynamicServerListInterceptorTest.java
@@ -16,6 +16,7 @@
 
 package com.huawei.registry.interceptors;
 
+import com.huawei.registry.config.RegisterDynamicConfig;
 import com.huawei.registry.context.RegisterContext;
 import com.huawei.registry.entity.MicroServiceInstance;
 import com.huawei.registry.interceptors.cloud3.x.ZookeeperInstanceSupplierInterceptorTest;
@@ -23,6 +24,7 @@ import com.huawei.registry.services.RegisterCenterService;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.service.ServiceManager;
+
 import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
@@ -78,11 +80,13 @@ public class DynamicServerListInterceptorTest extends BaseRegistryTest<DynamicSe
 
     @Test
     public void doBefore() throws NoSuchMethodException {
+        RegisterDynamicConfig.INSTANCE.setClose(false);
         RegisterContext.INSTANCE.setAvailable(true);
         final ExecuteContext context = interceptor.doBefore(buildContext(serverListLoadBalancer, null));
         Assert.assertTrue(context.isSkip());
         Mockito.verify(serverList, Mockito.times(1)).getUpdatedListOfServers();
         RegisterContext.INSTANCE.setAvailable(false);
+        RegisterDynamicConfig.INSTANCE.setClose(true);
     }
 
     @Override

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/HealthIndicatorInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/HealthIndicatorInterceptorTest.java
@@ -39,6 +39,7 @@ public class HealthIndicatorInterceptorTest extends BaseRegistryTest {
         REGISTER_CONFIG.setEnableSpringRegister(true);
         final ExecuteContext context = interceptor.before(buildContext());
         Assert.assertTrue(context.isSkip());
+        RegisterDynamicConfig.INSTANCE.setClose(false);
     }
 
     @Override


### PR DESCRIPTION
【修复issue】 #1113 

【修改内容】存在preStop节点时，不再自动注入优雅下线相关的钩子

【用例描述】业务yaml已配置preStop节点时，不再自动注入优雅下线相关的钩子

【自测情况】业务yaml已配置preStop节点时，不再自动注入优雅下线相关的钩子

【影响范围】不涉及