### PR TITLE
【enhancement】新增springboot注册插件事件上报&支持stop方法中上报事件

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
@@ -17,8 +17,11 @@
 package com.huaweicloud.sermant.core.plugin.service;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.event.collector.FrameworkEventCollector;
 import com.huaweicloud.sermant.core.service.ServiceManager;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -44,23 +47,27 @@ public class PluginServiceManager extends ServiceManager {
      * @param classLoader 插件服务包的ClassLoader
      */
     public static void initPluginService(ClassLoader classLoader) {
+        List<String> startServiceList = new ArrayList<>();
         for (PluginService service : ServiceLoader.load(PluginService.class, classLoader)) {
             if (loadService(service, service.getClass(), PluginService.class)) {
                 try {
                     service.start();
+                    startServiceList.add(service.getClass().getName());
                 } catch (Exception ex) {
-                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "Error occurs while starting plugin service: %s",
+                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH,
+                            "Error occurs while starting plugin service: %s",
                             service.getClass()), ex);
                 }
             }
         }
+        FrameworkEventCollector.getInstance().collectServiceStartEvent(startServiceList.toString());
     }
 
     /**
      * 获取插件服务
      *
      * @param serviceClass 插件服务类
-     * @param <T>          插件服务类型
+     * @param <T> 插件服务类型
      * @return 插件服务实例
      */
     public static <T extends PluginService> T getPluginService(Class<T> serviceClass) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceConfig.java
