### PR TITLE
【feature】add same az priority policy

### DIFF
--- a/.github/actions/scenarios/dubbo/router/action.yml
+++ b/.github/actions/scenarios/dubbo/router/action.yml
@@ -107,6 +107,7 @@ runs:
         SERVICE_META_ENVIRONMENT: development
         ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
         SERVICE_META_VERSION: 1.0.0
+        SERVICE_META_ZONE: az1
         SERVER_PORT: 18021
         DUBBO_PROTOCOL_PORT: 18821
       run: |
@@ -122,6 +123,7 @@ runs:
         SERVICE_META_ENVIRONMENT: development
         ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
         SERVICE_META_PARAMETERS: group-test:gray
+        SERVICE_META_ZONE: az1
         SERVICE_META_VERSION: 1.0.1
         SERVER_PORT: 18022
         DUBBO_PROTOCOL_PORT: 18822
@@ -138,6 +140,7 @@ runs:
         SERVICE_META_ENVIRONMENT: development
         ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
         SERVICE_META_PARAMETERS: group-test:red
+        SERVICE_META_ZONE: az2
         SERVICE_META_VERSION: 1.0.1
         SERVER_PORT: 18023
         DUBBO_PROTOCOL_PORT: 18823
@@ -159,6 +162,7 @@ runs:
         SERVICE_META_ENVIRONMENT: development
         ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
         SERVICE_META_PARAMETERS: group-test:gray
+        SERVICE_META_ZONE: az1
         SERVER_PORT: 18020
         DUBBO_PROTOCOL_PORT: 18820
       run: |

