### PR TITLE
【bugfix】避免springboot注册的时候serviceName被覆盖

### DIFF
--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/DefaultServiceInstance.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/DefaultServiceInstance.java
@@ -25,13 +25,15 @@ import java.util.Map;
  * @since 2022-09-26
  */
 public class DefaultServiceInstance extends HashedServiceInstance {
+    private static final int DEFAULT_PORT = 8080;
+
     private String serviceName;
 
     private String host;
 
     private String ip;
 
-    private int port;
+    private int port = DEFAULT_PORT;
 
     private String id;
 


### PR DESCRIPTION
【修复issue】https://github.com/huaweicloud/Sermant/issues/1197
【修改内容】增加了对SpringEnvironmentInfoInterceptor中设置服务名时的校验，避免重复触发时serviceName被默认值覆盖
【用例描述】不涉及
【自测情况】本地静态检查已过
【影响范围】不涉及