### PR TITLE
【enhancement】http请求兼容非标准HttpMethod的实现（1.0.x）

### DIFF
--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
@@ -31,16 +31,21 @@ import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 import com.huaweicloud.sermant.core.utils.ClassUtils;
 
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.Configurable;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.util.EntityUtils;
 
 import java.io.Closeable;
@@ -64,18 +69,6 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
     private static final String ERROR_RESPONSE_CLASS = "com.huawei.discovery.entity.ErrorCloseableHttpResponse";
 
     private static final String COMMON_REQUEST_CLASS = "com.huawei.discovery.entity.HttpCommonRequest";
-
-    private static final String HTTP_POST_NAME = "org.apache.http.client.methods.HttpPost";
-
-    private static final String HTTP_GET_NAME = "org.apache.http.client.methods.HttpGet";
-
-    private static final String HTTP_PUT_NAME = "org.apache.http.client.methods.HttpPut";
-
-    private static final String HTTP_DELETE_NAME = "org.apache.http.client.methods.HttpDelete";
-
-    private static final String HTTP_PATCH_NAME = "org.apache.http.client.methods.HttpPatch";
-
-    private static final String HTTP_HEAD_NAME = "org.apache.http.client.methods.HttpHead";
 
     private final AtomicBoolean isLoaded = new AtomicBoolean();
 
@@ -187,78 +180,134 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
         return new HttpHost(serviceInstance.getHost(), serviceInstance.getPort(), scheme);
     }
 
-    private HttpRequest rebuildRequest(String uriNew, String method, HttpRequest httpUriRequest) {
-        switch (httpUriRequest.getClass().getName()) {
-            case HTTP_POST_NAME:
-                return buildHttpPost(uriNew, (HttpPost) httpUriRequest);
-            case HTTP_GET_NAME:
-                return buildHttpGet(uriNew, (HttpGet) httpUriRequest);
-            case HTTP_PUT_NAME:
-                return buildHttpPut(uriNew, (HttpPut) httpUriRequest);
-            case HTTP_DELETE_NAME:
-                return buildHttpDelete(uriNew, (HttpDelete) httpUriRequest);
-            case HTTP_PATCH_NAME:
-                return buildHttpPatch(uriNew, (HttpPatch) httpUriRequest);
-            case HTTP_HEAD_NAME:
-                return buildHttpHead(uriNew, (HttpHead) httpUriRequest);
-            default:
-                return new HttpCommonRequest(method, uriNew);
+    private HttpRequest rebuildRequest(String uriNew, String method, HttpRequest httpRequest) {
+        try {
+            HttpUriRequest httpUriRequest = (HttpUriRequest) httpRequest;
+            switch (method) {
+                case "POST":
+                    return buildHttpPost(uriNew, httpUriRequest);
+                case "GET":
+                    return buildHttpGet(uriNew, httpUriRequest);
+                case "PUT":
+                    return buildHttpPut(uriNew, httpUriRequest);
+                case "DELETE":
+                    return buildHttpDelete(uriNew, httpUriRequest);
+                case "PATCH":
+                    return buildHttpPatch(uriNew, httpUriRequest);
+                case "HEAD":
+                    return buildHttpHead(uriNew, httpUriRequest);
+                case "OPTIONS":
+                    return buildHttpOptions(uriNew, httpUriRequest);
+                case "TRACE":
+                    return buildHttpTrace(uriNew, httpUriRequest);
+                default:
+                    return new HttpCommonRequest(method, uriNew);
+            }
+        } catch (ClassCastException exception) {
+            LOGGER.severe("Method implementation of HttpClient is not supported!" + exception.getMessage());
+            return new HttpCommonRequest(method, uriNew);
         }
     }
 
-    private HttpHead buildHttpHead(String uriNew, HttpHead httpUriRequest) {
+    private HttpTrace buildHttpTrace(String uriNew, HttpUriRequest httpUriRequest) {
+        HttpTrace httpTrace = new HttpTrace(uriNew);
+        httpTrace.setHeaders(httpUriRequest.getAllHeaders());
+        httpTrace.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpTrace.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpTrace.setConfig(configurable.getConfig());
+        }
+        return httpTrace;
+    }
+
+    private HttpOptions buildHttpOptions(String uriNew, HttpUriRequest httpUriRequest) {
+        HttpOptions httpOptions = new HttpOptions(uriNew);
+        httpOptions.setHeaders(httpUriRequest.getAllHeaders());
+        httpOptions.setProtocolVersion(httpUriRequest.getProtocolVersion());
+        httpOptions.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpOptions.setConfig(configurable.getConfig());
+        }
+        return httpOptions;
+    }
+
+    private HttpHead buildHttpHead(String uriNew, HttpUriRequest httpUriRequest) {
         HttpHead httpHead = new HttpHead(uriNew);
         httpHead.setHeaders(httpUriRequest.getAllHeaders());
-        httpHead.setConfig(httpUriRequest.getConfig());
         httpHead.setProtocolVersion(httpUriRequest.getProtocolVersion());
         httpHead.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpHead.setConfig(configurable.getConfig());
+        }
         return httpHead;
     }
 