--- a/.github/actions/scenarios/spring/router/spring-tag-az-router/action.yml
+++ b/.github/actions/scenarios/spring/router/spring-tag-az-router/action.yml
@@ -1,0 +1,269 @@
+name: "Spring Router Test For AZ tag"
+description: "Auto test for spring route for plugin sermant-router tag is used in az scene"
+runs:
+  using: "composite"
+  steps:
+    - name: entry
+      uses: ./.github/actions/common/entry
+      with:
+        log-dir: ./logs/tag-az-router
+    - name: 1.5.x config
+      if: matrix.springBootVersion == '1.5.0.RELEASE' && matrix.springCloudVersion == 'Edgware.SR2'
+      shell: bash
+      run: |
+        echo "tailVersion=-1.5.x" >> $GITHUB_ENV
+        echo "healthApi=health" >> $GITHUB_ENV
+    - name: 2.x config
+      if: matrix.springBootVersion != '1.5.0.RELEASE'
+      shell: bash
+      run: |
+        echo "healthApi=actuator/health" >> $GITHUB_ENV
+    - name: package common demos
+      shell: bash
+      run: |
+        sed -i 's|<version>${{ env.projectSpringBootVersion }}</version>|<version>${{ matrix.springBootVersion }}</version>|g' sermant-integration-tests/spring-test/pom.xml
+        mvn package -Dspring.cloud.version=${{ matrix.springCloudVersion }} -Dhttp.client.version=${{ matrix.httpClientVersion }} -Dspring.boot.version=${{ matrix.springBootVersion }} -DskipTests -P common-test${{ env.tailVersion }} --file sermant-integration-tests/spring-test/pom.xml
+    - name: package zuul demo
+      shell: bash
+      if: matrix.springCloudVersion == 'Edgware.SR2' || matrix.springCloudVersion == 'Finchley.RELEASE' || matrix.springCloudVersion == 'Greenwich.RELEASE' || matrix.springCloudVersion == 'Hoxton.RELEASE'
+      run: |
+        sed -i 's|<version>${{ env.projectSpringBootVersion }}</version>|<version>${{ matrix.springBootVersion }}</version>|g' sermant-integration-tests/spring-test/pom.xml
+        mvn package -Dspring.cloud.version=${{ matrix.springCloudVersion }} -Dhttp.client.version=${{ matrix.httpClientVersion }} -Dspring.boot.version=${{ matrix.springBootVersion }} -DskipTests -P zuul --file sermant-integration-tests/spring-test/spring-common-demos/pom.xml
+    - name: package gateway demo
+      shell: bash
+      if: matrix.springCloudVersion != 'Edgware.SR2'
+      run: |
+        sed -i 's|<version>${{ env.projectSpringBootVersion }}</version>|<version>${{ matrix.springBootVersion }}</version>|g' sermant-integration-tests/spring-test/pom.xml
+        mvn package -Dspring.cloud.version=${{ matrix.springCloudVersion }} -Dhttp.client.version=${{ matrix.httpClientVersion }} -Dspring.boot.version=${{ matrix.springBootVersion }} -DskipTests -P gateway --file sermant-integration-tests/spring-test/spring-common-demos/pom.xml
+    - name: post config
+      shell: bash
+      run: bash ./sermant-integration-tests/scripts/createStrategy.sh all
+    - name: post config to local-cse
+      shell: bash
+      run: mvn test -Dsermant.integration.test.type=TAG_ROUTER_CONFIG --file sermant-integration-tests/spring-test/pom.xml
+    - name: start cse feign provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az1
+        SERVICE_META_VERSION: 1.0.0
+        SERVER_PORT: 8015
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign${{ env.tailVersion }}/feign-provider${{ env.tailVersion }}/target/feign-provider${{ env.tailVersion }}.jar > ${{ env.logDir }}/feign-provider.log 2>&1 &
+    - name: start cse second feign provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az1
+        SERVICE_META_VERSION: 1.0.1
+        SERVER_PORT: 8016
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign${{ env.tailVersion }}/feign-provider${{ env.tailVersion }}/target/feign-provider${{ env.tailVersion }}.jar > ${{ env.logDir }}/feign-provider2.log 2>&1 &
+    - name: start cse third feign provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az2
+        SERVICE_META_VERSION: 1.0.0
+        SERVER_PORT: 8017
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign${{ env.tailVersion }}/feign-provider${{ env.tailVersion }}/target/feign-provider${{ env.tailVersion }}.jar > ${{ env.logDir }}/feign-provider3.log 2>&1 &
+    - name: start cse four feign provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az2
+        SERVICE_META_VERSION: 1.0.1
+        SERVER_PORT: 8018
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign${{ env.tailVersion }}/feign-provider${{ env.tailVersion }}/target/feign-provider${{ env.tailVersion }}.jar > ${{ env.logDir }}/feign-provider4.log 2>&1 &
+    - name: start cse feign consumer service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az1
+        SERVICE_META_VERSION: 1.0.0
+        SERVER_PORT: 8019
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-feign${{ env.tailVersion }}/feign-consumer${{ env.tailVersion }}/target/feign-consumer${{ env.tailVersion }}.jar > ${{ env.logDir }}/feign-consumer.log 2>&1 &
+    - name: start cse resttemplate provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az1
+        SERVICE_META_VERSION: 1.0.0
+        SERVER_PORT: 8021
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-provider/target/rest-provider.jar > ${{ env.logDir }}/rest-provider.log 2>&1 &
+    - name: start second resttemplate provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az1
+        SERVICE_META_VERSION: 1.0.1
+        SERVER_PORT: 8022
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-provider/target/rest-provider.jar > ${{ env.logDir }}/rest-provider2.log 2>&1 &
+    - name: start three resttemplate provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az2
+        SERVICE_META_VERSION: 1.0.1
+        SERVER_PORT: 8023
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-provider/target/rest-provider.jar > ${{ env.logDir }}/rest-provider3.log 2>&1 &
+    - name: start four resttemplate provider service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az2
+        SERVICE_META_VERSION: 1.0.2
+        SERVER_PORT: 8024
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-provider/target/rest-provider.jar > ${{ env.logDir }}/rest-provider4.log 2>&1 &
+    - name: start cse resttemplate consumer service
+      shell: bash
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVICE_META_ZONE: az1
+        SERVICE_META_VERSION: 1.0.0
+        SERVER_PORT: 8020
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-resttemplate/rest-consumer/target/rest-consumer.jar > ${{ env.logDir }}/rest-consumer.log 2>&1 &
+    - name: start cse gateway
+      shell: bash
+      if: matrix.springCloudVersion != 'Edgware.SR2'
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVER_PORT: 8001
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-gateway/target/spring-common-gateway.jar > ${{ env.logDir }}/spring-common-gateway.log 2>&1 &
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8001/actuator/health 120
+    - name: start cse zuul
+      shell: bash
+      if: matrix.springCloudVersion == 'Edgware.SR2' || matrix.springCloudVersion == 'Finchley.RELEASE' || matrix.springCloudVersion == 'Greenwich.RELEASE' || matrix.springCloudVersion == 'Hoxton.RELEASE'
+      env:
+        sermant.springboot.registry.enableRegistry: true
+        SERVICECOMB_SERVICE_ENABLESPRINGREGISTER: true
+        dynamic.config.dynamicConfigType: KIE
+        dynamic.config.serverAddress: 127.0.0.1:30110
+        SERVICE_META_ENVIRONMENT: development
+        ROUTER_PLUGIN_ENABLED_REGISTRY_PLUGIN_ADAPTATION: true
+        ROUTER_PLUGIN_USE_REQUEST_ROUTER: false
+        SERVER_PORT: 8000
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=default -jar \
+        sermant-integration-tests/spring-test/spring-common-demos/spring-common-zuul/target/spring-common-zuul.jar > ${{ env.logDir }}/spring-common-zuul.log 2>&1 &
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8000/${{ env.healthApi }} 120
+    - name: waiting for services start
+      shell: bash
+      run: |
+        ps -ef | grep java
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8015/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8016/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8017/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8018/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8019/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8020/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8021/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8022/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8023/${{ env.healthApi }} 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8024/${{ env.healthApi }} 120
+    - name: integration test module TAG_ROUTER_AZ
+      shell: bash
+      env:
+        SPRING_CLOUD_VERSION: ${{ matrix.springCloudVersion }}
+      run: mvn test -Dsermant.integration.test.type=TAG_ROUTER_AZ --file sermant-integration-tests/spring-test/pom.xml
+    - name: exit
+      if: always()
+      uses: ./.github/actions/common/exit
+      with:
+        processor-keyword: feign|rest|zuul|gateway
+    - name: if failure then upload error log
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() || cancelled() }}
+      with:
+        name: (${{ github.job }})-tag-az-router-(${{ matrix.springBootVersion }}-${{ matrix.springCloudVersion }})-logs
+        path: |
+          ./*.log
+          ./logs/**
+        if-no-files-found: warn
+        retention-days: 2

--- a/.github/workflows/spring_integration_test_2.yml
+++ b/.github/workflows/spring_integration_test_2.yml
@@ -82,7 +82,7 @@ jobs:
   test-for-spring:
     name: Test for spring
     runs-on: ubuntu-latest
-    needs: [build-agent-and-cache, download-midwares-and-cache]
+    needs: [ build-agent-and-cache, download-midwares-and-cache ]
     strategy:
       matrix:
         include:
@@ -129,6 +129,9 @@ jobs:
       - name: (spring tag router) test for springboot=${{ matrix.springBootVersion }} springCloudVersion=${{ matrix.springCloudVersion }}
         if: env.enableSpringTagRouter == 'true'
         uses: ./.github/actions/scenarios/spring/router/spring-tag-router
+      - name: (spring tag az router) test for springboot=${{ matrix.springBootVersion }} springCloudVersion=${{ matrix.springCloudVersion }}
+        if: env.enableSpringTagRouter == 'true'
+        uses: ./.github/actions/scenarios/spring/router/spring-tag-az-router
       - name: (spring lane) test for springboot=${{ matrix.springBootVersion }} springCloudVersion=${{ matrix.springCloudVersion }}
         if: env.enableSpringLane == 'true'
         uses: ./.github/actions/scenarios/spring/lane

--- a/sermant-integration-tests/spring-test/spring-common-demos/pom.xml
+++ b/sermant-integration-tests/spring-test/spring-common-demos/pom.xml
@@ -17,8 +17,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>spring-test</artifactId>
         <groupId>com.huawei.spring.test</groupId>
@@ -42,6 +42,12 @@
                 <module>spring-common-feign</module>
                 <module>spring-common-resttemplate</module>
             </modules>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>flowcontrol-test-1.5.x</id>
@@ -49,6 +55,23 @@
                 <module>spring-common-feign-1.5.x</module>
                 <module>spring-common-resttemplate</module>
             </modules>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.netflix.ribbon</groupId>
+                            <artifactId>ribbon-loadbalancer</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.netflix.ribbon</groupId>
+                    <artifactId>ribbon-loadbalancer</artifactId>
+                    <version>2.2.5</version>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>common-test</id>
@@ -56,6 +79,12 @@
                 <module>spring-common-feign</module>
                 <module>spring-common-resttemplate</module>
             </modules>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>common-test-1.5.x</id>
@@ -63,18 +92,47 @@
                 <module>spring-common-feign-1.5.x</module>
                 <module>spring-common-resttemplate</module>
             </modules>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.netflix.ribbon</groupId>
+                            <artifactId>ribbon-loadbalancer</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.netflix.ribbon</groupId>
+                    <artifactId>ribbon-loadbalancer</artifactId>
+                    <version>2.2.5</version>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>zuul</id>
             <modules>
                 <module>spring-common-zuul</module>
             </modules>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>gateway</id>
             <modules>
                 <module>spring-common-gateway</module>
             </modules>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 
@@ -82,10 +140,6 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-commons</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-zookeeper-discovery</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/rule/SermantTestType.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/rule/SermantTestType.java
@@ -73,6 +73,11 @@ public enum SermantTestType {
     TAG_ROUTER,
 
     /**
+     * 同AZ优先标签路由测试
+     */
+    TAG_ROUTER_AZ,
+
+    /**
      * 优雅上下线测试
      */
     GRACEFUL,

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/router/TagRouterAzRule.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/router/TagRouterAzRule.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.intergration.router;
+
+import com.huaweicloud.intergration.common.rule.AbstractTestRule;
+import com.huaweicloud.intergration.common.rule.SermantTestType;
+
+import java.util.Set;
+
+/**
+ * 路由同AZ优先能力测试
+ *
+ * @author robotLJW
+ * @since 2023-03-09
+ */
+public class TagRouterAzRule extends AbstractTestRule {
+    @Override
+    protected boolean isSupport(Set<SermantTestType> types) {
+        return types.contains(SermantTestType.TAG_ROUTER_AZ);
+    }
+}

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/router/TagRouterAzTest.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/router/TagRouterAzTest.java
@@ -1,0 +1,563 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.intergration.router;
+
+import com.huaweicloud.intergration.config.supprt.KieClient;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 同AZ优先能力测试
+ *
+ * @author robotLJW
+ * @since 2023-3-9
+ */
+
+public class TagRouterAzTest {
+    private static final RestTemplate REST_TEMPLATE = new RestTemplate();
+
+    private static final KieClient KIE_CLIENT = new KieClient(REST_TEMPLATE);
+
+    private static final int ZUUL_PORT = 8000;
+
+    private static final int GATEWAY_PORT = 8001;
+
+    private static final String REST_KEY = "servicecomb.routeRule.rest-provider";
+
+    private static final String FEIGN_KEY = "servicecomb.routeRule.feign-provider";
+
+    private static final String IP = "http://127.0.0.1:";
+
+    private static final String BOOT_BASE_PATH = "/router/boot/getMetadata?exit=false";
+
+    private static final String CLOUD_BASE_PATH = "/router/cloud/getMetadata?exit=false";
+
+    private static final String REST_BASE_PATH = "/rest";
+
+    private static final String FEIGN_BASE_PATH = "/feign";
+
+    private static final String ZUUL_REST_CLOUD_BASE_PATH = IP + ZUUL_PORT + REST_BASE_PATH + CLOUD_BASE_PATH;
+
+    private static final String ZUUL_FEIGN_BOOT_BASE_PATH = IP + ZUUL_PORT + FEIGN_BASE_PATH + BOOT_BASE_PATH;
+
+    private static final String ZUUL_FEIGN_CLOUD_BASE_PATH = IP + ZUUL_PORT + FEIGN_BASE_PATH + CLOUD_BASE_PATH;
+
+    private static final String GATEWAY_REST_CLOUD_BASE_PATH = IP + GATEWAY_PORT + REST_BASE_PATH + CLOUD_BASE_PATH;
+
+    private static final String GATEWAY_FEIGN_BOOT_BASE_PATH = IP + GATEWAY_PORT + FEIGN_BASE_PATH + BOOT_BASE_PATH;
+
+    private static final String GATEWAY_FEIGN_CLOUD_BASE_PATH = IP + GATEWAY_PORT + FEIGN_BASE_PATH + CLOUD_BASE_PATH;
+
+    private static final int TIMES = 30;
+
+    private static final String SERVICE_CONFIG = "SERVICE_CONFIG";
+
+    @Rule
+    public final TagRouterAzRule routerAzRule = new TagRouterAzRule();
+
+    public static final List<String> SPRING_CLOUD_VERSIONS_FOR_ZUUL = Arrays
+            .asList("Edgware.SR2", "Finchley.RELEASE", "Greenwich.RELEASE", "Hoxton.RELEASE");
+
+    public static final List<String> SPRING_CLOUD_VERSIONS_FOR_GATEWAY = Arrays
+            .asList("Finchley.RELEASE", "Greenwich.RELEASE", "Hoxton.RELEASE", "2020.0.0", "2021.0.0", "2021.0.3");
+
+    private final String springCloudVersion;
+
+    public TagRouterAzTest() throws InterruptedException {
+        springCloudVersion = Optional.ofNullable(System.getenv("SPRING_CLOUD_VERSION")).orElse("Hoxton.RELEASE");
+        clearConfig();
+    }
+
+    /**
+     * given: 标签路由测试：同标签路由场景测试（规则含有TriggerThreshold的policy）
+     * when: 触发大于triggerThreshold
+     * then: 执行同AZ优先策略
+     */
+    @Test
+    public void testRouterWithTriggerThresholdPolicyRuleOne() throws InterruptedException {
+        // 测试zuul场景：SPRING_CLOUD_VERSIONS_FOR_ZUUL中的版本，才带有zuul的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_ZUUL.contains(springCloudVersion)) {
+            testTriggerThresholdPolicyAZRule(ZUUL_REST_CLOUD_BASE_PATH, ZUUL_FEIGN_BOOT_BASE_PATH, ZUUL_FEIGN_CLOUD_BASE_PATH);
+        }
+
+        // 测试gateway场景：SPRING_CLOUD_VERSIONS_FOR_GATEWAY中的版本，才带有gateway的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_GATEWAY.contains(springCloudVersion)) {
+            testTriggerThresholdPolicyAZRule(GATEWAY_REST_CLOUD_BASE_PATH, GATEWAY_FEIGN_BOOT_BASE_PATH, GATEWAY_FEIGN_CLOUD_BASE_PATH);
+        }
+        clearConfig();
+    }
+
+    /**
+     * given：标签路由测试：同标签路由场景测试（规则含有TriggerThreshold的policy）
+     * when：触发小于triggerThreshold
+     * then：非同AZ优先策略
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testRouterWithTriggerThresholdPolicyRuleTwo() throws InterruptedException {
+        // 测试zuul场景：SPRING_CLOUD_VERSIONS_FOR_ZUUL中的版本，才带有zuul的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_ZUUL.contains(springCloudVersion)) {
+            testTriggerThresholdPolicyAZRuleTwo(ZUUL_REST_CLOUD_BASE_PATH, ZUUL_FEIGN_BOOT_BASE_PATH, ZUUL_FEIGN_CLOUD_BASE_PATH);
+            return;
+        }
+
+        // 测试gateway场景：SPRING_CLOUD_VERSIONS_FOR_GATEWAY中的版本，才带有gateway的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_GATEWAY.contains(springCloudVersion)) {
+            testTriggerThresholdPolicyAZRuleTwo(GATEWAY_REST_CLOUD_BASE_PATH, GATEWAY_FEIGN_BOOT_BASE_PATH, GATEWAY_FEIGN_CLOUD_BASE_PATH);
+        }
+        clearConfig();
+    }
+
+    /**
+     * given：测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * when：大于minAllInstances和大于triggerThreshold场景
+     * then：同AZ优先策略
+     *
+     * @throws InterruptedException
+     */
+
+    @Test
+    public void testRouterPolicyRuleOne()throws InterruptedException{
+        // 测试zuul场景：SPRING_CLOUD_VERSIONS_FOR_ZUUL中的版本，才带有zuul的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_ZUUL.contains(springCloudVersion)) {
+            testPolicyAZRuleOne(ZUUL_REST_CLOUD_BASE_PATH, ZUUL_FEIGN_BOOT_BASE_PATH, ZUUL_FEIGN_CLOUD_BASE_PATH);
+            return;
+        }
+
+        // 测试gateway场景：SPRING_CLOUD_VERSIONS_FOR_GATEWAY中的版本，才带有gateway的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_GATEWAY.contains(springCloudVersion)) {
+            testPolicyAZRuleOne(GATEWAY_REST_CLOUD_BASE_PATH, GATEWAY_FEIGN_BOOT_BASE_PATH, GATEWAY_FEIGN_CLOUD_BASE_PATH);
+        }
+        clearConfig();
+    }
+
+    /**
+     * given：测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * when：大于minAllInstances和小于triggerThreshold场景
+     * then：非同AZ优先策略
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testRouterPolicyRuleTwo()throws InterruptedException{
+        // 测试zuul场景：SPRING_CLOUD_VERSIONS_FOR_ZUUL中的版本，才带有zuul的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_ZUUL.contains(springCloudVersion)) {
+            testPolicyAZRuleTwo(ZUUL_REST_CLOUD_BASE_PATH, ZUUL_FEIGN_BOOT_BASE_PATH, ZUUL_FEIGN_CLOUD_BASE_PATH);
+        }
+
+        // 测试gateway场景：SPRING_CLOUD_VERSIONS_FOR_GATEWAY中的版本，才带有gateway的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_GATEWAY.contains(springCloudVersion)) {
+            testPolicyAZRuleTwo(GATEWAY_REST_CLOUD_BASE_PATH, GATEWAY_FEIGN_BOOT_BASE_PATH, GATEWAY_FEIGN_CLOUD_BASE_PATH);
+        }
+        clearConfig();
+    }
+
+    /**
+     * given：测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * when：小于minAllInstances和大于triggerThreshold场景
+     * then：同AZ优先策略
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testRouterPolicyRuleThree()throws InterruptedException{
+        // 测试zuul场景：SPRING_CLOUD_VERSIONS_FOR_ZUUL中的版本，才带有zuul的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_ZUUL.contains(springCloudVersion)) {
+            testPolicyAZRuleThree(ZUUL_REST_CLOUD_BASE_PATH, ZUUL_FEIGN_BOOT_BASE_PATH, ZUUL_FEIGN_CLOUD_BASE_PATH);
+        }
+
+        // 测试gateway场景：SPRING_CLOUD_VERSIONS_FOR_GATEWAY中的版本，才带有gateway的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_GATEWAY.contains(springCloudVersion)) {
+            testPolicyAZRuleThree(GATEWAY_REST_CLOUD_BASE_PATH, GATEWAY_FEIGN_BOOT_BASE_PATH, GATEWAY_FEIGN_CLOUD_BASE_PATH);
+        }
+        clearConfig();
+    }
+
+    /**
+     * given：测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * when：小于minAllInstances和小于triggerThreshold场景
+     * then：同AZ优先策略
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testRouterPolicyRuleFour()throws InterruptedException{
+        // 测试zuul场景：SPRING_CLOUD_VERSIONS_FOR_ZUUL中的版本，才带有zuul的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_ZUUL.contains(springCloudVersion)) {
+            testPolicyAZRuleFour(ZUUL_REST_CLOUD_BASE_PATH, ZUUL_FEIGN_BOOT_BASE_PATH, ZUUL_FEIGN_CLOUD_BASE_PATH);
+        }
+
+        // 测试gateway场景：SPRING_CLOUD_VERSIONS_FOR_GATEWAY中的版本，才带有gateway的依赖
+        if (SPRING_CLOUD_VERSIONS_FOR_GATEWAY.contains(springCloudVersion)) {
+            testPolicyAZRuleFour(GATEWAY_REST_CLOUD_BASE_PATH, GATEWAY_FEIGN_BOOT_BASE_PATH, GATEWAY_FEIGN_CLOUD_BASE_PATH);
+        }
+        clearConfig();
+    }
+
+    /**
+     * 测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold的policy
+     * 触发大于triggerThreshold
+     *
+     * @param restCloudBasePath
+     * @param feignBootBasePath
+     * @param feignCloudBasePath
+     * @throws InterruptedException
+     */
+    public void testTriggerThresholdPolicyAZRule(String restCloudBasePath, String feignBootBasePath, String feignCloudBasePath) throws InterruptedException {
+        // 规则含有TriggerThreshold的policy
+        String CONTENT = "---\n"
+                + "- kind: routematcher.sermant.io/tag\n"
+                + "  description: tag-az-rule-trigger-threshold-test\n"
+                + "  rules:\n"
+                + "    - precedence: 1\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          zone:\n"
+                + "            exact: 'az1'\n"
+                + "            caseInsensitive: false\n"
+                + "        policy:\n"
+                + "          triggerThreshold: 40\n"
+                + "      route:\n"
+                + "        - tags:\n"
+                + "            zone: CONSUMER_TAG\n";
+        Assert.assertTrue(KIE_CLIENT.publishConfig(REST_KEY, CONTENT));
+        Assert.assertTrue(KIE_CLIENT.publishConfig(FEIGN_KEY, CONTENT));
+        TimeUnit.SECONDS.sleep(3);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        // 测试命中group:CONSUMER_TAG的实例(consumer自身zone:az1)
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> exchange;
+        for (int i = 0; i < TIMES; i++) {
+            exchange = REST_TEMPLATE.exchange(restCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignBootBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+        }
+    }
+
+    /**
+     * 测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold的policy
+     * 触发小于于triggerThreshold
+     *
+     * @param restCloudBasePath
+     * @param feignBootBasePath
+     * @param feignCloudBasePath
+     * @throws InterruptedException
+     */
+    public void testTriggerThresholdPolicyAZRuleTwo(String restCloudBasePath, String feignBootBasePath, String feignCloudBasePath) throws InterruptedException {
+        // 规则含有TriggerThreshold的policy
+        String CONTENT = "---\n"
+                + "- kind: routematcher.sermant.io/tag\n"
+                + "  description: tag-az-rule-trigger-threshold-test\n"
+                + "  rules:\n"
+                + "    - precedence: 1\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          zone:\n"
+                + "            exact: 'az1'\n"
+                + "            caseInsensitive: false\n"
+                + "        policy:\n"
+                + "          triggerThreshold: 90\n"
+                + "      route:\n"
+                + "        - tags:\n"
+                + "            zone: CONSUMER_TAG\n";
+        Assert.assertTrue(KIE_CLIENT.publishConfig(REST_KEY, CONTENT));
+        Assert.assertTrue(KIE_CLIENT.publishConfig(FEIGN_KEY, CONTENT));
+        TimeUnit.SECONDS.sleep(3);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        // 测试命中group:CONSUMER_TAG的实例(consumer自身zone:az1)
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> exchange;
+        int restCloudAZ1 = 0, restCloudAZ2 = 0;
+        int feignBootAZ1 = 0, feignBootAZ2 = 0;
+        int feignCloudAZ1 = 0, feignCloudAZ2 = 0;
+        for (int i = 0; i < TIMES; i++) {
+            exchange = REST_TEMPLATE.exchange(restCloudBasePath, HttpMethod.GET, entity, String.class);
+            if (Objects.requireNonNull(exchange.getBody()).contains("az1")) {
+                restCloudAZ1++;
+            } else if (Objects.requireNonNull(exchange.getBody()).contains("az2")) {
+                restCloudAZ2++;
+            }
+
+            exchange = REST_TEMPLATE.exchange(feignBootBasePath, HttpMethod.GET, entity, String.class);
+            if (Objects.requireNonNull(exchange.getBody()).contains("az1")) {
+                feignBootAZ1++;
+            } else if (Objects.requireNonNull(exchange.getBody()).contains("az2")) {
+                feignBootAZ2++;
+            }
+
+            exchange = REST_TEMPLATE.exchange(feignCloudBasePath, HttpMethod.GET, entity, String.class);
+            if (Objects.requireNonNull(exchange.getBody()).contains("az1")) {
+                feignCloudAZ1++;
+            } else if (Objects.requireNonNull(exchange.getBody()).contains("az2")) {
+                feignCloudAZ2++;
+            }
+        }
+        Assert.assertNotEquals(0, restCloudAZ1);
+        Assert.assertNotEquals(0, restCloudAZ2);
+        Assert.assertNotEquals(0, feignBootAZ1);
+        Assert.assertNotEquals(0, feignBootAZ2);
+        Assert.assertNotEquals(0, feignCloudAZ1);
+        Assert.assertNotEquals(0, feignCloudAZ2);
+    }
+
+    /**
+     * 测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * 大于minAllInstances和大于triggerThreshold场景
+     * 同AZ优先策略
+     *
+     * @param restCloudBasePath
+     * @param feignBootBasePath
+     * @param feignCloudBasePath
+     * @throws InterruptedException
+     */
+    public void testPolicyAZRuleOne(String restCloudBasePath, String feignBootBasePath, String feignCloudBasePath) throws InterruptedException {
+        // 规则含有TriggerThreshold的policy
+        String CONTENT = "---\n"
+                + "- kind: routematcher.sermant.io/tag\n"
+                + "  description: tag-az-rule-trigger-threshold-test\n"
+                + "  rules:\n"
+                + "    - precedence: 1\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          zone:\n"
+                + "            exact: 'az1'\n"
+                + "            caseInsensitive: false\n"
+                + "        policy:\n"
+                + "          triggerThreshold: 40\n"
+                + "          minAllInstances: 2\n"
+                + "      route:\n"
+                + "        - tags:\n"
+                + "            zone: CONSUMER_TAG\n";
+        Assert.assertTrue(KIE_CLIENT.publishConfig(REST_KEY, CONTENT));
+        Assert.assertTrue(KIE_CLIENT.publishConfig(FEIGN_KEY, CONTENT));
+        TimeUnit.SECONDS.sleep(3);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        // 测试命中group:CONSUMER_TAG的实例(consumer自身zone:az1)
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> exchange;
+        for (int i = 0; i < TIMES; i++) {
+            exchange = REST_TEMPLATE.exchange(restCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignBootBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+        }
+    }
+
+    /**
+     * 测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * 大于minAllInstances和小于triggerThreshold场景
+     * 非同AZ优先策略
+     *
+     * @param restCloudBasePath
+     * @param feignBootBasePath
+     * @param feignCloudBasePath
+     * @throws InterruptedException
+     */
+    public void testPolicyAZRuleTwo(String restCloudBasePath, String feignBootBasePath, String feignCloudBasePath) throws InterruptedException {
+        // 规则含有TriggerThreshold的policy
+        String CONTENT = "---\n"
+                + "- kind: routematcher.sermant.io/tag\n"
+                + "  description: tag-az-rule-trigger-threshold-test\n"
+                + "  rules:\n"
+                + "    - precedence: 1\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          zone:\n"
+                + "            exact: 'az1'\n"
+                + "            caseInsensitive: false\n"
+                + "        policy:\n"
+                + "          triggerThreshold: 90\n"
+                + "          minAllInstances: 2\n"
+                + "      route:\n"
+                + "        - tags:\n"
+                + "            zone: CONSUMER_TAG\n";
+        Assert.assertTrue(KIE_CLIENT.publishConfig(REST_KEY, CONTENT));
+        Assert.assertTrue(KIE_CLIENT.publishConfig(FEIGN_KEY, CONTENT));
+        TimeUnit.SECONDS.sleep(3);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        // 测试命中group:CONSUMER_TAG的实例(consumer自身zone:az1)
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> exchange;
+        int restCloudAZ1 = 0, restCloudAZ2 = 0;
+        int feignBootAZ1 = 0, feignBootAZ2 = 0;
+        int feignCloudAZ1 = 0, feignCloudAZ2 = 0;
+        for (int i = 0; i < TIMES; i++) {
+            exchange = REST_TEMPLATE.exchange(restCloudBasePath, HttpMethod.GET, entity, String.class);
+            if (Objects.requireNonNull(exchange.getBody()).contains("az1")) {
+                restCloudAZ1++;
+            } else if (Objects.requireNonNull(exchange.getBody()).contains("az2")) {
+                restCloudAZ2++;
+            }
+
+            exchange = REST_TEMPLATE.exchange(feignBootBasePath, HttpMethod.GET, entity, String.class);
+            if (Objects.requireNonNull(exchange.getBody()).contains("az1")) {
+                feignBootAZ1++;
+            } else if (Objects.requireNonNull(exchange.getBody()).contains("az2")) {
+                feignBootAZ2++;
+            }
+
+            exchange = REST_TEMPLATE.exchange(feignCloudBasePath, HttpMethod.GET, entity, String.class);
+            if (Objects.requireNonNull(exchange.getBody()).contains("az1")) {
+                feignCloudAZ1++;
+            } else if (Objects.requireNonNull(exchange.getBody()).contains("az2")) {
+                feignCloudAZ2++;
+            }
+        }
+        Assert.assertNotEquals(0, restCloudAZ1);
+        Assert.assertNotEquals(0, restCloudAZ2);
+        Assert.assertNotEquals(0, feignBootAZ1);
+        Assert.assertNotEquals(0, feignBootAZ2);
+        Assert.assertNotEquals(0, feignCloudAZ1);
+        Assert.assertNotEquals(0, feignCloudAZ2);
+    }
+
+    /**
+     * 测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * 小于minAllInstances和大于triggerThreshold场景
+     * 同AZ优先策略
+     *
+     * @param restCloudBasePath
+     * @param feignBootBasePath
+     * @param feignCloudBasePath
+     * @throws InterruptedException
+     */
+    public void testPolicyAZRuleThree(String restCloudBasePath, String feignBootBasePath, String feignCloudBasePath) throws InterruptedException {
+        // 规则含有TriggerThreshold的policy
+        String CONTENT = "---\n"
+                + "- kind: routematcher.sermant.io/tag\n"
+                + "  description: tag-az-rule-trigger-threshold-test\n"
+                + "  rules:\n"
+                + "    - precedence: 1\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          zone:\n"
+                + "            exact: 'az1'\n"
+                + "            caseInsensitive: false\n"
+                + "        policy:\n"
+                + "          triggerThreshold: 40\n"
+                + "          minAllInstances: 10\n"
+                + "      route:\n"
+                + "        - tags:\n"
+                + "            zone: CONSUMER_TAG\n";
+        Assert.assertTrue(KIE_CLIENT.publishConfig(REST_KEY, CONTENT));
+        Assert.assertTrue(KIE_CLIENT.publishConfig(FEIGN_KEY, CONTENT));
+        TimeUnit.SECONDS.sleep(3);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        // 测试命中group:CONSUMER_TAG的实例(consumer自身zone:az1)
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> exchange;
+        for (int i = 0; i < TIMES; i++) {
+            exchange = REST_TEMPLATE.exchange(restCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignBootBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+        }
+    }
+
+    /**
+     * 测试tag匹配规则同AZ优先标签路由功能：规则含有TriggerThreshold和minAllInstances的policy
+     * 小于minAllInstances和小于triggerThreshold场景
+     * 同AZ优先策略
+     *
+     * @param restCloudBasePath
+     * @param feignBootBasePath
+     * @param feignCloudBasePath
+     * @throws InterruptedException
+     */
+    public void testPolicyAZRuleFour(String restCloudBasePath, String feignBootBasePath, String feignCloudBasePath) throws InterruptedException {
+        // 规则含有TriggerThreshold的policy
+        String CONTENT = "---\n"
+                + "- kind: routematcher.sermant.io/tag\n"
+                + "  description: tag-az-rule-trigger-threshold-test\n"
+                + "  rules:\n"
+                + "    - precedence: 1\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          zone:\n"
+                + "            exact: 'az1'\n"
+                + "            caseInsensitive: false\n"
+                + "        policy:\n"
+                + "          triggerThreshold: 90\n"
+                + "          minAllInstances: 10\n"
+                + "      route:\n"
+                + "        - tags:\n"
+                + "            zone: CONSUMER_TAG\n";
+        Assert.assertTrue(KIE_CLIENT.publishConfig(REST_KEY, CONTENT));
+        Assert.assertTrue(KIE_CLIENT.publishConfig(FEIGN_KEY, CONTENT));
+        TimeUnit.SECONDS.sleep(3);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        // 测试命中group:CONSUMER_TAG的实例(consumer自身zone:az1)
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> exchange;
+        for (int i = 0; i < TIMES; i++) {
+            exchange = REST_TEMPLATE.exchange(restCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignBootBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+
+            exchange = REST_TEMPLATE.exchange(feignCloudBasePath, HttpMethod.GET, entity, String.class);
+            Assert.assertTrue(Objects.requireNonNull(exchange.getBody()).contains("az1"));
+        }
+    }
+
+
+    private void clearConfig() throws InterruptedException {
+        KIE_CLIENT.deleteKey(REST_KEY);
+        KIE_CLIENT.deleteKey(FEIGN_KEY);
+        TimeUnit.SECONDS.sleep(3);
+    }
+
+}

--- a/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/handler/TagRouteHandler.java
+++ b/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/handler/TagRouteHandler.java
@@ -33,6 +33,7 @@ import com.huaweicloud.sermant.router.dubbo.strategy.RuleStrategyHandler;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * tag匹配方式的路由处理器
@@ -41,6 +42,17 @@ import java.util.Map;
  * @since 2023-02-24
  */
 public class TagRouteHandler extends AbstractRouteHandler {
+
+    /**
+     * 版本key
+     */
+    private static final String VERSION_KEY = "version";
+
+    /**
+     * 区域key
+     */
+    private static final String ZONE_KEY = "zone";
+
     @Override
     public Object handle(String targetService, List<Object> invokers, Object invocation, Map<String, String> queryMap,
             String serviceInterface) {
@@ -63,30 +75,21 @@ public class TagRouteHandler extends AbstractRouteHandler {
             return invokers;
         }
         List<Rule> rules = TagRuleUtils.getTagRules(configuration, targetService, DubboCache.INSTANCE.getAppName());
-        List<Route> routes = getRoutes(rules);
-        if (!CollectionUtils.isEmpty(routes)) {
-            return RuleStrategyHandler.INSTANCE.getMatchInvokers(targetService, invokers, routes);
+        Optional<Rule> rule = getRule(rules);
+        if (rule.isPresent() && !CollectionUtils.isEmpty(rule.get().getRoute())) {
+            return RuleStrategyHandler.INSTANCE.getMatchInvokers(targetService, invokers, rule.get());
         }
         return invokers;
     }
 
-    /**
-     * 获取匹配的路由
-     *
-     * @param list 有效的规则
-     * @return 匹配的路由
-     */
-    private List<Route> getRoutes(List<Rule> list) {
-        if (DubboCache.INSTANCE.getParameters() == null) {
-            return Collections.emptyList();
-        }
+    private Optional<Rule> getRule(List<Rule> list) {
         for (Rule rule : list) {
             List<Route> routeList = getRoutes(rule);
             if (!CollectionUtils.isEmpty(routeList)) {
-                return routeList;
+                return Optional.of(rule);
             }
         }
-        return Collections.emptyList();
+        return Optional.empty();
     }
 
     private List<Route> getRoutes(Rule rule) {
@@ -106,7 +109,21 @@ public class TagRouteHandler extends AbstractRouteHandler {
                 ValueMatch valueMatch = matchRule.getValueMatch();
                 List<String> values = valueMatch.getValues();
                 MatchStrategy matchStrategy = valueMatch.getMatchStrategy();
-                String tagValue = DubboCache.INSTANCE.getParameters().get(RouterConstant.PARAMETERS_KEY_PREFIX + key);
+                Map<String, String> parameters = DubboCache.INSTANCE.getParameters();
+                if (parameters == null) {
+                    return Collections.emptyList();
+                }
+                String tagValue;
+                switch (key) {
+                    case VERSION_KEY:
+                        tagValue = parameters.get(RouterConstant.VERSION_KEY);
+                        break;
+                    case ZONE_KEY:
+                        tagValue = parameters.get(RouterConstant.ZONE_KEY);
+                        break;
+                    default:
+                        tagValue = parameters.get(RouterConstant.PARAMETERS_KEY_PREFIX + key);
+                }
                 if (!isFullMatch && matchStrategy.isMatch(values, tagValue, matchRule.isCaseInsensitive())) {
                     // 如果不是全匹配，且匹配了一个，那么直接return
                     return rule.getRoute();

--- a/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/RuleStrategyHandler.java
+++ b/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/RuleStrategyHandler.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.router.dubbo.strategy;
 
 import com.huaweicloud.sermant.router.config.entity.Route;
+import com.huaweicloud.sermant.router.config.entity.Rule;
 import com.huaweicloud.sermant.router.config.strategy.RuleStrategy;
 import com.huaweicloud.sermant.router.dubbo.strategy.rule.InvokerRuleStrategy;
 
@@ -51,6 +52,18 @@ public enum RuleStrategyHandler {
      */
     public List<Object> getMatchInvokers(String serviceName, List<Object> invokers, List<Route> routes) {
         return ruleStrategy.getMatchInstances(serviceName, invokers, routes);
+    }
+
+    /**
+     * 根据rule选取标签应用的invokers
+     *
+     * @param serviceName 服务名
+     * @param invokers dubbo invokers
+     * @param rule 规则
+     * @return 标签应用的invokers
+     */
+    public List<Object> getMatchInvokers(String serviceName, List<Object> invokers, Rule rule) {
+        return ruleStrategy.getMatchInstances(serviceName, invokers, rule);
     }
 
     /**

--- a/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/instance/MatchInstanceStrategy.java
+++ b/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/instance/MatchInstanceStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,9 @@ public class MatchInstanceStrategy extends AbstractInstanceStrategy<Object, Map<
     private String getKey(String tag) {
         if (VERSION_KEY.equals(tag)) {
             return RouterConstant.VERSION_KEY;
+        }
+        if (ZONE_KEY.equals(tag)) {
+            return RouterConstant.ZONE_KEY;
         }
         return RouterConstant.PARAMETERS_KEY_PREFIX + tag;
     }

--- a/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/instance/MismatchInstanceStrategy.java
+++ b/sermant-plugins/sermant-router/dubbo-router-service/src/main/java/com/huaweicloud/sermant/router/dubbo/strategy/instance/MismatchInstanceStrategy.java
@@ -66,6 +66,9 @@ public class MismatchInstanceStrategy extends AbstractInstanceStrategy<Object, L
         if (VERSION_KEY.equals(tag)) {
             return RouterConstant.VERSION_KEY;
         }
+        if (ZONE_KEY.equals(tag)) {
+            return RouterConstant.ZONE_KEY;
+        }
         return RouterConstant.PARAMETERS_KEY_PREFIX + tag;
     }
 }

--- a/sermant-plugins/sermant-router/dubbo-router-service/src/test/java/com/huaweicloud/sermant/router/dubbo/RuleInitializationUtils.java
+++ b/sermant-plugins/sermant-router/dubbo-router-service/src/test/java/com/huaweicloud/sermant/router/dubbo/RuleInitializationUtils.java
@@ -18,14 +18,7 @@ package com.huaweicloud.sermant.router.dubbo;
 
 import com.huaweicloud.sermant.router.common.constants.RouterConstant;
 import com.huaweicloud.sermant.router.config.cache.ConfigCache;
-import com.huaweicloud.sermant.router.config.entity.EntireRule;
-import com.huaweicloud.sermant.router.config.entity.Match;
-import com.huaweicloud.sermant.router.config.entity.MatchRule;
-import com.huaweicloud.sermant.router.config.entity.MatchStrategy;
-import com.huaweicloud.sermant.router.config.entity.Route;
-import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
-import com.huaweicloud.sermant.router.config.entity.Rule;
-import com.huaweicloud.sermant.router.config.entity.ValueMatch;
+import com.huaweicloud.sermant.router.config.entity.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -342,4 +335,114 @@ public class RuleInitializationUtils {
         RouterConfiguration configuration = ConfigCache.getLabel(RouterConstant.DUBBO_CACHE_NAME);
         configuration.resetGlobalRule(Collections.singletonList(entireRule));
     }
+
+    public static void initAZTagMatchRule() {
+        ValueMatch valueMatch = new ValueMatch();
+        valueMatch.setMatchStrategy(MatchStrategy.EXACT);
+        valueMatch.setValues(Collections.singletonList("az1"));
+        MatchRule matchRule = new MatchRule();
+        matchRule.setValueMatch(valueMatch);
+        List<MatchRule> matchRuleList = new ArrayList<>();
+        matchRuleList.add(matchRule);
+        Map<String, List<MatchRule>> tagMatchRule = new HashMap<>();
+        tagMatchRule.put("zone", matchRuleList);
+        Match match = new Match();
+        match.setTags(tagMatchRule);
+        Rule rule = new Rule();
+        rule.setPrecedence(2);
+        rule.setMatch(match);
+        Route route = new Route();
+        route.setWeight(100);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("zone", "az1");
+        route.setTags(tags);
+        List<Route> routeList = new ArrayList<>();
+        routeList.add(route);
+        rule.setRoute(routeList);
+        List<Rule> ruleList = new ArrayList<>();
+        ruleList.add(rule);
+        EntireRule entireRule = new EntireRule();
+        entireRule.setRules(ruleList);
+        entireRule.setKind(RouterConstant.TAG_MATCH_KIND);
+        RouterConfiguration configuration = ConfigCache.getLabel(RouterConstant.DUBBO_CACHE_NAME);
+        configuration.resetGlobalRule(Collections.singletonList(entireRule));
+    }
+
+    public static void initAZTagMatchTriggerThresholdPolicyRule() {
+        ValueMatch valueMatch = new ValueMatch();
+        valueMatch.setMatchStrategy(MatchStrategy.EXACT);
+        valueMatch.setValues(Collections.singletonList("az1"));
+        MatchRule matchRule = new MatchRule();
+        matchRule.setValueMatch(valueMatch);
+        List<MatchRule> matchRuleList = new ArrayList<>();
+        matchRuleList.add(matchRule);
+        Map<String, List<MatchRule>> tagMatchRule = new HashMap<>();
+        tagMatchRule.put("zone", matchRuleList);
+        Match match = new Match();
+        match.setTags(tagMatchRule);
+        Policy policy = new Policy();
+        policy.setTriggerThreshold(60);
+        match.setPolicy(policy);
+        Rule rule = new Rule();
+        rule.setPrecedence(2);
+        rule.setMatch(match);
+        Route route = new Route();
+        route.setWeight(100);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("zone", "az1");
+        route.setTags(tags);
+        List<Route> routeList = new ArrayList<>();
+        routeList.add(route);
+        rule.setRoute(routeList);
+        List<Rule> ruleList = new ArrayList<>();
+        ruleList.add(rule);
+        Map<String, List<EntireRule>> map = new HashMap<>();
+        EntireRule entireRule = new EntireRule();
+        entireRule.setRules(ruleList);
+        entireRule.setKind(RouterConstant.TAG_MATCH_KIND);
+        map.put("foo", Collections.singletonList(entireRule));
+        RouterConfiguration configuration = ConfigCache.getLabel(RouterConstant.DUBBO_CACHE_NAME);
+        configuration.resetRouteRule(map);
+        configuration.resetGlobalRule(Collections.singletonList(entireRule));
+    }
+
+    public static void initAZTagMatchTriggerThresholdMinAllInstancesPolicyRule() {
+        ValueMatch valueMatch = new ValueMatch();
+        valueMatch.setMatchStrategy(MatchStrategy.EXACT);
+        valueMatch.setValues(Collections.singletonList("az1"));
+        MatchRule matchRule = new MatchRule();
+        matchRule.setValueMatch(valueMatch);
+        List<MatchRule> matchRuleList = new ArrayList<>();
+        matchRuleList.add(matchRule);
+        Map<String, List<MatchRule>> tagMatchRule = new HashMap<>();
+        tagMatchRule.put("zone", matchRuleList);
+        Match match = new Match();
+        match.setTags(tagMatchRule);
+        Policy policy = new Policy();
+        policy.setTriggerThreshold(50);
+        policy.setMinAllInstances(4);
+        match.setPolicy(policy);
+        Rule rule = new Rule();
+        rule.setPrecedence(2);
+        rule.setMatch(match);
+        Route route = new Route();
+        route.setWeight(100);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("zone", "az1");
+        route.setTags(tags);
+        List<Route> routeList = new ArrayList<>();
+        routeList.add(route);
+        rule.setRoute(routeList);
+        List<Rule> ruleList = new ArrayList<>();
+        ruleList.add(rule);
+        Map<String, List<EntireRule>> map = new HashMap<>();
+        EntireRule entireRule = new EntireRule();
+        entireRule.setRules(ruleList);
+        entireRule.setKind(RouterConstant.TAG_MATCH_KIND);
+        map.put("foo", Collections.singletonList(entireRule));
+        RouterConfiguration configuration = ConfigCache.getLabel(RouterConstant.DUBBO_CACHE_NAME);
+        configuration.resetRouteRule(map);
+        configuration.resetGlobalRule(Collections.singletonList(entireRule));
+    }
+
 }

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/entity/Match.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/entity/Match.java
@@ -89,6 +89,11 @@ public class Match {
     @JSONField(deserializeUsing = ValueMatchDeserializer.class)
     private Map<String, List<MatchRule>> tags;
 
+    /**
+     * 阈值策略
+     */
+    private Policy policy;
+
     public String getSource() {
         return source;
     }
@@ -175,5 +180,13 @@ public class Match {
 
     public void setTags(Map<String, List<MatchRule>> tags) {
         this.tags = tags;
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    public void setPolicy(Policy policy) {
+        this.policy = policy;
     }
 }

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/entity/Policy.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/entity/Policy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.config.entity;
+
+/**
+ * 阈值策略
+ *
+ * @author robotLJW
+ * @since 2023-02-28
+ */
+public class Policy {
+
+    /**
+     * 百分之一
+     */
+    private static final float ONE_PERCENT = 0.01f;
+
+    /**
+     * 同AZ占比触发阈值
+     */
+
+    private float triggerThreshold;
+
+    /**
+     * 全部实例最小可用阈值
+     */
+    private int minAllInstances;
+
+    public double getTriggerThreshold() {
+        return triggerThreshold;
+    }
+
+    public void setTriggerThreshold(float triggerThreshold) {
+        // 需要做个百分比转化，乘0.01
+        this.triggerThreshold = triggerThreshold * ONE_PERCENT;
+    }
+
+    public int getMinAllInstances() {
+        return minAllInstances;
+    }
+
+    public void setMinAllInstances(int minAllInstances) {
+        this.minAllInstances = minAllInstances;
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/strategy/RuleStrategy.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/strategy/RuleStrategy.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.router.config.strategy;
 
 import com.huaweicloud.sermant.router.config.entity.Route;
+import com.huaweicloud.sermant.router.config.entity.Rule;
 
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,16 @@ public interface RuleStrategy<I> {
      * @return 路由过滤后的实例
      */
     List<I> getMatchInstances(String serviceName, List<I> instances, List<Route> routes);
+
+    /**
+     * 选取路由的实例
+     *
+     * @param serviceName 服务名
+     * @param instances 实例列表
+     * @param rule 规则
+     * @return 规则过滤后的实例
+     */
+    List<I> getMatchInstances(String serviceName, List<I> instances, Rule rule);
 
     /**
      * 根据请求信息选取路由的实例

--- a/sermant-plugins/sermant-router/spring-router-service/src/main/java/com/huaweicloud/sermant/router/spring/handler/TagRouteHandler.java
+++ b/sermant-plugins/sermant-router/spring-router-service/src/main/java/com/huaweicloud/sermant/router/spring/handler/TagRouteHandler.java
@@ -34,6 +34,7 @@ import com.huaweicloud.sermant.router.spring.strategy.RuleStrategyHandler;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * tag匹配方式的路由处理器
@@ -63,30 +64,21 @@ public class TagRouteHandler extends AbstractRouteHandler {
             return instances;
         }
         List<Rule> rules = TagRuleUtils.getTagRules(configuration, targetName, AppCache.INSTANCE.getAppName());
-        List<Route> routes = getRoutes(rules);
-        if (!CollectionUtils.isEmpty(routes)) {
-            return RuleStrategyHandler.INSTANCE.getMatchInstances(targetName, instances, routes);
+        Optional<Rule> rule = getRule(rules);
+        if (rule.isPresent() && !CollectionUtils.isEmpty(rule.get().getRoute())) {
+            return RuleStrategyHandler.INSTANCE.getMatchInstances(targetName, instances, rule.get());
         }
         return instances;
     }
 
-    /**
-     * 获取匹配的路由
-     *
-     * @param list 有效的规则
-     * @return 匹配的路由
-     */
-    private List<Route> getRoutes(List<Rule> list) {
-        if (AppCache.INSTANCE.getMetadata() == null) {
-            return Collections.emptyList();
-        }
+    private Optional<Rule> getRule(List<Rule> list) {
         for (Rule rule : list) {
             List<Route> routeList = getRoutes(rule);
             if (!CollectionUtils.isEmpty(routeList)) {
-                return routeList;
+                return Optional.of(rule);
             }
         }
-        return Collections.emptyList();
+        return Optional.empty();
     }
 
     private List<Route> getRoutes(Rule rule) {

--- a/sermant-plugins/sermant-router/spring-router-service/src/main/java/com/huaweicloud/sermant/router/spring/strategy/RuleStrategyHandler.java
+++ b/sermant-plugins/sermant-router/spring-router-service/src/main/java/com/huaweicloud/sermant/router/spring/strategy/RuleStrategyHandler.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.router.spring.strategy;
 
 import com.huaweicloud.sermant.router.config.entity.Route;
+import com.huaweicloud.sermant.router.config.entity.Rule;
 import com.huaweicloud.sermant.router.config.strategy.AbstractRuleStrategy;
 import com.huaweicloud.sermant.router.spring.strategy.mapper.AbstractMetadataMapper;
 import com.huaweicloud.sermant.router.spring.strategy.mapper.DefaultMetadataMapper;
@@ -69,6 +70,18 @@ public enum RuleStrategyHandler {
      */
     public List<Object> getMatchInstances(String serviceName, List<Object> instances, List<Route> routes) {
         return getRuleStrategy(instances).getMatchInstances(serviceName, instances, routes);
+    }
+
+    /**
+     * 选取rule匹配的实例
+     *
+     * @param serviceName 服务名
+     * @param instances 实例列表
+     * @param rule rule规则
+     * @return 规则匹配的实例
+     */
+    public List<Object> getMatchInstances(String serviceName, List<Object> instances, Rule rule) {
+        return getRuleStrategy(instances).getMatchInstances(serviceName, instances, rule);
     }
 
     /**

--- a/sermant-plugins/sermant-router/spring-router-service/src/test/java/com/huaweicloud/sermant/router/spring/RuleInitializationUtils.java
+++ b/sermant-plugins/sermant-router/spring-router-service/src/test/java/com/huaweicloud/sermant/router/spring/RuleInitializationUtils.java
@@ -18,14 +18,7 @@ package com.huaweicloud.sermant.router.spring;
 
 import com.huaweicloud.sermant.router.common.constants.RouterConstant;
 import com.huaweicloud.sermant.router.config.cache.ConfigCache;
-import com.huaweicloud.sermant.router.config.entity.EntireRule;
-import com.huaweicloud.sermant.router.config.entity.Match;
-import com.huaweicloud.sermant.router.config.entity.MatchRule;
-import com.huaweicloud.sermant.router.config.entity.MatchStrategy;
-import com.huaweicloud.sermant.router.config.entity.Route;
-import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
-import com.huaweicloud.sermant.router.config.entity.Rule;
-import com.huaweicloud.sermant.router.config.entity.ValueMatch;
+import com.huaweicloud.sermant.router.config.entity.*;
 import com.huaweicloud.sermant.router.spring.cache.AppCache;
 
 import java.util.ArrayList;
@@ -349,4 +342,117 @@ public class RuleInitializationUtils {
         configuration.resetGlobalRule(Collections.singletonList(entireRule));
         AppCache.INSTANCE.setAppName("foo");
     }
+
+    public static void initAZTagMatchRule() {
+        ValueMatch valueMatch = new ValueMatch();
+        valueMatch.setMatchStrategy(MatchStrategy.EXACT);
+        valueMatch.setValues(Collections.singletonList("az1"));
+        MatchRule matchRule = new MatchRule();
+        matchRule.setValueMatch(valueMatch);
+        List<MatchRule> matchRuleList = new ArrayList<>();
+        matchRuleList.add(matchRule);
+        Map<String, List<MatchRule>> tagMatchRule = new HashMap<>();
+        tagMatchRule.put("zone", matchRuleList);
+        Match match = new Match();
+        match.setTags(tagMatchRule);
+        Rule rule = new Rule();
+        rule.setPrecedence(2);
+        rule.setMatch(match);
+        Route route = new Route();
+        route.setWeight(100);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("zone", "az1");
+        route.setTags(tags);
+        List<Route> routeList = new ArrayList<>();
+        routeList.add(route);
+        rule.setRoute(routeList);
+        List<Rule> ruleList = new ArrayList<>();
+        ruleList.add(rule);
+        Map<String, List<EntireRule>> map = new HashMap<>();
+        EntireRule entireRule = new EntireRule();
+        entireRule.setRules(ruleList);
+        entireRule.setKind(RouterConstant.TAG_MATCH_KIND);
+        map.put("foo", Collections.singletonList(entireRule));
+        RouterConfiguration configuration = ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME);
+        configuration.resetRouteRule(map);
+        AppCache.INSTANCE.setAppName("foo");
+    }
+
+    public static void initAZTagMatchTriggerThresholdPolicyRule() {
+        ValueMatch valueMatch = new ValueMatch();
+        valueMatch.setMatchStrategy(MatchStrategy.EXACT);
+        valueMatch.setValues(Collections.singletonList("az1"));
+        MatchRule matchRule = new MatchRule();
+        matchRule.setValueMatch(valueMatch);
+        List<MatchRule> matchRuleList = new ArrayList<>();
+        matchRuleList.add(matchRule);
+        Map<String, List<MatchRule>> tagMatchRule = new HashMap<>();
+        tagMatchRule.put("zone", matchRuleList);
+        Match match = new Match();
+        match.setTags(tagMatchRule);
+        Policy policy = new Policy();
+        policy.setTriggerThreshold(60);
+        match.setPolicy(policy);
+        Rule rule = new Rule();
+        rule.setPrecedence(2);
+        rule.setMatch(match);
+        Route route = new Route();
+        route.setWeight(100);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("zone", "az1");
+        route.setTags(tags);
+        List<Route> routeList = new ArrayList<>();
+        routeList.add(route);
+        rule.setRoute(routeList);
+        List<Rule> ruleList = new ArrayList<>();
+        ruleList.add(rule);
+        Map<String, List<EntireRule>> map = new HashMap<>();
+        EntireRule entireRule = new EntireRule();
+        entireRule.setRules(ruleList);
+        entireRule.setKind(RouterConstant.TAG_MATCH_KIND);
+        map.put("foo", Collections.singletonList(entireRule));
+        RouterConfiguration configuration = ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME);
+        configuration.resetRouteRule(map);
+        AppCache.INSTANCE.setAppName("foo");
+    }
+
+    public static void initAZTagMatchTriggerThresholdMinAllInstancesPolicyRule() {
+        ValueMatch valueMatch = new ValueMatch();
+        valueMatch.setMatchStrategy(MatchStrategy.EXACT);
+        valueMatch.setValues(Collections.singletonList("az1"));
+        MatchRule matchRule = new MatchRule();
+        matchRule.setValueMatch(valueMatch);
+        List<MatchRule> matchRuleList = new ArrayList<>();
+        matchRuleList.add(matchRule);
+        Map<String, List<MatchRule>> tagMatchRule = new HashMap<>();
+        tagMatchRule.put("zone", matchRuleList);
+        Match match = new Match();
+        match.setTags(tagMatchRule);
+        Policy policy = new Policy();
+        policy.setTriggerThreshold(50);
+        policy.setMinAllInstances(4);
+        match.setPolicy(policy);
+        Rule rule = new Rule();
+        rule.setPrecedence(2);
+        rule.setMatch(match);
+        Route route = new Route();
+        route.setWeight(100);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("zone", "az1");
+        route.setTags(tags);
+        List<Route> routeList = new ArrayList<>();
+        routeList.add(route);
+        rule.setRoute(routeList);
+        List<Rule> ruleList = new ArrayList<>();
+        ruleList.add(rule);
+        Map<String, List<EntireRule>> map = new HashMap<>();
+        EntireRule entireRule = new EntireRule();
+        entireRule.setRules(ruleList);
+        entireRule.setKind(RouterConstant.TAG_MATCH_KIND);
+        map.put("foo", Collections.singletonList(entireRule));
+        RouterConfiguration configuration = ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME);
+        configuration.resetRouteRule(map);
+        AppCache.INSTANCE.setAppName("foo");
+    }
+
 }

--- a/sermant-plugins/sermant-router/spring-router-service/src/test/java/com/huaweicloud/sermant/router/spring/handler/TagRouteHandlerTest.java
+++ b/sermant-plugins/sermant-router/spring-router-service/src/test/java/com/huaweicloud/sermant/router/spring/handler/TagRouteHandlerTest.java
@@ -137,4 +137,221 @@ public class TagRouteHandlerTest {
         Assert.assertEquals(instance2, targetInstances.get(0));
         ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetGlobalRule(Collections.emptyList());
     }
+
+    /**
+     * 测试rule规则如下：
+     * given: match为精确匹配az1，未设置policy，下游provider有az1实例
+     * when: route至az1
+     * then: 有能匹配到az1下游provider实例
+     */
+    @Test
+    public void testGetTargetInstancesByTagRulesWithoutPolicySceneOne() {
+        RuleInitializationUtils.initAZTagMatchRule();
+        List<Object> instances = new ArrayList<>();
+        ServiceInstance instance1 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az1");
+        ServiceInstance instance2 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        instances.add(instance1);
+        instances.add(instance2);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        List<Object> targetInstances = tagRouteHandler.handle("foo", instances,
+                new RequestData(null, null, null));
+        Assert.assertEquals(1, targetInstances.size());
+        Assert.assertEquals(instance1, targetInstances.get(0));
+        ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetRouteRule(Collections.emptyMap());
+    }
+
+    /**
+     * 测试rule规则如下：
+     * given：match为精确匹配az1，未设置policy，下游provider无az1实例
+     * when：route至az1
+     * then：不能匹配到下游provider实例
+     */
+    @Test
+    public void testGetTargetInstancesByTagRulesWithoutPolicySceneTwo() {
+        RuleInitializationUtils.initAZTagMatchRule();
+        List<Object> instances = new ArrayList<>();
+        ServiceInstance instance1 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        ServiceInstance instance2 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az3");
+        instances.add(instance1);
+        instances.add(instance2);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        List<Object> targetInstances = tagRouteHandler.handle("foo", instances,
+                new RequestData(null, null, null));
+        Assert.assertEquals(0, targetInstances.size());
+        ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetRouteRule(Collections.emptyMap());
+    }
+
+    /**
+     * 测试rule规则如下：
+     * given：match为精确匹配az1，设置policy的triggerThreshold为60，下游provider有az1实例
+     * when：route至az1
+     * then：能匹配到az1下游provider实例
+     */
+    @Test
+    public void testGetTargetInstancesByTagRulesWithPolicySceneOne() {
+        RuleInitializationUtils.initAZTagMatchTriggerThresholdPolicyRule();
+        List<Object> instances = new ArrayList<>();
+        ServiceInstance instance1 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az1");
+        ServiceInstance instance2 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        ServiceInstance instance3 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az1");
+        instances.add(instance1);
+        instances.add(instance2);
+        instances.add(instance3);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        List<Object> targetInstances = tagRouteHandler.handle("foo", instances,
+                new RequestData(null, null, null));
+        Assert.assertEquals(2, targetInstances.size());
+        ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetRouteRule(Collections.emptyMap());
+    }
+
+    /**
+     * 测试rule规则如下：
+     * given: match为精确匹配az1，设置policy的triggerThreshold为60，下游provider有/无az1实例
+     * when: route至az1，但是触发了阈值规则：az1可用实例数/ALL实例数小于triggerThreshold
+     * then: 返回所有实例
+     */
+    @Test
+    public void testGetTargetInstancesByTagRulesWithPolicySceneTwo() {
+        RuleInitializationUtils.initAZTagMatchTriggerThresholdPolicyRule();
+        // 场景一：下游provider有符合要求的实例
+        List<Object> instances = new ArrayList<>();
+        ServiceInstance instance1 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az1");
+        ServiceInstance instance2 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        instances.add(instance1);
+        instances.add(instance2);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        List<Object> targetInstances = tagRouteHandler.handle("foo", instances,
+                new RequestData(null, null, null));
+        Assert.assertEquals(2, targetInstances.size());
+
+        // 场景二：下游provider无符合要求的实例
+        List<Object> instances2 = new ArrayList<>();
+        ServiceInstance instance3 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az3");
+        ServiceInstance instance4 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az4");
+        instances2.add(instance3);
+        instances2.add(instance4);
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        targetInstances = tagRouteHandler.handle("foo", instances2,
+                new RequestData(null, null, null));
+        Assert.assertEquals(2, targetInstances.size());
+
+        ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetRouteRule(Collections.emptyMap());
+    }
+
+    /**
+     * 测试rule规则如下：
+     * given: match为精确匹配az1，设置policy的triggerThreshold为50，minAllInstances为4，下游provider有az1实例
+     * when: route至az1，minAllInstances小于5，az1实例/ALL实例占比大于triggerThreshold
+     * then: 能匹配到az1的下游provider实例
+     */
+    @Test
+    public void testGetTargetInstancesByTagRulesWithPolicySceneThree() {
+        RuleInitializationUtils.initAZTagMatchTriggerThresholdMinAllInstancesPolicyRule();
+        List<Object> instances = new ArrayList<>();
+        ServiceInstance instance1 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az1");
+        ServiceInstance instance2 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        ServiceInstance instance3 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az1");
+        ServiceInstance instance4 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az2");
+        ServiceInstance instance5 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.2", "az1");
+        instances.add(instance1);
+        instances.add(instance2);
+        instances.add(instance3);
+        instances.add(instance4);
+        instances.add(instance5);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        List<Object> targetInstances = tagRouteHandler.handle("foo", instances,
+                new RequestData(null, null, null));
+        Assert.assertEquals(3, targetInstances.size());
+        ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetRouteRule(Collections.emptyMap());
+    }
+
+    /**
+     * 测试rule规则如下：
+     * given：match为精确匹配az1，设置policy的triggerThreshold为50，minAllInstances为4，下游provider有az1实例
+     * when：route至az1，minAllInstances小于5，az1实例/ALL实例占比小于triggerThreshold
+     * then：返回所有下游provider实例
+     */
+    @Test
+    public void testGetTargetInstancesByTagRulesWithPolicySceneFour() {
+        RuleInitializationUtils.initAZTagMatchTriggerThresholdMinAllInstancesPolicyRule();
+        List<Object> instances = new ArrayList<>();
+        ServiceInstance instance1 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az1");
+        ServiceInstance instance2 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        ServiceInstance instance3 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az1");
+        ServiceInstance instance4 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az2");
+        ServiceInstance instance5 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.2", "az2");
+        instances.add(instance1);
+        instances.add(instance2);
+        instances.add(instance3);
+        instances.add(instance4);
+        instances.add(instance5);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        List<Object> targetInstances = tagRouteHandler.handle("foo", instances,
+                new RequestData(null, null, null));
+        Assert.assertEquals(5, targetInstances.size());
+        ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetRouteRule(Collections.emptyMap());
+    }
+
+    /**
+     * 测试rule规则如下：
+     * given：match为精确匹配az1，设置policy的triggerThreshold为50，minAllInstances为4，下游provider有az1实例
+     * when：route至az1，minAllInstances大于3，az1实例/ALL实例占比小于或者大于triggerThreshold
+     * then：返回下游az1的provider实例
+     */
+    @Test
+    public void testGetTargetInstancesByTagRulesWithPolicySceneFive() {
+        RuleInitializationUtils.initAZTagMatchTriggerThresholdMinAllInstancesPolicyRule();
+        // 场景一: az1实例/ALL实例占比大于triggerThreshold
+        List<Object> instances = new ArrayList<>();
+        ServiceInstance instance1 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az1");
+        ServiceInstance instance2 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        ServiceInstance instance3 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az1");
+        instances.add(instance1);
+        instances.add(instance2);
+        instances.add(instance3);
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("zone", "az1");
+        AppCache.INSTANCE.setMetadata(metadata);
+        List<Object> targetInstances = tagRouteHandler.handle("foo", instances,
+                new RequestData(null, null, null));
+        Assert.assertEquals(2, targetInstances.size());
+
+        // 场景二: az1实例/ALL实例占比小于triggerThreshold
+        List<Object> instances2 = new ArrayList<>();
+        ServiceInstance instance4 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az1");
+        ServiceInstance instance5 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        ServiceInstance instance6 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az2");
+        instances2.add(instance4);
+        instances2.add(instance5);
+        instances2.add(instance6);
+        targetInstances = tagRouteHandler.handle("foo", instances2,
+                new RequestData(null, null, null));
+        Assert.assertEquals(1, targetInstances.size());
+
+        List<Object> instances3 = new ArrayList<>();
+        ServiceInstance instance7 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az3");
+        ServiceInstance instance8 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.0", "az2");
+        ServiceInstance instance9 = TestDefaultServiceInstance.getTestDefaultServiceInstance("1.0.1", "az2");
+        instances3.add(instance7);
+        instances3.add(instance8);
+        instances3.add(instance9);
+        targetInstances = tagRouteHandler.handle("foo", instances3,
+                new RequestData(null, null, null));
+        Assert.assertEquals(0, targetInstances.size());
+
+        ConfigCache.getLabel(RouterConstant.SPRING_CACHE_NAME).resetRouteRule(Collections.emptyMap());
+    }
 }


### PR DESCRIPTION
【修复issue】#1139

【修改内容】新增同可用区（Availability Zones）优先路由功能。
1、router匹配规则新增policy，其实包含triggerThreshold和minAllInstances；
2、新增rule规则（az-tag）获取匹配上的实例策略逻辑，通过triggerThreshold和minAllInstances来判断走相关执行逻辑
> 主要逻辑如下：
> 1.全部可用实例数小于全部实例最小可用阈值，则同AZ优先
> 2.未设置全部实例最小可用阈值，未超过同AZ比例阈值，则同AZ优先
> 3.设置了全部实例最小可用阈值，但其小于全部AZ可用实例，未超过同AZ比例阈值，则同AZ优先

3、补充相关UT和集成测试用例

【用例描述】新增相关测试用例，主要测了如下两个场景
场景一：AZ亲和场景未配置阈值规则
场景二：AZ亲和场景，配置阈值规则，但未设置全部实例最小可用阈值
场景三：AZ亲和场景，设置阈值&设置全部实例最小可用阈值

**针对场景一：**
 
> **given:**  match为精确匹配az1，未设置policy，下游provider有az1实例
> **when:**  route至az1
> **then:**  有能匹配到az1下游provider实例

> **given:** match为精确匹配az1，未设置policy，下游provider无az1实例
> **when:** route至az1
> **then:** 不能匹配到下游provider实例

**针对场景二：**

> **given:** match为精确匹配az1，设置policy的triggerThreshold为60，下游provider有az1实例
> **when:** route至az1
> **then:** 能匹配到az1下游provider实例

> **given:** match为精确匹配az1，设置policy的triggerThreshold为60，下游provider有/无az1实例
> **when:**  route至az1，但是触发了阈值规则：az1可用实例数/ALL实例数小于triggerThreshold
> **then:**  返回所有实例

**针对场景三：**

> **given:** match为精确匹配az1，设置policy的triggerThreshold为50，minAllInstances为4，下游provider有az1实例
> **when:** route至az1，minAllInstances小于5，az1实例/ALL实例占比大于triggerThreshold
> **then:** 能匹配到az1的下游provider实例

> **given:** match为精确匹配az1，设置policy的triggerThreshold为50，minAllInstances为4，下游provider有az1实例
> **when:** route至az1，minAllInstances小于5，az1实例/ALL实例占比小于triggerThreshold
> **then:** 返回所有下游provider实例

> **given:** match为精确匹配az1，设置policy的triggerThreshold为50，minAllInstances为4，下游provider有az1实例
> **when:**  route至az1，minAllInstances大于3，az1实例/ALL实例占比小于或者大于triggerThreshold
> **then:**  返回下游az1的provider实例

【自测情况】1、本地静态检查通过；2、UT和集成测试用例通过

【影响范围】
1、对router插件使用有影响
2、需要更新一些router插件文档
