### PR TITLE
修复订阅与配置变动时，线程中的类加载器不一致的bug

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/DefaultGroupConfigSubscriber.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/DefaultGroupConfigSubscriber.java
@@ -17,6 +17,8 @@
 
 package com.huaweicloud.sermant.core.plugin.subscribe;
 
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.DefaultConfigProcessor;
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.IntegratedEventListenerAdapter;
 import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
 import com.huaweicloud.sermant.core.utils.LabelGroupUtils;
@@ -40,8 +42,8 @@ public class DefaultGroupConfigSubscriber extends AbstractGroupConfigSubscriber 
      * 默认配置订阅
      *
      * @param serviceName 服务名
-     * @param listener    监听器
-     * @param pluginName  插件名称
+     * @param listener 监听器
+     * @param pluginName 插件名称
      */
     public DefaultGroupConfigSubscriber(String serviceName, DynamicConfigListener listener, String pluginName) {
         this(serviceName, listener, null, pluginName);
@@ -50,10 +52,10 @@ public class DefaultGroupConfigSubscriber extends AbstractGroupConfigSubscriber 
     /**
      * 自定义配置中心实现
      *
-     * @param serviceName          服务名
-     * @param listener             监听器
+     * @param serviceName 服务名
+     * @param listener 监听器
      * @param dynamicConfigService 配置中心实现
-     * @param pluginName           插件名称
+     * @param pluginName 插件名称
      */
     public DefaultGroupConfigSubscriber(String serviceName, DynamicConfigListener listener,
             DynamicConfigService dynamicConfigService, String pluginName) {
@@ -64,8 +66,9 @@ public class DefaultGroupConfigSubscriber extends AbstractGroupConfigSubscriber 
 
     @Override
     protected Map<String, DynamicConfigListener> buildGroupSubscribers() {
-        return Collections.singletonMap(LabelGroupUtils
-            .createLabelGroup(Collections.singletonMap("service", serviceName)), listener);
+        return Collections
+                .singletonMap(LabelGroupUtils.createLabelGroup(Collections.singletonMap("service", serviceName)),
+                        new IntegratedEventListenerAdapter(new DefaultConfigProcessor(listener), null));
     }
 
     @Override

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/processor/DefaultConfigProcessor.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/processor/DefaultConfigProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.plugin.subscribe.processor;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+
+/**
+ * 默认配置处理器
+ *
+ * @author provenceee
+ * @since 2023-04-11
+ */
+public class DefaultConfigProcessor implements ConfigProcessor {
+    /**
+     * 原监听器
+     */
+    private final DynamicConfigListener originListener;
+
+    /**
+     * 构造器
+     *
+     * @param listener 原始监听器
+     */
+    public DefaultConfigProcessor(DynamicConfigListener listener) {
+        this.originListener = listener;
+    }
+
+    @Override
+    public void process(String rawGroup, DynamicConfigEvent event) {
+        originListener.process(event);
+    }
+
+    @Override
+    public void addHolder(ConfigDataHolder dataHolder) {
+    }
+}


### PR DESCRIPTION
【修复issue】 #1187 

【修改内容】推送配置变动通知时，把当前线程中的类加载器设置为订阅时的类加载器，通知完成后，再还原

【用例描述】在PluginService的start方法中，订阅配置，不会导致动态配置插件的集成测试报错

【自测情况】修改前，本地与流水环境均能复现该问题，修改后，本地与流水环境不再报错

【影响范围】无
