### PR TITLE
【enhancement】优化netty重连时间策略（1.1.0-alpha）

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -44,6 +44,9 @@ gateway.nettyIp=127.0.0.1
 gateway.nettyPort=6888
 gateway.nettyConnectTimeout=5000
 gateway.nettyWriteAndReadWaitTime=60000
+gateway.sendInternalTime=10
+gateway.initReconnectInternalTime=5
+gateway.maxReconnectInternalTime=180
 
 # service meta config
 service.meta.application=default

--- a/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
@@ -44,6 +44,9 @@ gateway.nettyIp=127.0.0.1
 gateway.nettyPort=6888
 gateway.nettyConnectTimeout=5000
 gateway.nettyWriteAndReadWaitTime=60000
+gateway.sendInternalTime=10
+gateway.initReconnectInternalTime=5
+gateway.maxReconnectInternalTime=180
 
 # service meta config
 service.meta.application=default

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/send/config/GatewayConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/send/config/GatewayConfig.java
@@ -31,9 +31,30 @@ public class GatewayConfig implements BaseConfig {
 
     private static final long NETTY_DEFAULT_WRITE_READ_WAIT_TIME = 60000L;
 
+    /**
+     * netty服务端的地址
+     */
     private String nettyIp;
 
+    /**
+     * netty服务端的端口
+     */
     private int nettyPort;
+
+    /**
+     * netty发送消息的间隔，单位：秒
+     */
+    private int sendInternalTime;
+
+    /**
+     * netty连接后断开的初始重连时间，单位：秒
+     */
+    private int initReconnectInternalTime;
+
+    /**
+     * netty连接后断开的最大重连时间，单位：秒
+     */
+    private int maxReconnectInternalTime;
 
     /**
      * Netty 需要设置Integer型超时事件，故此处为int非long
@@ -72,5 +93,29 @@ public class GatewayConfig implements BaseConfig {
 
     public void setNettyWriteAndReadWaitTime(long nettyWriteAndReadWaitTime) {
         this.nettyWriteAndReadWaitTime = nettyWriteAndReadWaitTime;
+    }
+
+    public int getSendInternalTime() {
+        return sendInternalTime;
+    }
+
+    public void setSendInternalTime(int sendInternalTime) {
+        this.sendInternalTime = sendInternalTime;
+    }
+
+    public int getInitReconnectInternalTime() {
+        return initReconnectInternalTime;
+    }
+
+    public void setInitReconnectInternalTime(int initReconnectInternalTime) {
+        this.initReconnectInternalTime = initReconnectInternalTime;
+    }
+
+    public int getMaxReconnectInternalTime() {
+        return maxReconnectInternalTime;
+    }
+
+    public void setMaxReconnectInternalTime(int maxReconnectInternalTime) {
+        this.maxReconnectInternalTime = maxReconnectInternalTime;
     }
 }


### PR DESCRIPTION
【修复issue】https://github.com/huaweicloud/Sermant/issues/1190

【修改内容】使用指数退避方式优化netty重连时间策略，避免性能下降

【用例描述】
1、断开backend连接，重连时间依次为5、10、20、40、80、160、180、180、180...
2、重新连接后再次断开backend连接，初始重连时间恢复为5，并重复1中过程。
【自测情况】1、本地静态检查清理情况；2 本地测试通过

【影响范围】无