### PR TITLE
【fix】设置GatewayConfig默认的配置&修复配置为空的解析bug

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
@@ -84,15 +84,15 @@ public class ConfigValueUtil {
      * <li>service-meta-applicationname</li>
      */
     private static final KeyFormatter[] KEY_FORMATTERS = new KeyFormatter[]{
-        key -> key,
-        key -> key.replace('.', '_'),
-        key -> key.replace('.', '-'),
-        key -> key.toUpperCase(Locale.ROOT),
-        key -> key.toUpperCase(Locale.ROOT).replace('.', '_'),
-        key -> key.toUpperCase(Locale.ROOT).replace('.', '-'),
-        key -> key.toLowerCase(Locale.ROOT),
-        key -> key.toLowerCase(Locale.ROOT).replace('.', '_'),
-        key -> key.toLowerCase(Locale.ROOT).replace('.', '-'),
+            key -> key,
+            key -> key.replace('.', '_'),
+            key -> key.replace('.', '-'),
+            key -> key.toUpperCase(Locale.ROOT),
+            key -> key.toUpperCase(Locale.ROOT).replace('.', '_'),
+            key -> key.toUpperCase(Locale.ROOT).replace('.', '-'),
+            key -> key.toLowerCase(Locale.ROOT),
+            key -> key.toLowerCase(Locale.ROOT).replace('.', '_'),
+            key -> key.toLowerCase(Locale.ROOT).replace('.', '-'),
     };
 
     /**
@@ -101,12 +101,12 @@ public class ConfigValueUtil {
      */
     private static final List<ValueReferFunction<String, Map<String, Object>, String>>
             VALUE_REFER_FUNCTION = Arrays.asList(
-                (key, argsMap) -> {
+            (key, argsMap) -> {
                 final Object config = argsMap.get(key);
                 return config == null ? null : config.toString();
-                },
-                (key, argsMap) -> System.getenv(key),
-                (key, argsMap) -> System.getProperty(key)
+            },
+            (key, argsMap) -> System.getenv(key),
+            (key, argsMap) -> System.getProperty(key)
     );
 
     /**
@@ -115,13 +115,13 @@ public class ConfigValueUtil {
      */
     private static final List<ValueFixFunction<String, Map<String, Object>, FixedValueProvider, String>>
             VALUE_FIX_FUNCTIONS = Arrays.asList(
-                (key, argsMap, provider) -> {
-                    final Object config = argsMap.get(key);
-                    return config == null ? null : config.toString();
-                },
-                (key, argsMap, provider) -> System.getenv(key),
-                (key, argsMap, provider) -> System.getProperty(key),
-                (key, argsMap, provider) -> provider == null ? null : provider.getFixedValue(key)
+            (key, argsMap, provider) -> {
+                final Object config = argsMap.get(key);
+                return config == null ? null : config.toString();
+            },
+            (key, argsMap, provider) -> System.getenv(key),
+            (key, argsMap, provider) -> System.getProperty(key),
+            (key, argsMap, provider) -> provider == null ? null : provider.getFixedValue(key)
     );
 
     private ConfigValueUtil() {
@@ -251,7 +251,7 @@ public class ConfigValueUtil {
      */
     public static <R> R toBaseType(String configStr, Class<R> type) {
         Object result = null;
-        if (configStr == null) {
+        if (configStr == null || "".equals(configStr)) {
             return (R) result;
         }
         if (type == int.class) {
@@ -345,7 +345,7 @@ public class ConfigValueUtil {
      * 获取配置键的参考值，优先级：入参 > 环境变量 > 系统变量 > 配置
      * <p>修正不同配置格式获取值, 含'-','_','.',大写以及小写</p>
      *
-     * @param key       键
+     * @param key 键
      * @param configVal 配置值
      * @return 最终配置参考值
      */
@@ -369,10 +369,9 @@ public class ConfigValueUtil {
     }
 
     /**
-     * 由KeyFormatter处理后读取环境变量
-     * 优先级：入参 > 环境变量 > 系统变量 > 配置
+     * 由KeyFormatter处理后读取环境变量 优先级：入参 > 环境变量 > 系统变量 > 配置
      *
-     * @param key     键
+     * @param key 键
      * @param argsMap 入参
      * @return 最终配置参考值
      */
@@ -466,7 +465,7 @@ public class ConfigValueUtil {
         /**
          * 应用修正
          *
-         * @param key              键
+         * @param key 键
          * @param bootstrapArgsMap 启动参数Map
          * @return 最终参考值
          */

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/send/config/GatewayConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/send/config/GatewayConfig.java
@@ -27,41 +27,51 @@ import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
  */
 @ConfigTypeKey("gateway")
 public class GatewayConfig implements BaseConfig {
-    private static final int NETTY_DEFAULT_CONNECT_TIMEOUT = 5000;
+    private static final int DEFAULT_INIT_RECONNECT_INTERNAL_TIME = 5;
 
-    private static final long NETTY_DEFAULT_WRITE_READ_WAIT_TIME = 60000L;
+    private static final int DEFAULT_MAX_RECONNECT_INTERNAL_TIME = 180;
+
+    private static final int DEFAULT_NETTY_CONNECT_TIMEOUT = 5000;
+
+    private static final long DEFAULT_NETTY_WRITE_READ_WAIT_TIME = 60000L;
+
+    private static final String DEFAULT_NETTY_IP = "127.0.0.1";
+
+    private static final int DEFAULT_NETTY_PORT = 6888;
+
+    private static final int DEFAULT_SEND_INTERNAL_TIME = 10;
 
     /**
      * netty服务端的地址
      */
-    private String nettyIp;
+    private String nettyIp = DEFAULT_NETTY_IP;
 
     /**
      * netty服务端的端口
      */
-    private int nettyPort;
+    private int nettyPort = DEFAULT_NETTY_PORT;
 
     /**
      * netty发送消息的间隔，单位：秒
      */
-    private int sendInternalTime;
+    private int sendInternalTime = DEFAULT_SEND_INTERNAL_TIME;
 
     /**
      * netty连接后断开的初始重连时间，单位：秒
      */
-    private int initReconnectInternalTime;
+    private int initReconnectInternalTime = DEFAULT_INIT_RECONNECT_INTERNAL_TIME;
 
     /**
      * netty连接后断开的最大重连时间，单位：秒
      */
-    private int maxReconnectInternalTime;
+    private int maxReconnectInternalTime = DEFAULT_MAX_RECONNECT_INTERNAL_TIME;
 
     /**
      * Netty 需要设置Integer型超时事件，故此处为int非long
      */
-    private int nettyConnectTimeout = NETTY_DEFAULT_CONNECT_TIMEOUT;
+    private int nettyConnectTimeout = DEFAULT_NETTY_CONNECT_TIMEOUT;
 
-    private long nettyWriteAndReadWaitTime = NETTY_DEFAULT_WRITE_READ_WAIT_TIME;
+    private long nettyWriteAndReadWaitTime = DEFAULT_NETTY_WRITE_READ_WAIT_TIME;
 
     public String getNettyIp() {
         return nettyIp;


### PR DESCRIPTION
【修复issue】https://github.com/huaweicloud/Sermant/issues/1193

【修改内容】
1、设置GatewayConfig默认的配置
2、修复配置为空的解析bug

【用例描述】1、本地配置配置文件时，int字段的value为空，可以正常解析

【自测情况】1、本地静态检查清理情况；2、本地自测通过

【影响范围】无