-    private HttpPatch buildHttpPatch(String uriNew, HttpPatch httpUriRequest) {
+    private HttpPatch buildHttpPatch(String uriNew, HttpUriRequest httpUriRequest) {
+        HttpEntityEnclosingRequest httpEntityEnclosingRequest = (HttpEntityEnclosingRequest) httpUriRequest;
         HttpPatch httpPatch = new HttpPatch(uriNew);
+        httpPatch.setEntity(httpEntityEnclosingRequest.getEntity());
         httpPatch.setHeaders(httpUriRequest.getAllHeaders());
-        httpPatch.setConfig(httpUriRequest.getConfig());
         httpPatch.setProtocolVersion(httpUriRequest.getProtocolVersion());
         httpPatch.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpPatch.setConfig(configurable.getConfig());
+        }
         return httpPatch;
     }
 
-    private HttpDelete buildHttpDelete(String uriNew, HttpDelete httpUriRequest) {
+    private HttpDelete buildHttpDelete(String uriNew, HttpUriRequest httpUriRequest) {
         HttpDelete httpDelete = new HttpDelete(uriNew);
         httpDelete.setHeaders(httpUriRequest.getAllHeaders());
-        httpDelete.setConfig(httpUriRequest.getConfig());
         httpDelete.setProtocolVersion(httpUriRequest.getProtocolVersion());
         httpDelete.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpDelete.setConfig(configurable.getConfig());
+        }
         return httpDelete;
     }
 
-    private HttpPut buildHttpPut(String uriNew, HttpPut httpUriRequest) {
+    private HttpPut buildHttpPut(String uriNew, HttpUriRequest httpUriRequest) {
+        HttpEntityEnclosingRequest httpEntityEnclosingRequest = (HttpEntityEnclosingRequest) httpUriRequest;
         HttpPut httpPut = new HttpPut(uriNew);
-        httpPut.setEntity(httpUriRequest.getEntity());
+        httpPut.setEntity(httpEntityEnclosingRequest.getEntity());
         httpPut.setHeaders(httpUriRequest.getAllHeaders());
-        httpPut.setConfig(httpUriRequest.getConfig());
         httpPut.setProtocolVersion(httpUriRequest.getProtocolVersion());
         httpPut.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpPut.setConfig(configurable.getConfig());
+        }
         return httpPut;
     }
 
-    private HttpGet buildHttpGet(String uriNew, HttpGet httpUriRequest) {
+    private HttpGet buildHttpGet(String uriNew, HttpUriRequest httpUriRequest) {
         HttpGet httpGet = new HttpGet(uriNew);
         httpGet.setHeaders(httpUriRequest.getAllHeaders());
-        httpGet.setConfig(httpUriRequest.getConfig());
         httpGet.setProtocolVersion(httpUriRequest.getProtocolVersion());
         httpGet.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpGet.setConfig(configurable.getConfig());
+        }
         return httpGet;
     }
 
-    private HttpPost buildHttpPost(String uriNew, HttpPost httpUriRequest) {
+    private HttpPost buildHttpPost(String uriNew, HttpUriRequest httpUriRequest) {
+        HttpEntityEnclosingRequest httpEntityEnclosingRequest = (HttpEntityEnclosingRequest) httpUriRequest;
         HttpPost httpPost = new HttpPost(uriNew);
-        httpPost.setEntity(httpUriRequest.getEntity());
+        httpPost.setEntity(httpEntityEnclosingRequest.getEntity());
         httpPost.setHeaders(httpUriRequest.getAllHeaders());
-        httpPost.setConfig(httpUriRequest.getConfig());
         httpPost.setProtocolVersion(httpUriRequest.getProtocolVersion());
         httpPost.setParams(httpUriRequest.getParams());
+        if (httpUriRequest instanceof Configurable) {
+            Configurable configurable = (Configurable) httpUriRequest;
+            httpPost.setConfig(configurable.getConfig());
+        }
         return httpPost;
     }
 


### PR DESCRIPTION
【修复issue】https://github.com/huaweicloud/Sermant/issues/1177

【修改内容】使用httpclient时，可使用fluent-hc包等来发送HTTP请求，需兼容HttpEntityEnclosingRequest和HttpUriRequest的其他非标准实现，该PR兼容此类实现。
![image](https://user-images.githubusercontent.com/46025350/230250049-c43e82d9-a46d-4fe6-9d90-4748bd2957e4.png)

【用例描述】本地自测fluent-hc发送各http请求可以正常被重新构造

【自测情况】1、本地静态检查清理通过；2、本地自测通过

【影响范围】兼容使用fluent-hc等实现httpmethod的用户