@@ -112,26 +112,25 @@ public class ServiceConfig implements BaseConfig {
      * @return 是否开启了该服务
      */
     public boolean checkServiceEnable(String serviceName) {
-        if ("com.huaweicloud.sermant.implement.service.heartbeat.HeartbeatServiceImpl".equals(serviceName)) {
+        if (ServiceManager.HEARTBEAT_SERVICE_IMPL.equals(serviceName)) {
             return isHeartBeatEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.send.netty.NettyGatewayClient".equals(serviceName)) {
+        if (ServiceManager.NETTY_GATEWAY_CLIENT.equals(serviceName)) {
             return isGatewayEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.dynamicconfig.BufferedDynamicConfigService".equals(
-                serviceName)) {
+        if (ServiceManager.BUFFERED_DYNAMIC_CONFIG_SERVICE.equals(serviceName)) {
             return isDynamicConfigEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.tracing.TracingServiceImpl".equals(serviceName)) {
+        if (ServiceManager.TRACING_SERVICE_IMPL.equals(serviceName)) {
             return isTracingEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.visibility.VisibilityServiceImpl".equals(serviceName)) {
+        if (ServiceManager.VISIBILITY_SERVICE_IMPL.equals(serviceName)) {
             return isVisibilityEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.inject.InjectServiceImpl".equals(serviceName)) {
+        if (ServiceManager.INJECT_SERVICE_IMPL.equals(serviceName)) {
             return isInjectEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.monitor.RegistryServiceImpl".equals(serviceName)) {
+        if (ServiceManager.REGISTRY_SERVICE_IMPL.equals(serviceName)) {
             return isMonitorEnable();
         }
         return false;

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceManager.java
@@ -28,6 +28,7 @@ import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.event.EventManager;
 import com.huaweicloud.sermant.core.event.collector.FrameworkEventCollector;
 import com.huaweicloud.sermant.core.exception.DupServiceException;
+import com.huaweicloud.sermant.core.service.send.api.GatewayClient;
 import com.huaweicloud.sermant.core.utils.SpiLoadUtils;
 
 import java.util.ArrayList;
@@ -47,6 +48,48 @@ import java.util.logging.Logger;
  * @since 2021-10-26
  */
 public class ServiceManager {
+    /**
+     * 动态配置服务类名
+     */
+    public static final String BUFFERED_DYNAMIC_CONFIG_SERVICE = "com.huaweicloud.sermant"
+            + ".implement.service.dynamicconfig.BufferedDynamicConfigService";
+
+    /**
+     * 心跳服务类名
+     */
+    public static final String HEARTBEAT_SERVICE_IMPL = "com.huaweicloud.sermant.implement.service.heartbeat"
+            + ".HeartbeatServiceImpl";
+
+    /**
+     * 注入服务类名
+     */
+    public static final String INJECT_SERVICE_IMPL = "com.huaweicloud.sermant.implement.service.inject"
+            + ".InjectServiceImpl";
+
+    /**
+     * netty网关服务类名
+     */
+    public static final String NETTY_GATEWAY_CLIENT = "com.huaweicloud.sermant.implement.service.send.netty"
+            + ".NettyGatewayClient";
+
+    /**
+     * 注册信息服务类名
+     */
+    public static final String REGISTRY_SERVICE_IMPL = "com.huaweicloud.sermant.implement.service.monitor"
+            + ".RegistryServiceImpl";
+
+    /**
+     * 链路追踪服务类名
+     */
+    public static final String TRACING_SERVICE_IMPL = "com.huaweicloud.sermant.implement.service.tracing"
+            + ".TracingServiceImpl";
+
+    /**
+     * 服务可见性服务类名
+     */
+    public static final String VISIBILITY_SERVICE_IMPL = "com.huaweicloud.sermant.implement.service.visibility"
+            + ".VisibilityServiceImpl";
+
     /**
      * 日志
      */
@@ -141,17 +184,26 @@ public class ServiceManager {
      * 添加关闭服务的钩子
      */
     private static void addStopHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-            @Override
-            public void run() {
-                offerEvent();
-                for (BaseService baseService : new HashSet<>(SERVICES.values())) {
-                    try {
-                        baseService.stop();
-                    } catch (Exception ex) {
-                        LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH,
-                                "Error occurs while stopping service: %s", baseService.getClass().toString()), ex);
-                    }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            BaseService nettyGateWayClient = SERVICES.get(NETTY_GATEWAY_CLIENT);
+            SERVICES.remove(NETTY_GATEWAY_CLIENT);
+            SERVICES.remove(GatewayClient.class.getCanonicalName());
+            for (BaseService baseService : new HashSet<>(SERVICES.values())) {
+                try {
+                    baseService.stop();
+                } catch (Exception ex) {
+                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH,
+                            "Error occurs while stopping service: %s", baseService.getClass().toString()), ex);
+                }
+            }
+            offerEvent();
+            if (nettyGateWayClient != null) {
+                try {
+                    nettyGateWayClient.stop();
+                } catch (Exception ex) {
+                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH,
+                            "Error occurs while stopping service: %s",
+                            nettyGateWayClient.getClass().toString()), ex);
                 }
             }
         }));
@@ -159,9 +211,11 @@ public class ServiceManager {
 
     private static void offerEvent() {
         // 上报服务关闭事件
+        ArrayList<String> stopServiceArray = new ArrayList<>();
         for (BaseService baseService : new HashSet<>(SERVICES.values())) {
-            FrameworkEventCollector.getInstance().collectServiceStopEvent(baseService.getClass().getName());
+            stopServiceArray.add(baseService.getClass().getName());
         }
+        FrameworkEventCollector.getInstance().collectServiceStopEvent(stopServiceArray.toString());
 
         // 上报Sermant关闭的事件
         FrameworkEventCollector.getInstance().collectAgentStopEvent();

--- a/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
+++ b/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
@@ -518,7 +518,10 @@ const eventName = reactive({
   SAME_TAG_RULE_MATCH: "同标签优先规则匹配成功",
   SAME_TAG_RULE_MISMATCH: "同标签优先规则匹配失败",
   INSTANCE_REMOVAL: "实例摘除",
-  INSTANCE_RECOVERY: "实例恢复"
+  INSTANCE_RECOVERY: "实例恢复",
+  SPRINGBOOT_REGISTRY: "SpringBoot服务注册",
+  SPRINGBOOT_UNREGISTRY: "SpringBoot服务移除注册",
+  SPRINGBOOT_GRAY_CONFIG_TAKE_EFFECT: "SpringBoot注册插件灰度规则生效"
 });
 
 const displayState = reactive({

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/config/EffectStategyDynamicConfigListener.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/config/EffectStategyDynamicConfigListener.java
@@ -17,6 +17,7 @@
 package com.huawei.discovery.config;
 
 import com.huawei.discovery.entity.PlugEffectStrategyCache;
+import com.huawei.discovery.event.SpringBootRegistryEventCollector;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
@@ -43,6 +44,7 @@ public class EffectStategyDynamicConfigListener implements DynamicConfigListener
                 + "[%s], " + "content [%s] ",event.getKey(), event.getEventType(), event.getContent()));
         if (StringUtils.equalsIgnoreCase(PlugEffectWhiteBlackConstants.DYNAMIC_CONFIG_LISTENER_KEY, event.getKey())) {
             PlugEffectStrategyCache.INSTANCE.resolve(event.getEventType(), event.getContent());
+            SpringBootRegistryEventCollector.getInstance().collectGrayConfigTakeEffectEvent(event.getContent());
         }
     }
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/DefaultServiceInstance.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/entity/DefaultServiceInstance.java
@@ -131,4 +131,17 @@ public class DefaultServiceInstance extends HashedServiceInstance {
     public void setId(String id) {
         this.id = id;
     }
+
+    @Override
+    public String toString() {
+        return "{"
+                + "serviceName='" + serviceName + '\''
+                + ", host='" + host + '\''
+                + ", ip='" + ip + '\''
+                + ", port=" + port
+                + ", id='" + id + '\''
+                + ", metadata=" + metadata
+                + ", status='" + status + '\''
+                + '}';
+    }
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventCollector.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventCollector.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.discovery.event;
+
+import com.huawei.discovery.entity.DefaultServiceInstance;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.event.Event;
+import com.huaweicloud.sermant.core.event.EventCollector;
+import com.huaweicloud.sermant.core.event.EventInfo;
+import com.huaweicloud.sermant.core.event.EventManager;
+import com.huaweicloud.sermant.core.event.config.EventConfig;
+
+/**
+ * springboot注册插件事件采集器
+ *
+ * @author lilai
+ * @since 2023-04-14
+ */
+public class SpringBootRegistryEventCollector extends EventCollector {
+    private static volatile SpringBootRegistryEventCollector collector;
+
+    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
+
+    private SpringBootRegistryEventCollector() {
+    }
+
+    /**
+     * 获取springboot注册插件事件采集器单例
+     *
+     * @return springboot注册插件事件采集器单例
+     */
+    public static SpringBootRegistryEventCollector getInstance() {
+        if (collector == null) {
+            synchronized (SpringBootRegistryEventCollector.class) {
+                if (collector == null) {
+                    collector = new SpringBootRegistryEventCollector();
+                    EventManager.registerCollector(SpringBootRegistryEventCollector.getInstance());
+                }
+            }
+        }
+        return collector;
+    }
+
+    /**
+     * 采集服务注册事件
+     *
+     * @param instance 微服务实例
+     */
+    public void collectRegistryEvent(DefaultServiceInstance instance) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Service instance register:" + instance.toString();
+        offerEvent(new Event(SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getScope(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getEventLevel(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getEventType(),
+                new EventInfo(SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getName(), eventDescription)));
+    }
+
+    /**
+     * 采集服务移除注册事件
+     *
+     * @param instance 微服务实例
+     */
+    public void collectUnRegistryEvent(DefaultServiceInstance instance) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Service instance unregister:" + instance.toString();
+        offerEvent(new Event(SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getScope(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getEventLevel(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getEventType(),
+                new EventInfo(SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getName(), eventDescription)));
+    }
+
+    /**
+     * 采集灰度配置生效事件
+     *
+     * @param config 灰度配置
+     */
+    public void collectGrayConfigTakeEffectEvent(String config) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Gray config take effect:" + config;
+        offerEvent(new Event(SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_TAKE_EFFECT.getScope(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_TAKE_EFFECT.getEventLevel(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_TAKE_EFFECT.getEventType(),
+                new EventInfo(SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_TAKE_EFFECT.getName(),
+                        eventDescription)));
+    }
+}

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventDefinition.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventDefinition.java
@@ -14,34 +14,33 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.router.common.event;
+package com.huawei.discovery.event;
 
 import com.huaweicloud.sermant.core.event.EventLevel;
 import com.huaweicloud.sermant.core.event.EventType;
 
 /**
- * 路由插件事件定义
+ * Springboot注册插件事件定义
  *
  * @author lilai
- * @since 2023-03-28
+ * @since 2023-04-14
  */
-public enum RouterEventDefinition {
+public enum SpringBootRegistryEventDefinition {
     /**
-     * 路由插件规则生效事件
+     * SpringBoot服务注册事件
      */
-
-    ROUTER_RULE_TAKE_EFFECT("ROUTER_RULE_TAKE_EFFECT", EventType.OPERATION, EventLevel.NORMAL),
-
-    /**
-     * 同TAG优先规则匹配生效
-     */
-    SAME_TAG_RULE_MATCH("SAME_TAG_RULE_MATCH", EventType.GOVERNANCE, EventLevel.NORMAL),
+    SPRINGBOOT_REGISTRY("SPRINGBOOT_REGISTRY", EventType.GOVERNANCE, EventLevel.IMPORTANT),
 
     /**
-     * 同TAG优先规则匹配失效
+     * SpringBoot注册插件灰度配置生效事件
      */
-    SAME_TAG_RULE_MISMATCH("SAME_TAG_RULE_MISMATCH", EventType.GOVERNANCE,
-            EventLevel.NORMAL);
+    SPRINGBOOT_GRAY_CONFIG_TAKE_EFFECT("SPRINGBOOT_GRAY_CONFIG_TAKE_EFFECT", EventType.OPERATION, EventLevel.NORMAL),
+
+    /**
+     * SpringBoot服务移除注册事件
+     */
+    SPRINGBOOT_UNREGISTRY("SPRINGBOOT_UNREGISTRY", EventType.GOVERNANCE,
+            EventLevel.IMPORTANT);
 
     private final String name;
 
@@ -49,7 +48,7 @@ public enum RouterEventDefinition {
 
     private final EventLevel eventLevel;
 
-    RouterEventDefinition(String name, EventType eventType, EventLevel eventLevel) {
+    SpringBootRegistryEventDefinition(String name, EventType eventType, EventLevel eventLevel) {
         this.name = name;
         this.eventType = eventType;
         this.eventLevel = eventLevel;
@@ -68,6 +67,6 @@ public enum RouterEventDefinition {
     }
 
     public String getScope() {
-        return "router-plugin";
+        return "springboot-registry-plugin";
     }
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/SpringApplicationInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/SpringApplicationInterceptor.java
@@ -17,6 +17,7 @@
 package com.huawei.discovery.interceptors;
 
 import com.huawei.discovery.entity.RegisterContext;
+import com.huawei.discovery.event.SpringBootRegistryEventCollector;
 import com.huawei.discovery.service.ConfigCenterService;
 import com.huawei.discovery.service.RegistryService;
 
@@ -58,6 +59,8 @@ public class SpringApplicationInterceptor extends AbstractInterceptor {
         if ((logStartupInfo instanceof Boolean) && (Boolean) logStartupInfo && INIT.compareAndSet(false, true)) {
             registryService.registry(RegisterContext.INSTANCE.getServiceInstance());
             configCenterService.init(RegisterContext.INSTANCE.getServiceInstance().getServiceName());
+            SpringBootRegistryEventCollector.getInstance().collectRegistryEvent(RegisterContext.INSTANCE
+                    .getServiceInstance());
         }
         return context;
     }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/registry/RegistryImpl.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/registry/RegistryImpl.java
@@ -17,7 +17,9 @@
 package com.huawei.discovery.service.registry;
 
 import com.huawei.discovery.config.DiscoveryPluginConfig;
+import com.huawei.discovery.entity.RegisterContext;
 import com.huawei.discovery.entity.ServiceInstance;
+import com.huawei.discovery.event.SpringBootRegistryEventCollector;
 import com.huawei.discovery.service.RegistryService;
 import com.huawei.discovery.service.lb.DiscoveryManager;
 
@@ -71,6 +73,8 @@ public class RegistryImpl implements RegistryService {
                 LOGGER.log(Level.WARNING, "Stop lb service failed!", ex);
             } finally {
                 addStatusForHeartbeat();
+                SpringBootRegistryEventCollector.getInstance().collectUnRegistryEvent(RegisterContext.INSTANCE
+                        .getServiceInstance());
             }
         }
     }


### PR DESCRIPTION
【修复issue】#1205

【修改内容】
（1）添加springboot注册插件的注册事件，移除注册事件和灰度配置事件的上报
（2）新增插件服务的stop方法中添加的事件上报
（3）添加插件服务启动事件的上报

【用例描述】
测试过程：
（1）启动backend
（2）启用springboot注册插件来启动服务，并开启事件上报
（3）发布灰度配置
（4）关闭服务
（5）观察backend事件的上报
测试结果：
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/46025350/233236697-4f9a5a7b-b39f-4542-bc1e-8e95cd4b1109.png">


【自测情况】1、本地静态检查通过；2、本地测试通过

【影响范围】无