### PR TITLE
【enhancement】add policy event, report to backend

### DIFF
--- a/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
+++ b/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
@@ -515,6 +515,8 @@ const eventName = reactive({
   GRACEFUL_OFFLINE_END: "无损下线结束",
   // 路由插件事件
   ROUTER_RULE_TAKE_EFFECT: "路由插件规则生效",
+  SAME_TAG_RULE_MATCH: "同标签优先规则匹配成功",
+  SAME_TAG_RULE_MISMATCH: "同标签优先规则匹配失败",
   INSTANCE_REMOVAL: "实例摘除",
   INSTANCE_RECOVERY: "实例恢复"
 });

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/PolicyEvent.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/PolicyEvent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.common.event;
+
+/**
+ * Policy事件包含三件：
+ * 1.相同标签规则匹配成功: 全部实例最小可用阈值大于全部可用实例数，则同TAG优先
+ * 2.相同标签规则匹配成功:
+ *     未设置全部实例最小可用阈值，超过(大于等于)同TAG比例阈值，则同TAG优先
+ *     设置了全部实例最小可用阈值，但其小于全部TAG可用实例，超过(大于等于)同TAG比例阈值，则同TAG优先
+ * 3.相同标签规则匹配失败
+ *
+ * @author robotLJW
+ * @since 2023-04-03
+ *
+ */
+public enum PolicyEvent {
+    /**
+     * 符合相同Tag规则匹配：全部可用实例数小于全部实例最小可用阈值，则同TAG优先
+     */
+    SAME_TAG_MATCH_LESS_MIN_ALL_INSTANCES("According to the policy in the rule, same tag rule match that less"
+            + " than the minimum available threshold for all instances"),
+
+    /**
+     * 符合相同Tag规则匹配：超过同TAG比例阈值，则同TAG优先
+     */
+    SAME_TAG_MATCH_EXCEEDED_TRIGGER_THRESHOLD("According to the policy in the rule, same tag rule match that"
+            + " exceeded trigger threshold"),
+
+    /**
+     * 相同Tag规则匹配没匹配上
+     */
+    SAME_TAG_MISMATCH("According to the policy in the rule, same tag rule mismatch");
+
+    /**
+     * 事件描述
+     */
+    private String desc;
+
+    PolicyEvent(String desc) {
+        this.desc = desc;
+    }
+
+    public String getDesc() {
+        return this.desc;
+    }
+}

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventCollector.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventCollector.java
@@ -85,4 +85,42 @@ public class RouterEventCollector extends EventCollector {
                 RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventType(),
                 new EventInfo(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getName(), eventDescription)));
     }
