### PR TITLE
【fix】修复springboot注册插件获取spring.application.name的bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <gpg.plugin.version>3.0.1</gpg.plugin.version>
         <javadoc.plugin.version>3.3.2</javadoc.plugin.version>
         <nexus.staging.plugin.version>1.6.7</nexus.staging.plugin.version>
+        <frontend.plugin.version>1.12.1</frontend.plugin.version>
 
         <sermant.name>sermant-agent</sermant.name>
         <sermant.basedir>${pom.basedir}</sermant.basedir>
@@ -284,6 +285,11 @@
                 <artifactId>mockito-inline</artifactId>
                 <version>${mockito-inline.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend.plugin.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/sermant-backend/pom.xml
+++ b/sermant-backend/pom.xml
@@ -17,7 +17,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.netty.version>4.1.86.Final</io.netty.version>
         <spring-boot.version>2.6.1</spring-boot.version>
-        <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
         <protobuf-java.version>3.9.1</protobuf-java.version>
         <lombok.version>1.18.12</lombok.version>
         <fastjson.version>1.2.83</fastjson.version>

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/declarers/SpringEnvironmentInfoDeclarer.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/declarers/SpringEnvironmentInfoDeclarer.java
@@ -33,7 +33,7 @@ public class SpringEnvironmentInfoDeclarer extends BaseDeclarer {
 
     private static final String INTERCEPT_CLASS = SpringEnvironmentInfoInterceptor.class.getCanonicalName();
 
-    private static final String METHOD_NAME = "prepareEnvironment";
+    private static final String METHOD_NAME = "applyInitializers";
 
     @Override
     public ClassMatcher getClassMatcher() {

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/DefaultServiceInstance.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/DefaultServiceInstance.java
@@ -25,15 +25,13 @@ import java.util.Map;
  * @since 2022-09-26
  */
 public class DefaultServiceInstance extends HashedServiceInstance {
-    private static final int DEFAULT_PORT = 8080;
-
     private String serviceName;
 
     private String host;
 
     private String ip;
 
-    private int port = DEFAULT_PORT;
+    private int port;
 
     private String id;
 
@@ -132,5 +130,18 @@ public class DefaultServiceInstance extends HashedServiceInstance {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "{"
+                + "serviceName='" + serviceName + '\''
+                + ", host='" + host + '\''
+                + ", ip='" + ip + '\''
+                + ", port=" + port
+                + ", id='" + id + '\''
+                + ", metadata=" + metadata
+                + ", status='" + status + '\''
+                + '}';
     }
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/interceptors/SpringEnvironmentInfoInterceptorTest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/interceptors/SpringEnvironmentInfoInterceptorTest.java
@@ -16,16 +16,17 @@
 
 package com.huawei.discovery.interceptors;
 
+import com.huawei.discovery.entity.RegisterContext;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 
-import com.huawei.discovery.entity.RegisterContext;
-import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
-
 public class SpringEnvironmentInfoInterceptorTest extends BaseTest {
-
     private SpringEnvironmentInfoInterceptor interceptor;
 
     private final Object[] arguments;
@@ -34,7 +35,7 @@ public class SpringEnvironmentInfoInterceptorTest extends BaseTest {
      * 构造方法
      */
     public SpringEnvironmentInfoInterceptorTest() {
-        arguments = new Object[2];
+        arguments = new Object[1];
     }
 
     @Override
@@ -50,7 +51,9 @@ public class SpringEnvironmentInfoInterceptorTest extends BaseTest {
         Mockito.when(environment.getProperty("server.address")).thenReturn("192.168.0.157");
         Mockito.when(environment.getProperty("server.port")).thenReturn("8010");
         Mockito.when(environment.getProperty("spring.application.name")).thenReturn("zookeeper-provider-demo");
-        context.afterMethod(environment, null);
+        ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
+        applicationContext.setEnvironment(environment);
+        arguments[0] = applicationContext;
         interceptor.after(context);
         Assert.assertEquals(RegisterContext.INSTANCE.getServiceInstance().getServiceName(), "zookeeper-provider-demo");
     }


### PR DESCRIPTION
【修复issue】 #1197 
【修改内容】修改获取spring.application.name的拦截点，原拦截点获取spring.application.name时，environment未完成初始化，导致获取值不对
【用例描述】不涉及
【自测情况】本地静态检查已过
【影响范围】不涉及