### PR TITLE
【bugfix】修复http请求拦截点缺失信息

### DIFF
--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/HttpCommonRequest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/HttpCommonRequest.java
@@ -16,7 +16,9 @@
 
 package com.huawei.discovery.entity;
 
+import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
 
 import java.net.URI;
 
@@ -34,10 +36,16 @@ public class HttpCommonRequest extends HttpGet {
      *
      * @param methodType 方法类型
      * @param uri 请求路径
+     * @param httpUriRequest 请求
      */
-    public HttpCommonRequest(String methodType, String uri) {
+    public HttpCommonRequest(HttpRequest httpUriRequest, String methodType, String uri) {
         this.methodType = methodType;
+        HttpRequestBase oldHttpRequest = (HttpRequestBase) httpUriRequest;
         setURI(URI.create(uri));
+        setHeaders(oldHttpRequest.getAllHeaders());
+        setConfig(oldHttpRequest.getConfig());
+        setProtocolVersion(oldHttpRequest.getProtocolVersion());
+        setParams(oldHttpRequest.getParams());
     }
 
     @Override

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttpClientInterceptor.java
@@ -77,9 +77,9 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
         AtomicReference<Request> rebuildRequest = new AtomicReference<>();
         rebuildRequest.set(request);
         invokerService.invoke(
-                buildInvokerFunc(uri, hostAndPath, request, rebuildRequest, context),
-                buildExFunc(rebuildRequest),
-                hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
+                        buildInvokerFunc(uri, hostAndPath, request, rebuildRequest, context),
+                        buildExFunc(rebuildRequest),
+                        hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
                 .ifPresent(o -> setResultOrThrow(context, o, uri.getPath()));
         return context;
     }
@@ -110,7 +110,7 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
     }
 
     private Function<InvokerContext, Object> buildInvokerFunc(URI uri, Map<String, String> hostAndPath,
-        Request request, AtomicReference<Request> rebuildRequest, ExecuteContext context) {
+            Request request, AtomicReference<Request> rebuildRequest, ExecuteContext context) {
         return invokerContext -> {
             final String method = request.method();
             Request newRequest = covertRequest(uri, hostAndPath, request, method, invokerContext.getServiceInstance());
@@ -138,6 +138,9 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
         return request
                 .newBuilder()
                 .url(newUrl)
+                .method(request.method(), request.body())
+                .headers(request.headers())
+                .tag(request.tag())
                 .build();
     }
 

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
@@ -36,6 +36,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.util.EntityUtils;
 
 import java.io.Closeable;
@@ -80,9 +81,9 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
         }
         RequestInterceptorUtils.printRequestLog("HttpClient", hostAndPath);
         invokerService.invoke(
-                buildInvokerFunc(hostAndPath, httpRequest, context),
-                buildExFunc(httpRequest, Thread.currentThread().getContextClassLoader()),
-                hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
+                        buildInvokerFunc(hostAndPath, httpRequest, context),
+                        buildExFunc(httpRequest, Thread.currentThread().getContextClassLoader()),
+                        hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
                 .ifPresent(result -> this.setResultOrThrow(context, result,
                         hostAndPath.get(HttpConstants.HTTP_URI_PATH)));
         return context;
@@ -175,10 +176,23 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
             HttpPost oldHttpPost = (HttpPost) httpUriRequest;
             HttpPost httpPost = new HttpPost(uriNew);
             httpPost.setEntity(oldHttpPost.getEntity());
+            httpPost.setHeaders(oldHttpPost.getAllHeaders());
+            httpPost.setConfig(oldHttpPost.getConfig());
+            httpPost.setProtocolVersion(oldHttpPost.getProtocolVersion());
+            httpPost.setParams(oldHttpPost.getParams());
             return httpPost;
-        } else {
-            return new HttpCommonRequest(method, uriNew);
         }
+        if (httpUriRequest instanceof HttpPut) {
+            HttpPut oldHttpPut = (HttpPut) httpUriRequest;
+            HttpPut httpPut = new HttpPut(uriNew);
+            httpPut.setEntity(oldHttpPut.getEntity());
+            httpPut.setHeaders(oldHttpPut.getAllHeaders());
+            httpPut.setConfig(oldHttpPut.getConfig());
+            httpPut.setProtocolVersion(oldHttpPut.getProtocolVersion());
+            httpPut.setParams(oldHttpPut.getParams());
+            return httpPut;
+        }
+        return new HttpCommonRequest(httpUriRequest, method, uriNew);
     }
 
     @Override

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/entity/HttpCommonRequestTest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/entity/HttpCommonRequestTest.java
@@ -16,6 +16,8 @@
 
 package com.huawei.discovery.entity;
 
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpGet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,7 +32,8 @@ public class HttpCommonRequestTest {
     public void test() {
         String uri = "http://www.ccc.com/test";
         String method = "GET";
-        final HttpCommonRequest httpCommonRequest = new HttpCommonRequest(method, uri);
+        HttpRequest httpRequest = new HttpGet("www.test.com");
+        final HttpCommonRequest httpCommonRequest = new HttpCommonRequest(httpRequest, method, uri);
         Assert.assertEquals(httpCommonRequest.getMethod(), method);
         Assert.assertEquals(httpCommonRequest.getRequestLine().getUri(), uri);
     }


### PR DESCRIPTION
【修复issue】#1134

【修改内容】修复springboot插件httpclient拦截点和okhttp拦截点缺失请求的部分信息

【用例描述】用例已覆盖

【自测情况】1、本地静态检查通过；2、UT通过

【影响范围】Springboot注册插件 httpclient和okhttp客户端使用
