### PR TITLE
【bugfix】修复http请求拦截点缺失信息 (1.0.x分支)

### DIFF
--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/HttpCommonRequest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/HttpCommonRequest.java
@@ -21,7 +21,7 @@ import org.apache.http.client.methods.HttpGet;
 import java.net.URI;
 
 /**
- * 定义Http请求, 除POST请求外其他均兼容
+ * 定义Http请求
  *
  * @author zhouss
  * @since 2022-10-11

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttpClientInterceptor.java
@@ -77,9 +77,9 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
         AtomicReference<Request> rebuildRequest = new AtomicReference<>();
         rebuildRequest.set(request);
         invokerService.invoke(
-                buildInvokerFunc(uri, hostAndPath, request, rebuildRequest, context),
-                buildExFunc(rebuildRequest),
-                hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
+                        buildInvokerFunc(uri, hostAndPath, request, rebuildRequest, context),
+                        buildExFunc(rebuildRequest),
+                        hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
                 .ifPresent(o -> setResultOrThrow(context, o, uri.getPath()));
         return context;
     }
@@ -110,7 +110,7 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
     }
 
     private Function<InvokerContext, Object> buildInvokerFunc(URI uri, Map<String, String> hostAndPath,
-        Request request, AtomicReference<Request> rebuildRequest, ExecuteContext context) {
+            Request request, AtomicReference<Request> rebuildRequest, ExecuteContext context) {
         return invokerContext -> {
             final String method = request.method();
             Request newRequest = covertRequest(uri, hostAndPath, request, method, invokerContext.getServiceInstance());
@@ -138,6 +138,9 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
         return request
                 .newBuilder()
                 .url(newUrl)
+                .method(request.method(), request.body())
+                .headers(request.headers())
+                .tag(request.tag())
                 .build();
     }
 

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
@@ -35,7 +35,12 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.util.EntityUtils;
 
 import java.io.Closeable;
@@ -60,6 +65,18 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
 
     private static final String COMMON_REQUEST_CLASS = "com.huawei.discovery.entity.HttpCommonRequest";
 
+    private static final String HTTP_POST_NAME = "org.apache.http.client.methods.HttpPost";
+
+    private static final String HTTP_GET_NAME = "org.apache.http.client.methods.HttpGet";
+
+    private static final String HTTP_PUT_NAME = "org.apache.http.client.methods.HttpPut";
+
+    private static final String HTTP_DELETE_NAME = "org.apache.http.client.methods.HttpDelete";
+
+    private static final String HTTP_PATCH_NAME = "org.apache.http.client.methods.HttpPatch";
+
+    private static final String HTTP_HEAD_NAME = "org.apache.http.client.methods.HttpHead";
+
     private final AtomicBoolean isLoaded = new AtomicBoolean();
 
     @Override
@@ -80,9 +97,9 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
         }
         RequestInterceptorUtils.printRequestLog("HttpClient", hostAndPath);
         invokerService.invoke(
-                buildInvokerFunc(hostAndPath, httpRequest, context),
-                buildExFunc(httpRequest, Thread.currentThread().getContextClassLoader()),
-                hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
+                        buildInvokerFunc(hostAndPath, httpRequest, context),
+                        buildExFunc(httpRequest, Thread.currentThread().getContextClassLoader()),
+                        hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
                 .ifPresent(result -> this.setResultOrThrow(context, result,
                         hostAndPath.get(HttpConstants.HTTP_URI_PATH)));
         return context;
@@ -171,14 +188,78 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
     }
 
     private HttpRequest rebuildRequest(String uriNew, String method, HttpRequest httpUriRequest) {
-        if (httpUriRequest instanceof HttpPost) {
-            HttpPost oldHttpPost = (HttpPost) httpUriRequest;
-            HttpPost httpPost = new HttpPost(uriNew);
-            httpPost.setEntity(oldHttpPost.getEntity());
-            return httpPost;
-        } else {
-            return new HttpCommonRequest(method, uriNew);
+        switch (httpUriRequest.getClass().getName()) {
+            case HTTP_POST_NAME:
+                return buildHttpPost(uriNew, (HttpPost) httpUriRequest);
+            case HTTP_GET_NAME:
+                return buildHttpGet(uriNew, (HttpGet) httpUriRequest);
+            case HTTP_PUT_NAME:
+                return buildHttpPut(uriNew, (HttpPut) httpUriRequest);
+            case HTTP_DELETE_NAME:
+                return buildHttpDelete(uriNew, (HttpDelete) httpUriRequest);
+            case HTTP_PATCH_NAME:
+                return buildHttpPatch(uriNew, (HttpPatch) httpUriRequest);
+            case HTTP_HEAD_NAME:
+                return buildHttpHead(uriNew, (HttpHead) httpUriRequest);
+            default:
+                return new HttpCommonRequest(method, uriNew);
         }
+    }
+
+    private HttpHead buildHttpHead(String uriNew, HttpHead httpUriRequest) {
+        HttpHead httpHead = new HttpHead(uriNew);
+        httpHead.setHeaders(httpUriRequest.getAllHeaders());
+        httpHead.setConfig(httpUriRequest.getConfig());
+        httpHead.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpHead.setParams(httpUriRequest.getParams());
+        return httpHead;
+    }
+
+    private HttpPatch buildHttpPatch(String uriNew, HttpPatch httpUriRequest) {
+        HttpPatch httpPatch = new HttpPatch(uriNew);
+        httpPatch.setHeaders(httpUriRequest.getAllHeaders());
+        httpPatch.setConfig(httpUriRequest.getConfig());
+        httpPatch.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpPatch.setParams(httpUriRequest.getParams());
+        return httpPatch;
+    }
+
+    private HttpDelete buildHttpDelete(String uriNew, HttpDelete httpUriRequest) {
+        HttpDelete httpDelete = new HttpDelete(uriNew);
+        httpDelete.setHeaders(httpUriRequest.getAllHeaders());
+        httpDelete.setConfig(httpUriRequest.getConfig());
+        httpDelete.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpDelete.setParams(httpUriRequest.getParams());
+        return httpDelete;
+    }
+
+    private HttpPut buildHttpPut(String uriNew, HttpPut httpUriRequest) {
+        HttpPut httpPut = new HttpPut(uriNew);
+        httpPut.setEntity(httpUriRequest.getEntity());
+        httpPut.setHeaders(httpUriRequest.getAllHeaders());
+        httpPut.setConfig(httpUriRequest.getConfig());
+        httpPut.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpPut.setParams(httpUriRequest.getParams());
+        return httpPut;
+    }
+
+    private HttpGet buildHttpGet(String uriNew, HttpGet httpUriRequest) {
+        HttpGet httpGet = new HttpGet(uriNew);
+        httpGet.setHeaders(httpUriRequest.getAllHeaders());
+        httpGet.setConfig(httpUriRequest.getConfig());
+        httpGet.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpGet.setParams(httpUriRequest.getParams());
+        return httpGet;
+    }
+
+    private HttpPost buildHttpPost(String uriNew, HttpPost httpUriRequest) {
+        HttpPost httpPost = new HttpPost(uriNew);
+        httpPost.setEntity(httpUriRequest.getEntity());
+        httpPost.setHeaders(httpUriRequest.getAllHeaders());
+        httpPost.setConfig(httpUriRequest.getConfig());
+        httpPost.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpPost.setParams(httpUriRequest.getParams());
+        return httpPost;
     }
 
     @Override


### PR DESCRIPTION
【修复issue】https://github.com/huaweicloud/Sermant/issues/1134

【修改内容】修复springboot插件httpclient拦截点和okhttp拦截点缺失请求的部分信息

【用例描述】用例已覆盖

【自测情况】1、本地静态检查通过；2、UT通过

【影响范围】Springboot注册插件 httpclient和okhttp客户端使用