+
+    /**
+     * 采集选取下游serviceName匹配有效事件
+     *
+     * @param tagMsg tags信息
+     * @param serviceName service名
+     * @param reason 原因
+     */
+    public void collectSameTagMatchedEvent(String tagMsg, String serviceName, String reason) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "The matching with the tag (" + tagMsg + ") rule takes effect when request "
+                + "service is " + serviceName + " (reason: " + reason + ")";
+        offerEvent(new Event(RouterEventDefinition.SAME_TAG_RULE_MATCH.getScope(),
+                RouterEventDefinition.SAME_TAG_RULE_MATCH.getEventLevel(),
+                RouterEventDefinition.SAME_TAG_RULE_MATCH.getEventType(),
+                new EventInfo(RouterEventDefinition.SAME_TAG_RULE_MATCH.getName(), eventDescription)));
+    }
+
+    /**
+     * 采集选取下游serviceName匹配无效事件
+     *
+     * @param tagMsg tags信息
+     * @param serviceName service名
+     * @param reason 原因
+     */
+    public void collectSameTagMisMatchedEvent(String tagMsg, String serviceName, String reason) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "The matching with the tag (" + tagMsg + ") rule did not take effect when request "
+                + "service is " + serviceName + " (reason: " + reason + ")";
+        offerEvent(new Event(RouterEventDefinition.SAME_TAG_RULE_MISMATCH.getScope(),
+                RouterEventDefinition.SAME_TAG_RULE_MISMATCH.getEventLevel(),
+                RouterEventDefinition.SAME_TAG_RULE_MISMATCH.getEventType(),
+                new EventInfo(RouterEventDefinition.SAME_TAG_RULE_MISMATCH.getName(), eventDescription)));
+    }
 }

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventDefinition.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventDefinition.java
@@ -30,7 +30,18 @@ public enum RouterEventDefinition {
      * 路由插件规则生效事件
      */
 
-    ROUTER_RULE_TAKE_EFFECT("ROUTER_RULE_TAKE_EFFECT", EventType.GOVERNANCE, EventLevel.NORMAL);
+    ROUTER_RULE_TAKE_EFFECT("ROUTER_RULE_TAKE_EFFECT", EventType.GOVERNANCE, EventLevel.NORMAL),
+
+    /**
+     * 同TAG优先规则匹配生效
+     */
+    SAME_TAG_RULE_MATCH("SAME_TAG_RULE_MATCH", EventType.GOVERNANCE, EventLevel.NORMAL),
+
+    /**
+     * 同TAG优先规则匹配失效
+     */
+    SAME_TAG_RULE_MISMATCH("SAME_TAG_RULE_MISMATCH", EventType.GOVERNANCE,
+            EventLevel.NORMAL);
 
     private final String name;
 

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/utils/PolicyEventUtils.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/utils/PolicyEventUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.router.config.utils;
+
+import com.huaweicloud.sermant.router.common.event.PolicyEvent;
+import com.huaweicloud.sermant.router.common.event.RouterEventCollector;
+import com.huaweicloud.sermant.router.config.entity.MatchRule;
+
+import com.alibaba.fastjson.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *
+ * Policy事件上报工具类
+ *
+ * @author robotLJW
+ * @since 2023-04-06
+ */
+public class PolicyEventUtils {
+
+    private static final ConcurrentHashMap<String, PolicyEvent> POLICY_EVENT_CONCURRENT_HASH_MAP
+            = new ConcurrentHashMap<>();
+
+    private PolicyEventUtils() {
+    }
+
+    /**
+     * 通知相同TAG匹配上的事件
+     *
+     * @param newState 新匹配状态
+     * @param tags match里的tags信息
+     * @param serviceName 服务名
+     */
+    public static void notifySameTagMatchedEvent(PolicyEvent newState, Map<String, List<MatchRule>> tags,
+                                                 String serviceName) {
+        PolicyEvent previousState = POLICY_EVENT_CONCURRENT_HASH_MAP.get(serviceName);
+        if (!newState.equals(previousState)) {
+            POLICY_EVENT_CONCURRENT_HASH_MAP.put(serviceName, newState);
+            RouterEventCollector.getInstance().collectSameTagMatchedEvent(JSONObject.toJSONString(tags), serviceName,
+                    newState.getDesc());
+        }
+    }
+
+    /**
+     * 通知相同TAG未匹配上的事件
+     *
+     * @param newState 新匹配状态
+     * @param tags match里的tags信息
+     * @param serviceName 服务名
+     */
+    public static void notifySameTagMisMatchedEvent(PolicyEvent newState, Map<String, List<MatchRule>> tags,
+                                                    String serviceName) {
+        PolicyEvent previousState = POLICY_EVENT_CONCURRENT_HASH_MAP.get(serviceName);
+        if (!newState.equals(previousState)) {
+            POLICY_EVENT_CONCURRENT_HASH_MAP.put(serviceName, newState);
+            RouterEventCollector.getInstance().collectSameTagMisMatchedEvent(JSONObject.toJSONString(tags), serviceName,
+                    newState.getDesc());
+        }
+    }
+
+}


### PR DESCRIPTION
【修复issue】#1176

【修改内容】
Policy事件包含三件：
 1.相同标签规则匹配成功: 全部实例最小可用阈值大于全部可用实例数，则同TAG优先
 2.相同标签规则匹配成功:
      未设置全部实例最小可用阈值，超过(大于等于)同TAG比例阈值，则同TAG优先
      设置了全部实例最小可用阈值，但其小于全部TAG可用实例，超过(大于等于)同TAG比例阈值，则同TAG优先
 3.相同标签规则匹配失败

【用例描述】无

【自测情况】（feign，rest，dubbo）：**只会上报前后两次状态不同的事件**
应用：一个带gray:red的parameter且版本为1.0.1的consumer
三个provider分别是：
1. 带group:abcd的parameter
2. 带group:abc的parameter
3. 版本为1.0.0

模拟请求：
```bash
curl  ip:port/router/cloud/getMetadata
```

**场景一：policy中仅设置比例阈值为20%，同TAG优先**

```yaml
---
- kind: routematcher.sermant.io/tag
  description: aaa
  rules:
    - precedence: 1
      match:
        tags:
          group:
            exact: abc
        policy:
          triggerThreshold: 20
      route:
        - tags:
            gray: CONSUMER_TAG
```
验证：同TAG优先，一直访问到带red的下游服务
![image](https://user-images.githubusercontent.com/27326092/230576006-b8270b19-78ba-4585-8178-f22dda84b0cd.png)


backend界面：同TAG优先规则匹配生效

![image](https://user-images.githubusercontent.com/27326092/230575871-06a320a6-991f-44e0-9c38-05fec449fb12.png)

---

**场景二：policy中仅设置比例阈值为50%，非同TAG优先，随机访问ALL** 
```yaml
---
- kind: routematcher.sermant.io/tag
  description: aaa
  rules:
    - precedence: 1
      match:
        tags:
          group:
            exact: abc
        policy:
          triggerThreshold: 50
      route:
        - tags:
            gray: CONSUMER_TAG
```
验证：非同TAG优先，随机访问
![image](https://user-images.githubusercontent.com/27326092/230576354-f80d8c90-a800-4771-a522-d12b47b384cf.png)

backend界面：同TAG优先规则匹配失效
![image](https://user-images.githubusercontent.com/27326092/230576436-834dcd0f-5760-4cc8-a281-84bdc9b1f559.png)

---
**场景三：policy中设置比例阈值为20%和最小可用实例阈值4，同TAG优先** 
```yaml
---
- kind: routematcher.sermant.io/tag
  description: aaa
  rules:
    - precedence: 1
      match:
        tags:
          group:
            exact: abc
        policy:
          triggerThreshold: 20
          minAllInstances: 4
      route:
        - tags:
            gray: CONSUMER_TAG
```
验证：同TAG优先，一直访问到带red的下游服务
![image](https://user-images.githubusercontent.com/27326092/230576709-58a818ba-7e71-4c50-b572-b228da617666.png)

backend界面：同TAG优先规则匹配生效
![image](https://user-images.githubusercontent.com/27326092/230576854-a8fae2fa-a58e-40e6-a6a0-5a06c2bd9094.png)

---
**场景四：policy中设置比例阈值为20%和最小可用实例阈值1，同TAG优先** 
```yaml
---
- kind: routematcher.sermant.io/tag
  description: aaa
  rules:
    - precedence: 1
      match:
        tags:
          group:
            exact: abc
        policy:
          triggerThreshold: 20
          minAllInstances: 1
      route:
        - tags:
            gray: CONSUMER_TAG
```
验证：同TAG优先，一直访问到带red的下游服务
![image](https://user-images.githubusercontent.com/27326092/230577062-25003392-6a3b-4cc3-b753-214ab161d4fa.png)

backend界面：同TAG优先规则匹配生效
![image](https://user-images.githubusercontent.com/27326092/230577177-d33c94fd-3d5f-4c13-9419-85ce76844a3f.png)

---
**场景五：policy中设置比例阈值为50%和最小可用实例阈值1，非同TAG优先，随机访问ALL** 
```yaml
---
- kind: routematcher.sermant.io/tag
  description: aaa
  rules:
    - precedence: 1
      match:
        tags:
          group:
            exact: abc
        policy:
          triggerThreshold: 50
          minAllInstances: 1
      route:
        - tags:
            gray: CONSUMER_TAG
```
验证：非同TAG优先，随机访问ALL
![image](https://user-images.githubusercontent.com/27326092/230577589-8a628f2b-d3c3-44a3-b1eb-738df8218fda.png)
backend界面：同TAG优先规则匹配失效
![image](https://user-images.githubusercontent.com/27326092/230577679-e1a1f99f-c415-47d0-9257-822e71a0b348.png)

【影响范围】是需要更新一些文档（router手册）
