### PR TITLE
【enhancement】优化输出被增强类字节码文件的开关和路径配置

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -5,6 +5,9 @@ agent.config.ignoredInterfaces=org.springframework.cglib.proxy.Factory
 agent.config.combineStrategy=ALL
 agent.config.serviceBlackList=com.huaweicloud.sermant.implement.service.heartbeat.HeartbeatServiceImpl,com.huaweicloud.sermant.implement.service.send.netty.NettyGatewayClient,com.huaweicloud.sermant.implement.service.tracing.TracingServiceImpl
 agent.config.serviceInjectList=com.huawei.discovery.service.lb.filter.NopInstanceFilter,com.huawei.discovery.service.lb.DiscoveryManager,com.huawei.discovery.service.util.ApplyUtil,com.huawei.discovery.service.lb.cache.InstanceCacheManager
+agent.config.isOutputEnhancedClasses=false
+agent.config.enhancedClassesOutputPath=
+agent.config.isShowEnhanceLog=false
 
 # event config
 event.config.enable=false

--- a/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
@@ -5,6 +5,9 @@ agent.config.ignoredInterfaces=org.springframework.cglib.proxy.Factory
 agent.config.combineStrategy=ALL
 agent.config.serviceBlackList=com.huaweicloud.sermant.implement.service.heartbeat.HeartbeatServiceImpl,com.huaweicloud.sermant.implement.service.send.netty.NettyGatewayClient,com.huaweicloud.sermant.implement.service.tracing.TracingServiceImpl
 agent.config.serviceInjectList=com.huawei.discovery.service.lb.filter.NopInstanceFilter,com.huawei.discovery.service.lb.DiscoveryManager
+agent.config.isOutputEnhancedClasses=false
+agent.config.enhancedClassesOutputPath=
+agent.config.isShowEnhanceLog=false
 
 # event config
 event.config.enable=false

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/CommonConstant.java
@@ -137,6 +137,11 @@ public class CommonConstant {
      */
     public static final String TRANSFORM = "TRANSFORM";
 
+    /**
+     * 默认的增强后字节码文件输出路径父目录
+     */
+    public static final String ENHANCED_CLASS_OUTPUT_PARENT_DIR = "enhancedClasses";
+
     private CommonConstant() {
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/config/AgentConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/config/AgentConfig.java
@@ -51,12 +51,17 @@ public class AgentConfig implements BaseConfig {
     /**
      * 是否在增强过程中输出检索日志
      */
-    private boolean isShowEnhanceLogEnable = false;
+    private boolean isShowEnhanceLog = false;
+
+    /**
+     * 是否输出被增强的类的字节码文件
+     */
+    private boolean isOutputEnhancedClasses = false;
 
     /**
      * 被增强类的输出路径，如果为空，则不输出
      */
-    private String enhancedClassOutputPath;
+    private String enhancedClassesOutputPath;
 
     /**
      * 插件的合并策略，定义{@link PluginDeclarer}插件声明器的合并策略
@@ -97,20 +102,28 @@ public class AgentConfig implements BaseConfig {
         this.ignoredPrefixes = ignoredPrefixes;
     }
 
-    public boolean isShowEnhanceLogEnable() {
-        return isShowEnhanceLogEnable;
+    public boolean isShowEnhanceLog() {
+        return isShowEnhanceLog;
     }
 
-    public void setShowEnhanceLogEnable(boolean showEnhanceLogEnable) {
-        isShowEnhanceLogEnable = showEnhanceLogEnable;
+    public void setShowEnhanceLog(boolean showEnhanceLog) {
+        isShowEnhanceLog = showEnhanceLog;
     }
 
-    public String getEnhancedClassOutputPath() {
-        return enhancedClassOutputPath;
+    public boolean isOutputEnhancedClasses() {
+        return isOutputEnhancedClasses;
     }
 
-    public void setEnhancedClassOutputPath(String enhancedClassOutputPath) {
-        this.enhancedClassOutputPath = enhancedClassOutputPath;
+    public void setOutputEnhancedClasses(boolean outputEnhancedClasses) {
+        isOutputEnhancedClasses = outputEnhancedClasses;
+    }
+
+    public String getEnhancedClassesOutputPath() {
+        return enhancedClassesOutputPath;
+    }
+
+    public void setEnhancedClassesOutputPath(String enhancedClassesOutputPath) {
+        this.enhancedClassesOutputPath = enhancedClassesOutputPath;
     }
 
     public Set<String> getServiceBlackList() {
@@ -152,8 +165,7 @@ public class AgentConfig implements BaseConfig {
         NONE,
 
         /**
-         * 仅合并{@link PluginDeclarer#getClassMatcher}为{@link
-         * ClassTypeMatcher}的插件声明器，即通过匹配的类名合并
+         * 仅合并{@link PluginDeclarer#getClassMatcher}为{@link ClassTypeMatcher}的插件声明器，即通过匹配的类名合并
          * <p>插件较多，且主要是全限定名匹配的场景时，该策略有优势
          */
         BY_NAME,

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/FileUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/FileUtils.java
@@ -52,6 +52,15 @@ public class FileUtils {
     }
 
     /**
+     * 获取sermant-agent-x.x.x/agent的文件夹绝对路径
+     *
+     * @return agent路径
+     */
+    public static String getAgentPath() {
+        return AGENT_PATH;
+    }
+
+    /**
      * 检验文件路径
      *
      * @param path 输入路径
@@ -121,7 +130,7 @@ public class FileUtils {
      *
      * @param sourceFile 源文件夹
      * @param targetPath 目标文件夹
-     * @param isCover    是否覆盖
+     * @param isCover 是否覆盖
      * @throws IOException 拷贝失败
      */
     public static void copyAllFiles(File sourceFile, String targetPath, boolean isCover) throws IOException {
@@ -166,7 +175,7 @@ public class FileUtils {
     /**
      * 通过通配符的方式检索子文件
      *
-     * @param dir   文件夹
+     * @param dir 文件夹
      * @param wcStr 通配符模式，允许','拼接多个
      * @return 子文件集
      */


### PR DESCRIPTION
【修复issue】#1162

【修改内容】
1、在config.properties增加被增强类的字节码文件输出开关agent.config.isOutputEnhancedClasses，默认为false。
2、默认输出路径为sermant-agent/agent/enhancedClasses/20230401160102123, 最后一层文件夹为输出时间
3、自定义输出路径agent.config.enhancedClassesOutputPath默认为空，如果不配置，将使用2中的默认输出路径。

【用例描述】
测试用例1：
步骤：
（1）agent.config.isOutputEnhancedClasses=false，其余配置不修改，挂载sermant启动宿主应用
（2）查看sermant-agent/agent是否有文件输出
结果：
（1）无输出
测试用例2：
（1）agent.config.isOutputEnhancedClasses=true，其余配置不修改，挂载sermant启动宿主应用
（2）查看sermant-agent/agent是否有文件输出
结果：
（1）sermant-agent/agent/enhancedClasses/20230401160102123, 文件夹中输出被增强类的字节码文件
测试用例3：
（1）agent.config.isOutputEnhancedClasses=true，agent.config.enhancedClassesOutputPath=自定义路径，其余配置不修改，挂载sermant启动宿主应用
（2）查看自定义路径是否有文件输出
结果：
（1）自定义路径/enhancedClasses/20230401160102123, 文件夹中输出被增强类的字节码文件

【自测情况】1、本地静态检查通过；2、测试用例通过

【影响范围】用户需输出查看被增强类的字节码文件时可修改上述配置
