### PR TITLE
事件上报集成测试用例

### DIFF
--- a/.github/actions/scenarios/backend/memory/action.yml
+++ b/.github/actions/scenarios/backend/memory/action.yml
@@ -1,0 +1,82 @@
+name: "Backend Test Use Memory"
+description: "Auto test for Backend"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        java-version: '8'
+        distribution: 'adopt'
+        cache: maven
+    - name: Set up python
+      uses: actions/setup-python@v3.1.3
+      with:
+        python-version: '3.10'
+    - name: download middlewares
+      uses: actions/cache@v3
+      with:
+        path: |
+          apache-zookeeper-*/
+        key: ${{ runner.os }}-middlewares-${{ github.run_id }}
+    - name: start zookeeper
+      shell: bash
+      run: bash apache-zookeeper-3.6.3-bin/bin/zkServer.sh start apache-zookeeper-3.6.3-bin/conf/zoo_sample.cfg
+    - name: download agent
+      uses: actions/cache@v3
+      with:
+        path: sermant-agent-*/
+        key: ${{ runner.os }}-agent-${{ github.run_id }}
+    - name: package dubbo 2.6.0 tests
+      shell: bash
+      run: mvn package -Dalibaba.dubbo.version=2.6.0 -DskipTests -P260 --file sermant-integration-tests/dubbo-test/pom.xml
+    - name: entry
+      uses: ./.github/actions/common/entry
+      with:
+        log-dir: ./logs/backend
+    - name: start backend with memory
+      shell: bash
+      run: |
+        nohup java -jar sermant-agent-${{ env.sermantVersion }}/server/sermant/sermant-backend-${{ env.sermantVersion }}.jar &
+    - name: start demo
+      shell: bash
+      env:
+        AGENT_CONFIG_ISOUTPUTENHANCEDCLASSES: "true"
+        AGENT_CONFIG_ISSHOWENHANCELOG: "true"
+        AGENT_SERVICE_HEARTBEAT_ENABLE: "true"
+        AGENT_SERVICE_GATEWAY_ENABLE: "true"
+        EVENT_ENABLE: "true"
+        EVENT_OFFERWARNLOG: "true"
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=backend-demo -jar sermant-integration-tests/dubbo-test/dubbo-2-6-integration-provider/target/dubbo-integration-provider.jar &
+    - name: waiting for demo start
+      shell: bash
+      run: |
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:28021/actuator/health 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8900/sermant/event/webhooks 120
+    - name: stop demo
+      shell: bash
+      run: |
+        netstat -nlp | grep :28021 | awk '{print $7}' | awk -F "/" '{print $1}' | xargs kill
+    - name: install requests
+      shell: bash
+      run: |
+        pip install requests
+    - name: start test
+      shell: bash
+      run: |
+        python -m unittest ./sermant-integration-tests/scripts/testBackend.py
+    - name: stop backend
+      shell: bash
+      run: |
+        netstat -nlp | grep :8900 | awk '{print $7}' | awk -F "/" '{print $1}' | xargs kill
+    - name: if failure then upload error log
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() || cancelled() }}
+      with:
+        name: (${{ github.job }})-backend-logs
+        path: |
+          ./*.log
+          ./logs/**
+        if-no-files-found: warn
+        retention-days: 2

--- a/.github/actions/scenarios/backend/redis/action.yml
+++ b/.github/actions/scenarios/backend/redis/action.yml
@@ -1,0 +1,58 @@
+name: "Backend Test Use Redis"
+description: "Auto test for Backend"
+runs:
+  using: "composite"
+  steps:
+    - name: entry
+      uses: ./.github/actions/common/entry
+      with:
+        log-dir: ./logs/backend
+    - name: install redis
+      shell: bash
+      run: |
+        sudo apt install redis-server -y
+        sudo sed -i 's/# requirepass foobared/requirepass 123456/g' /etc/redis/redis.conf
+        sudo service redis restart
+    - name: start backend with redis
+      shell: bash
+      env:
+        DATABASE_TYPE: REDIS
+        DATABASE_VERSION: "6.0"
+        DATABASE_PASSWORD: "123456"
+      run: |
+        nohup java -jar sermant-agent-${{ env.sermantVersion }}/server/sermant/sermant-backend-${{ env.sermantVersion }}.jar &
+    - name: start demo
+      shell: bash
+      env:
+        AGENT_CONFIG_ISOUTPUTENHANCEDCLASSES: "true"
+        AGENT_CONFIG_ISSHOWENHANCELOG: "true"
+        AGENT_SERVICE_HEARTBEAT_ENABLE: "true"
+        AGENT_SERVICE_GATEWAY_ENABLE: "true"
+        EVENT_ENABLE: "true"
+        EVENT_OFFERWARNLOG: "true"
+        EVENT_OFFERERRORLOG: "true"
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar=appName=backend-demo -jar sermant-integration-tests/dubbo-test/dubbo-2-6-integration-provider/target/dubbo-integration-provider.jar &
+    - name: waiting for demo start
+      shell: bash
+      run: |
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:28021/actuator/health 120
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8900/sermant/event/webhooks 120
+    - name: stop demo
+      shell: bash
+      run: |
+        netstat -nlp | grep :28021 | awk '{print $7}' | awk -F "/" '{print $1}' | xargs kill
+    - name: start test
+      shell: bash
+      run: |
+        python -m unittest ./sermant-integration-tests/scripts/testBackend.py
+    - name: if failure then upload error log
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() || cancelled() }}
+      with:
+        name: (${{ github.job }})-backend-logs
+        path: |
+          ./*.log
+          ./logs/**
+        if-no-files-found: warn
+        retention-days: 2

--- a/.github/workflows/backend_integration_test.yml
+++ b/.github/workflows/backend_integration_test.yml
@@ -1,0 +1,66 @@
+name: Backend Integration Test
+env:
+  sermantVersion: 1.0.0
+on:
+  push:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'sermant-agentcore/**'
+      - 'sermant-backend/**'
+      - '.github/workflows/backend*.yml'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
+jobs:
+  download-midwares-and-cache:
+    name: download midwares and cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: cache middlewares
+        uses: actions/cache@v3
+        with:
+          path: |
+            apache-zookeeper-*/
+          key: ${{ runner.os }}-middlewares-${{ github.run_id }}
+      - name: download middlewares
+        run: |
+          export ROOT_PATH=$(pwd)
+          bash ./sermant-integration-tests/scripts/tryDownloadMidware.sh zk
+          tar -zxf apache-zookeeper-3.6.3-bin.tar.gz
+  build-agent-and-cache:
+    name: build agent and cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: maven
+      - name: cache agent
+        uses: actions/cache@v3
+        with:
+          path: sermant-agent-*/
+          key: ${{ runner.os }}-agent-${{ github.run_id }}
+      - name: package agent
+        run: |
+          sed -i '/sermant-backend-lite/d' pom.xml
+          sed -i '/sermant-integration-tests/d' pom.xml
+          sed -i '/sermant-injector/d' pom.xml
+          mvn package -DskipTests -Ptest --file pom.xml
+  test-for-backend:
+    name: Test for backend
+    runs-on: ubuntu-latest
+    needs: [ build-agent-and-cache, download-midwares-and-cache ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: start backend use memory test
+        uses: ./.github/actions/scenarios/backend/memory
+      - name: start backend use redis test
+        uses: ./.github/actions/scenarios/backend/redis
+
+

--- a/sermant-integration-tests/scripts/testBackend.py
+++ b/sermant-integration-tests/scripts/testBackend.py
@@ -1,0 +1,207 @@
+#
+# Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+import json
+import unittest
+import time
+
+import requests
+
+
+class TestBackend(unittest.TestCase):
+    request_url_query_event = "http://127.0.0.1:8900/sermant/event/events"
+    request_url_query_page = "http://127.0.0.1:8900/sermant/event/events/page?page="
+    request_url_query_webhook = "http://127.0.0.1:8900/sermant/event/webhooks"
+    request_url_set_webhook = "http://127.0.0.1:8900/sermant/event/webhooks/"
+    sermant_start = "SERMANT_START"
+    sermant_stop = "SERMANT_STOP"
+    sermant_service_stop = "SERMANT_SERVICE_STOP"
+    sermant_service_start = "SERMANT_SERVICE_START"
+    sermant_transform_success = "SERMANT_TRANSFORM_SUCCESS"
+    sermant_transform_failure = "SERMANT_TRANSFORM_FAILURE"
+    log_warn = "WARNING"
+    log_error = "SEVERE"
+    level_normal = "normal"
+    level_important = "important"
+
+    def get_all_event(self, param=None):
+        """
+        获取满足条件的所有事件
+        :param param: 查询条件
+        :return: 事件
+        """
+        query_event_param = {
+                "service": [],
+                "ip": [],
+                "scope": "",
+                "type": [],
+                "level": [],
+                "startTime": 0,
+                "endTime": 0
+            }
+        if param is None:
+            param = {}
+        result = []
+        session = requests.session()
+        now_time = int(round(time.time() * 1000))
+        query_event_param.update({
+            "startTime": 0,
+            "endTime": now_time
+        })
+        query_event_param.update(param)
+        resp = session.get(self.request_url_query_event, params=query_event_param).json()
+        total_page = resp.get("totalPage")
+        result.extend(resp.get("events"))
+        for page in range(2, total_page + 1):
+            result.extend(session.get(self.request_url_query_page + str(page)).json().get("events"))
+        session.close()
+        return result
+
+    def event_field_verify(self, verify_name):
+        """
+        验证是否包含某种事件
+        :param verify_name: 事件名
+        :return: 验证结果
+        """
+        result = False
+        events = self.get_all_event()
+        if any(verify_name in json.dumps(event) for event in events):
+            result = True
+        return result
+
+    def test_sermant_start(self):
+        """
+        验证sermant启动事件
+        :return: None
+        """
+        self.assertTrue(self.event_field_verify(self.sermant_start))
+
+    def test_sermant_stop(self):
+        """
+        验证sermant停止事件
+        :return: None
+        """
+        self.assertTrue(self.event_field_verify(self.sermant_stop))
+
+    def test_sermant_service_start(self):
+        """
+        验证核心服务启动事件
+        :return: None
+        """
+        self.assertTrue(self.event_field_verify(self.sermant_service_start))
+
+    def test_sermant_service_stop(self):
+        """
+        验证核心服务停止事件
+        :return: None
+        """
+        self.assertTrue(self.event_field_verify(self.sermant_service_stop))
+
+    def test_sermant_transform_success(self):
+        """
+        验证增强成功事件
+        :return: None
+        """
+        self.assertTrue(self.event_field_verify(self.sermant_transform_success))
+
+    def test_backend_query_by_time(self):
+        """
+        验证查询顺序
+        :return: None
+        """
+        result = True
+        events = self.get_all_event()
+        if any(events[i].get("time") < events[i + 1].get("time") for i in range(0, len(events) - 1)):
+            result = False
+        self.assertTrue(result)
+
+    def test_backend_query_by_service_name(self):
+        """
+        验证服务名查询
+        :return: None
+        """
+        result = False
+        events = self.get_all_event(param={"service": ["default"]})
+        if len(events) > 0 and all(event.get("meta").get("service") == "default" for event in events):
+            result = True
+        self.assertTrue(result)
+
+    def test_backend_query_by_ip(self):
+        """
+        验证ip查询
+        :return: None
+        """
+        result = False
+        ip = "172.17.0.1"
+        events = self.get_all_event(param={"ip": [ip]})
+        if len(events) > 0 and all(event.get("meta").get("ip") == ip for event in events):
+            result = True
+        self.assertTrue(result)
+
+    def test_backend_query_by_event_type(self):
+        """
+        验证事件类型查询
+        :return: None
+        """
+        result = False
+        events = self.get_all_event(param={"type": ["operation", "log"]})
+        if len(events) > 0 and all(event.get("type") in ["operation", "log"] for event in events):
+            result = True
+        self.assertTrue(result)
+
+    def test_backend_query_by_event_level(self):
+        """
+        验证事件级别查询
+        :return: None
+        """
+        result = False
+        events = self.get_all_event(param={"level": ["normal", "important"]})
+        if len(events) > 0 and all(event.get("level") in ["normal", "important"] for event in events):
+            result = True
+        self.assertTrue(result)
+
+    def test_backend_webhook_info(self):
+        """
+        验证webhook查询
+        :return: None
+        """
+        resp = requests.get(self.request_url_query_webhook).json()
+        self.assertEqual(resp.get("total"), 2)
+
+    def test_backend_set_webhook(self):
+        """
+        验证webhook设置
+        :return: None
+        """
+        headers = {'content-type': 'application/json'}
+        self.assertTrue(
+            requests.put(self.request_url_set_webhook + '0',
+                         data=json.dumps({"url": "url", "enable": True}),
+                         headers=headers).json())
+        self.assertTrue(
+            requests.put(self.request_url_set_webhook + '1',
+                         data=json.dumps({"url": "url", "enable": True}),
+                         headers=headers).json())
+        resp = requests.get(self.request_url_query_webhook).json()
+        self.assertEqual(resp.get("total"), 2)
+        for webhook in resp.get("webhooks"):
+            self.assertTrue(webhook.get("enable"))
+            self.assertEqual(webhook.get("url"), "url")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
【修复issue】#1099

【修改内容】

- 增加backend集成测试，包括使用内存和redis

【用例描述】

- 事件上报测试：检测serman启停，核心服务启停，transform增强成功等
- 事件查询：按时间，服务名，IP，类型，级别等