### PR TITLE
修改事件过期时间单位和webhook通知级别

### DIFF
--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/memory/MemoryClientImpl.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/memory/MemoryClientImpl.java
@@ -61,25 +61,25 @@ public class MemoryClientImpl implements EventDao {
      */
     public MemoryClientImpl(BackendConfig backendConfig) {
         this.eventMap = ExpiringMap.builder().expiration(
-                backendConfig.getEventExpire(), TimeUnit.SECONDS)
+                backendConfig.getEventExpire(), TimeUnit.DAYS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
         this.agentInstanceMap = ExpiringMap.builder()
-                .expiration(backendConfig.getEventExpire(), TimeUnit.SECONDS)
+                .expiration(backendConfig.getEventExpire(), TimeUnit.DAYS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
         this.eventTimeKeyMap = ExpiringMap.builder()
-                .expiration(backendConfig.getEventExpire(), TimeUnit.SECONDS)
+                .expiration(backendConfig.getEventExpire(), TimeUnit.DAYS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
         this.sessionMap = ExpiringMap.builder()
                 .expiration(backendConfig.getSessionTimeout(), TimeUnit.SECONDS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
         this.emergency = ExpiringMap.builder()
-                .expiration(backendConfig.getEventExpire(), TimeUnit.SECONDS)
+                .expiration(backendConfig.getEventExpire(), TimeUnit.DAYS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
         this.important = ExpiringMap.builder()
-                .expiration(backendConfig.getEventExpire(), TimeUnit.SECONDS)
+                .expiration(backendConfig.getEventExpire(), TimeUnit.DAYS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
         this.normal = ExpiringMap.builder()
-                .expiration(backendConfig.getEventExpire(), TimeUnit.SECONDS)
+                .expiration(backendConfig.getEventExpire(), TimeUnit.DAYS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
     }
 

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/redis/RedisClientImpl.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/redis/RedisClientImpl.java
@@ -237,7 +237,7 @@ public class RedisClientImpl implements EventDao {
     public void cleanOverDueEventTimerTask() {
         if (backendConfig.getDatabase().equals(DatabaseType.REDIS)) {
             Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.SECOND, -backendConfig.getEventExpire());
+            calendar.add(Calendar.DATE, -backendConfig.getEventExpire());
             List<Tuple> needCleanEvent = queryByTimeRange(
                     CommonConst.REDIS_EVENT_FIELD_SET_KEY, 0, calendar.getTimeInMillis());
             List<String> eventKeys = needCleanEvent.stream().map(Tuple::getElement).collect(Collectors.toList());

--- a/sermant-backend/src/main/resources/application.properties
+++ b/sermant-backend/src/main/resources/application.properties
@@ -25,10 +25,12 @@ database.password=
 database.filter.thread.num=10000
 
 # webhook level[EMERGENCY,IMPORTANT,NORMAL]
-webhook.eventpush.level=NORMAL
+webhook.eventpush.level=EMERGENCY
 
-# Event Expiration Time (s)
-database.event.expire=1800
+# Event Expiration Time (day)
+database.event.expire=7
+
+# event field Expiration Time (s)
 database.field.expire=5
 database.fixedDelay=10000
 


### PR DESCRIPTION
【修复issue】#1099

【修改内容】

- 事件过期时间单位由秒更改为天，默认保存7天
- 事件webhook通知级别更改为EMERGENCY

【用例描述】不需修改用例