### PR TITLE
【enhancement】新增路由插件事件上报

### DIFF
--- a/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
+++ b/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
@@ -504,6 +504,8 @@ const eventName = reactive({
   GRACEFUL_ONLINE_END: "无损上线结束",
   GRACEFUL_OFFLINE_BEGIN: "无损下线开始",
   GRACEFUL_OFFLINE_END: "无损下线结束",
+  // 路由插件事件
+  ROUTER_RULE_TAKE_EFFECT: "路由插件规则生效",
 });
 
 const displayState = reactive({

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventCollector.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventCollector.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.common.event;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.event.Event;
+import com.huaweicloud.sermant.core.event.EventCollector;
+import com.huaweicloud.sermant.core.event.EventInfo;
+import com.huaweicloud.sermant.core.event.EventManager;
+import com.huaweicloud.sermant.core.event.config.EventConfig;
+
+/**
+ * 路由插件事件采集器
+ *
+ * @author lilai
+ * @since 2023-03-28
+ */
+public class RouterEventCollector extends EventCollector {
+    private static volatile RouterEventCollector routerEventCollecter;
+
+    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
+
+    private RouterEventCollector() {
+    }
+
+    /**
+     * 获取路由插件事件采集器单例
+     *
+     * @return 路由插件事件采集器单例
+     */
+    public static RouterEventCollector getInstance() {
+        if (routerEventCollecter == null) {
+            synchronized (RouterEventCollector.class) {
+                if (routerEventCollecter == null) {
+                    routerEventCollecter = new RouterEventCollector();
+                    EventManager.registerCollector(RouterEventCollector.getInstance());
+                }
+            }
+        }
+        return routerEventCollecter;
+    }
+
+    /**
+     * 采集服务粒度规则生效事件
+     *
+     * @param rule 路由插件的规则
+     */
+    public void collectServiceRouteRuleEvent(String rule) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Service router rule refresh:" + System.lineSeparator() + rule;
+        offerEvent(new Event(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getScope(),
+                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventLevel(),
+                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventType(),
+                new EventInfo(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getName(), eventDescription)));
+    }
+
+    /**
+     * 采集全局粒度规则生效事件
+     *
+     * @param rule 路由插件的规则
+     */
+    public void collectGlobalRouteRuleEvent(String rule) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Global router rule refresh:" + System.lineSeparator() + rule;
+        offerEvent(new Event(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getScope(),
+                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventLevel(),
+                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventType(),
+                new EventInfo(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getName(), eventDescription)));
+    }
+}

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventDefinition.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventDefinition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.common.event;
+
+import com.huaweicloud.sermant.core.event.EventLevel;
+import com.huaweicloud.sermant.core.event.EventType;
+
+/**
+ * 路由插件事件定义
+ *
+ * @author lilai
+ * @since 2023-03-28
+ */
+public enum RouterEventDefinition {
+    /**
+     * 路由插件规则生效事件
+     */
+
+    ROUTER_RULE_TAKE_EFFECT("ROUTER_RULE_TAKE_EFFECT", EventType.GOVERNANCE, EventLevel.NORMAL);
+
+    private final String name;
+
+    private final EventType eventType;
+
+    private final EventLevel eventLevel;
+
+    RouterEventDefinition(String name, EventType eventType, EventLevel eventLevel) {
+        this.name = name;
+        this.eventType = eventType;
+        this.eventLevel = eventLevel;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public EventLevel getEventLevel() {
+        return eventLevel;
+    }
+
+    public String getScope() {
+        return "router-plugin";
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/GlobalConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/GlobalConfigHandler.java
@@ -20,12 +20,14 @@ import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEv
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
 import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.common.event.RouterEventCollector;
 import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
 import com.huaweicloud.sermant.router.config.cache.ConfigCache;
 import com.huaweicloud.sermant.router.config.entity.EntireRule;
 import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
 import com.huaweicloud.sermant.router.config.utils.RuleUtils;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 
@@ -46,6 +48,8 @@ public class GlobalConfigHandler extends AbstractConfigHandler {
         if (event.getEventType() == DynamicConfigEventType.DELETE) {
             configuration.resetGlobalRule(Collections.emptyList());
             RuleUtils.initMatchKeys(configuration);
+            RouterEventCollector.getInstance()
+                    .collectGlobalRouteRuleEvent(JSON.toJSONString(configuration.getGlobalRule()));
             return;
         }
         List<EntireRule> list = JSONArray.parseArray(JSONObject.toJSONString(getRule(event)), EntireRule.class);
@@ -60,6 +64,8 @@ public class GlobalConfigHandler extends AbstractConfigHandler {
             configuration.resetGlobalRule(list);
         }
         RuleUtils.initMatchKeys(configuration);
+        RouterEventCollector.getInstance()
+                .collectGlobalRouteRuleEvent(JSON.toJSONString(configuration.getGlobalRule()));
     }
 
     @Override

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandler.java
@@ -19,12 +19,14 @@ package com.huaweicloud.sermant.router.config.handler;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
 import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.common.event.RouterEventCollector;
 import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
 import com.huaweicloud.sermant.router.config.cache.ConfigCache;
 import com.huaweicloud.sermant.router.config.entity.EntireRule;
 import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
 import com.huaweicloud.sermant.router.config.utils.RuleUtils;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 
@@ -47,6 +49,8 @@ public class RouterConfigHandler extends AbstractConfigHandler {
         if (event.getEventType() == DynamicConfigEventType.DELETE) {
             configuration.resetRouteRule(Collections.emptyMap());
             RuleUtils.initKeys(configuration);
+            RouterEventCollector.getInstance()
+                    .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
             return;
         }
         Map<String, String> routeRuleMap = getRouteRuleMap(event);
@@ -68,6 +72,8 @@ public class RouterConfigHandler extends AbstractConfigHandler {
         }
         configuration.resetRouteRule(routeRule);
         RuleUtils.initKeys(configuration);
+        RouterEventCollector.getInstance()
+                .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
     }
 
     @Override

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/ServiceConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/ServiceConfigHandler.java
@@ -20,12 +20,14 @@ import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEv
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
 import com.huaweicloud.sermant.core.utils.StringUtils;
 import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.common.event.RouterEventCollector;
 import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
 import com.huaweicloud.sermant.router.config.cache.ConfigCache;
 import com.huaweicloud.sermant.router.config.entity.EntireRule;
 import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
 import com.huaweicloud.sermant.router.config.utils.RuleUtils;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 
@@ -49,6 +51,8 @@ public class ServiceConfigHandler extends AbstractConfigHandler {
         if (event.getEventType() == DynamicConfigEventType.DELETE) {
             configuration.removeServiceRule(serviceName);
             RuleUtils.initKeys(configuration);
+            RouterEventCollector.getInstance()
+                    .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
             return;
         }
         List<EntireRule> list = JSONArray.parseArray(JSONObject.toJSONString(getRule(event, serviceName)),
@@ -64,6 +68,8 @@ public class ServiceConfigHandler extends AbstractConfigHandler {
             configuration.updateServiceRule(serviceName, list);
         }
         RuleUtils.initKeys(configuration);
+        RouterEventCollector.getInstance()
+                .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
     }
 
     @Override


### PR DESCRIPTION
【修复issue】#1150

【修改内容】
1. 新增路由插件事件采集器和事件上报类型ROUTER_RULE_TAKE_EFFECT（路由插件规则生效事件）。
2. 在路由插件路由规则或染色规则更新时会有事件上报至backend以供观测。

【用例描述】1. 挂载sermant启动宿主应用和backend；2. 下发有效的路由规则或染色规则或者删除配置节点；3. backend收到相关事件，确认配置生效。
<img width="1388" alt="image" src="https://user-images.githubusercontent.com/46025350/228723042-d074cbd9-79fc-4804-abcd-2c95d9d44cf5.png">


【自测情况】1、本地静态检查通过；2、测试用例通过；

【影响范围】无
