### PR TITLE
【bugfix】修复httpclientasync用例不通过的问题

### DIFF
--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/HttpCommonRequest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/HttpCommonRequest.java
@@ -16,14 +16,12 @@
 
 package com.huawei.discovery.entity;
 
-import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
 
 import java.net.URI;
 
 /**
- * 定义Http请求, 除POST请求外其他均兼容
+ * 定义其他Http请求
  *
  * @author zhouss
  * @since 2022-10-11
@@ -36,16 +34,10 @@ public class HttpCommonRequest extends HttpGet {
      *
      * @param methodType 方法类型
      * @param uri 请求路径
-     * @param httpUriRequest 请求
      */
-    public HttpCommonRequest(HttpRequest httpUriRequest, String methodType, String uri) {
+    public HttpCommonRequest(String methodType, String uri) {
         this.methodType = methodType;
-        HttpRequestBase oldHttpRequest = (HttpRequestBase) httpUriRequest;
         setURI(URI.create(uri));
-        setHeaders(oldHttpRequest.getAllHeaders());
-        setConfig(oldHttpRequest.getConfig());
-        setProtocolVersion(oldHttpRequest.getProtocolVersion());
-        setParams(oldHttpRequest.getParams());
     }
 
     @Override

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
@@ -35,6 +35,10 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.util.EntityUtils;
@@ -60,6 +64,18 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
     private static final String ERROR_RESPONSE_CLASS = "com.huawei.discovery.entity.ErrorCloseableHttpResponse";
 
     private static final String COMMON_REQUEST_CLASS = "com.huawei.discovery.entity.HttpCommonRequest";
+
+    private static final String HTTP_POST_NAME = "org.apache.http.client.methods.HttpPost";
+
+    private static final String HTTP_GET_NAME = "org.apache.http.client.methods.HttpGet";
+
+    private static final String HTTP_PUT_NAME = "org.apache.http.client.methods.HttpPut";
+
+    private static final String HTTP_DELETE_NAME = "org.apache.http.client.methods.HttpDelete";
+
+    private static final String HTTP_PATCH_NAME = "org.apache.http.client.methods.HttpPatch";
+
+    private static final String HTTP_HEAD_NAME = "org.apache.http.client.methods.HttpHead";
 
     private final AtomicBoolean isLoaded = new AtomicBoolean();
 
@@ -172,27 +188,78 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
     }
 
     private HttpRequest rebuildRequest(String uriNew, String method, HttpRequest httpUriRequest) {
-        if (httpUriRequest instanceof HttpPost) {
-            HttpPost oldHttpPost = (HttpPost) httpUriRequest;
-            HttpPost httpPost = new HttpPost(uriNew);
-            httpPost.setEntity(oldHttpPost.getEntity());
-            httpPost.setHeaders(oldHttpPost.getAllHeaders());
-            httpPost.setConfig(oldHttpPost.getConfig());
-            httpPost.setProtocolVersion(oldHttpPost.getProtocolVersion());
-            httpPost.setParams(oldHttpPost.getParams());
-            return httpPost;
+        switch (httpUriRequest.getClass().getName()) {
+            case HTTP_POST_NAME:
+                return buildHttpPost(uriNew, (HttpPost) httpUriRequest);
+            case HTTP_GET_NAME:
+                return buildHttpGet(uriNew, (HttpGet) httpUriRequest);
+            case HTTP_PUT_NAME:
+                return buildHttpPut(uriNew, (HttpPut) httpUriRequest);
+            case HTTP_DELETE_NAME:
+                return buildHttpDelete(uriNew, (HttpDelete) httpUriRequest);
+            case HTTP_PATCH_NAME:
+                return buildHttpPatch(uriNew, (HttpPatch) httpUriRequest);
+            case HTTP_HEAD_NAME:
+                return buildHttpHead(uriNew, (HttpHead) httpUriRequest);
+            default:
+                return new HttpCommonRequest(method, uriNew);
         }
-        if (httpUriRequest instanceof HttpPut) {
-            HttpPut oldHttpPut = (HttpPut) httpUriRequest;
-            HttpPut httpPut = new HttpPut(uriNew);
-            httpPut.setEntity(oldHttpPut.getEntity());
-            httpPut.setHeaders(oldHttpPut.getAllHeaders());
-            httpPut.setConfig(oldHttpPut.getConfig());
-            httpPut.setProtocolVersion(oldHttpPut.getProtocolVersion());
-            httpPut.setParams(oldHttpPut.getParams());
-            return httpPut;
-        }
-        return new HttpCommonRequest(httpUriRequest, method, uriNew);
+    }
+
+    private HttpHead buildHttpHead(String uriNew, HttpHead httpUriRequest) {
+        HttpHead httpHead = new HttpHead(uriNew);
+        httpHead.setHeaders(httpUriRequest.getAllHeaders());
+        httpHead.setConfig(httpUriRequest.getConfig());
+        httpHead.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpHead.setParams(httpUriRequest.getParams());
+        return httpHead;
+    }
+
+    private HttpPatch buildHttpPatch(String uriNew, HttpPatch httpUriRequest) {
+        HttpPatch httpPatch = new HttpPatch(uriNew);
+        httpPatch.setHeaders(httpUriRequest.getAllHeaders());
+        httpPatch.setConfig(httpUriRequest.getConfig());
+        httpPatch.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpPatch.setParams(httpUriRequest.getParams());
+        return httpPatch;
+    }
+
+    private HttpDelete buildHttpDelete(String uriNew, HttpDelete httpUriRequest) {
+        HttpDelete httpDelete = new HttpDelete(uriNew);
+        httpDelete.setHeaders(httpUriRequest.getAllHeaders());
+        httpDelete.setConfig(httpUriRequest.getConfig());
+        httpDelete.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpDelete.setParams(httpUriRequest.getParams());
+        return httpDelete;
+    }
+
+    private HttpPut buildHttpPut(String uriNew, HttpPut httpUriRequest) {
+        HttpPut httpPut = new HttpPut(uriNew);
+        httpPut.setEntity(httpUriRequest.getEntity());
+        httpPut.setHeaders(httpUriRequest.getAllHeaders());
+        httpPut.setConfig(httpUriRequest.getConfig());
+        httpPut.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpPut.setParams(httpUriRequest.getParams());
+        return httpPut;
+    }
+
+    private HttpGet buildHttpGet(String uriNew, HttpGet httpUriRequest) {
+        HttpGet httpGet = new HttpGet(uriNew);
+        httpGet.setHeaders(httpUriRequest.getAllHeaders());
+        httpGet.setConfig(httpUriRequest.getConfig());
+        httpGet.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpGet.setParams(httpUriRequest.getParams());
+        return httpGet;
+    }
+
+    private HttpPost buildHttpPost(String uriNew, HttpPost httpUriRequest) {
+        HttpPost httpPost = new HttpPost(uriNew);
+        httpPost.setEntity(httpUriRequest.getEntity());
+        httpPost.setHeaders(httpUriRequest.getAllHeaders());
+        httpPost.setConfig(httpUriRequest.getConfig());
+        httpPost.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpPost.setParams(httpUriRequest.getParams());
+        return httpPost;
     }
 
     @Override

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/entity/HttpCommonRequestTest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/entity/HttpCommonRequestTest.java
@@ -16,8 +16,6 @@
 
 package com.huawei.discovery.entity;
 
-import org.apache.http.HttpRequest;
-import org.apache.http.client.methods.HttpGet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,8 +30,7 @@ public class HttpCommonRequestTest {
     public void test() {
         String uri = "http://www.ccc.com/test";
         String method = "GET";
-        HttpRequest httpRequest = new HttpGet("www.test.com");
-        final HttpCommonRequest httpCommonRequest = new HttpCommonRequest(httpRequest, method, uri);
+        final HttpCommonRequest httpCommonRequest = new HttpCommonRequest(method, uri);
         Assert.assertEquals(httpCommonRequest.getMethod(), method);
         Assert.assertEquals(httpCommonRequest.getRequestLine().getUri(), uri);
     }


### PR DESCRIPTION
【修复issue】https://github.com/huaweicloud/Sermant/issues/1134

【修改内容】修复httpclientasync用例不通过的问题

【用例描述】用例已覆盖

【自测情况】1、本地静态检查通过；2、UT通过

【影响范围】无