### PR TITLE
【fix】使用servicecomb.routeRule为key配置路由规则时，路由规则报错

### DIFF
--- a/sermant-integration-tests/dubbo-test/dubbo-2-6-integration-controller/src/main/java/com/huaweicloud/integration/controller/LaneController.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-2-6-integration-controller/src/main/java/com/huaweicloud/integration/controller/LaneController.java
@@ -27,18 +27,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * 泳道测试
@@ -60,7 +53,6 @@ public class LaneController {
      */
     @GetMapping("/getLaneByDubbo")
     public Map<String, Object> getLaneByDubbo(TestEntity entity) {
-        RpcContext.getContext().setAttachments(getLaneFlag());
         RpcContext.getContext().setAttachment(Constant.LANE_TEST_USER_ID, String.valueOf(entity.getId()));
         return laneService.getLaneByDubbo(entity.getName(), new LaneTestEntity(entity.getLaneId(), entity.isEnabled()),
                 new String[]{entity.getArrName()}, Collections.singletonList(entity.getListId()),
@@ -79,7 +71,6 @@ public class LaneController {
     public Map<String, Object> getLaneByFeign(@RequestParam(value = "name", defaultValue = "") String name,
             @RequestParam(value = "id", defaultValue = "0") int id,
             @RequestParam(value = "enabled", defaultValue = "false") boolean enabled) {
-        RpcContext.getContext().setAttachments(getLaneFlag());
         RpcContext.getContext().setAttachment(Constant.LANE_TEST_USER_ID, String.valueOf(id));
         return laneService.getLaneByFeign(name, new LaneTestEntity(id, enabled));
     }
@@ -96,30 +87,7 @@ public class LaneController {
     public Map<String, Object> getLaneByRest(@RequestParam(value = "name", defaultValue = "") String name,
             @RequestParam(value = "id", defaultValue = "0") int id,
             @RequestParam(value = "enabled", defaultValue = "false") boolean enabled) {
-        RpcContext.getContext().setAttachments(getLaneFlag());
         RpcContext.getContext().setAttachment(Constant.LANE_TEST_USER_ID, String.valueOf(id));
         return laneService.getLaneByRest(name, new LaneTestEntity(id, enabled));
-    }
-
-    private Map<String, String> getLaneFlag() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
-                .getRequest();
-        Map<String, String> headers = new HashMap<>();
-        Enumeration<?> enumeration = request.getHeaderNames();
-        while (enumeration.hasMoreElements()) {
-            String key = (String) enumeration.nextElement();
-            if (key.startsWith("x-sermant-")) {
-                headers.put(key, enumeration2List(request.getHeaders(key)).get(0));
-            }
-        }
-        return headers;
-    }
-
-    private List<String> enumeration2List(Enumeration<?> enumeration) {
-        List<String> collection = new ArrayList<>();
-        while (enumeration.hasMoreElements()) {
-            collection.add((String) enumeration.nextElement());
-        }
-        return collection;
     }
 }

--- a/sermant-integration-tests/dubbo-test/dubbo-2-7-integration-controller/src/main/java/com/huaweicloud/integration/controller/LaneController.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-2-7-integration-controller/src/main/java/com/huaweicloud/integration/controller/LaneController.java
@@ -26,18 +26,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * 泳道测试
@@ -59,7 +52,6 @@ public class LaneController {
      */
     @GetMapping("/getLaneByDubbo")
     public Map<String, Object> getLaneByDubbo(TestEntity entity) {
-        RpcContext.getContext().setAttachments(getLaneFlag());
         RpcContext.getContext().setAttachment(Constant.LANE_TEST_USER_ID, String.valueOf(entity.getId()));
         return laneService.getLaneByDubbo(entity.getName(), new LaneTestEntity(entity.getLaneId(), entity.isEnabled()),
                 new String[]{entity.getArrName()}, Collections.singletonList(entity.getListId()),
@@ -78,7 +70,6 @@ public class LaneController {
     public Map<String, Object> getLaneByFeign(@RequestParam(value = "name", defaultValue = "") String name,
             @RequestParam(value = "id", defaultValue = "0") int id,
             @RequestParam(value = "enabled", defaultValue = "false") boolean enabled) {
-        RpcContext.getContext().setAttachments(getLaneFlag());
         RpcContext.getContext().setAttachment(Constant.LANE_TEST_USER_ID, String.valueOf(id));
         return laneService.getLaneByFeign(name, new LaneTestEntity(id, enabled));
     }
@@ -95,30 +86,7 @@ public class LaneController {
     public Map<String, Object> getLaneByRest(@RequestParam(value = "name", defaultValue = "") String name,
             @RequestParam(value = "id", defaultValue = "0") int id,
             @RequestParam(value = "enabled", defaultValue = "false") boolean enabled) {
-        RpcContext.getContext().setAttachments(getLaneFlag());
         RpcContext.getContext().setAttachment(Constant.LANE_TEST_USER_ID, String.valueOf(id));
         return laneService.getLaneByRest(name, new LaneTestEntity(id, enabled));
-    }
-
-    private Map<String, String> getLaneFlag() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
-                .getRequest();
-        Map<String, String> headers = new HashMap<>();
-        Enumeration<?> enumeration = request.getHeaderNames();
-        while (enumeration.hasMoreElements()) {
-            String key = (String) enumeration.nextElement();
-            if (key.startsWith("x-sermant-")) {
-                headers.put(key, enumeration2List(request.getHeaders(key)).get(0));
-            }
-        }
-        return headers;
-    }
-
-    private List<String> enumeration2List(Enumeration<?> enumeration) {
-        List<String> collection = new ArrayList<>();
-        while (enumeration.hasMoreElements()) {
-            collection.add((String) enumeration.nextElement());
-        }
-        return collection;
     }
 }

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/flowcontrol/RestFlowControlTest.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/flowcontrol/RestFlowControlTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * @since 2022-08-02
  */
 @EnabledIfSystemProperty(named = "sermant.integration.test.type", matches = "FLOW_CONTROL")
-public class RestFlowControlTest extends FlowControlTest{
+public class RestFlowControlTest extends FlowControlTest {
     @Override
     protected String getRestConsumerUrl() {
         return "http://127.0.0.1:8005/flowcontrol";

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandler.java
@@ -53,14 +53,14 @@ public class RouterConfigHandler extends AbstractConfigHandler {
                     .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
             return;
         }
-        Map<String, String> routeRuleMap = getRouteRuleMap(event);
+        Map<String, List<Object>> routeRuleMap = getRouteRuleMap(event);
         Map<String, List<EntireRule>> routeRule = new HashMap<>();
-        for (Entry<String, String> entry : routeRuleMap.entrySet()) {
-            List<Map<String, String>> routeRuleList = yaml.load(entry.getValue());
-            if (CollectionUtils.isEmpty(routeRuleList)) {
+        for (Entry<String, List<Object>> entry : routeRuleMap.entrySet()) {
+            List<Object> value = entry.getValue();
+            if (CollectionUtils.isEmpty(value)) {
                 continue;
             }
-            List<EntireRule> list = JSONArray.parseArray(JSONObject.toJSONString(routeRuleList), EntireRule.class);
+            List<EntireRule> list = JSONArray.parseArray(JSONObject.toJSONString(value), EntireRule.class);
             RuleUtils.removeInvalidRules(list, RouterConstant.DUBBO_CACHE_NAME.equals(cacheName),
                     RouterConstant.DUBBO_CACHE_NAME.equals(cacheName));
             if (!CollectionUtils.isEmpty(list)) {
@@ -81,9 +81,9 @@ public class RouterConfigHandler extends AbstractConfigHandler {
         return RouterConstant.ROUTER_KEY_PREFIX.equals(key);
     }
 
-    private Map<String, String> getRouteRuleMap(DynamicConfigEvent event) {
+    private Map<String, List<Object>> getRouteRuleMap(DynamicConfigEvent event) {
         String content = event.getContent();
-        Map<String, String> routeRuleMap = yaml.load(content);
+        Map<String, List<Object>> routeRuleMap = yaml.load(content);
         if (CollectionUtils.isEmpty(routeRuleMap)) {
             return Collections.emptyMap();
         }


### PR DESCRIPTION
【修复issue】 #1168 

【修改内容】修改了servicecomb.routeRule为key的路由配置监听器的解析逻辑

【自测情况】1、修改前，使用servicecomb.routeRule为key配置路由规则时，路由规则报错；2、修改后，使用servicecomb.routeRule为key配置路由规则时，路由规则不报错

【影响范围】不涉及
