### PR TITLE
新增springboot注册插件事件上报&支持stop方法中上报事件

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
@@ -17,8 +17,11 @@
 package com.huaweicloud.sermant.core.plugin.service;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.event.collector.FrameworkEventCollector;
 import com.huaweicloud.sermant.core.service.ServiceManager;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -44,23 +47,27 @@ public class PluginServiceManager extends ServiceManager {
      * @param classLoader 插件服务包的ClassLoader
      */
     public static void initPluginService(ClassLoader classLoader) {
+        List<String> startServiceList = new ArrayList<>();
         for (PluginService service : ServiceLoader.load(PluginService.class, classLoader)) {
             if (loadService(service, service.getClass(), PluginService.class)) {
                 try {
                     service.start();
+                    startServiceList.add(service.getClass().getName());
                 } catch (Exception ex) {
-                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "Error occurs while starting plugin service: %s",
+                    LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH,
+                            "Error occurs while starting plugin service: %s",
                             service.getClass()), ex);
                 }
             }
         }
+        FrameworkEventCollector.getInstance().collectServiceStartEvent(startServiceList.toString());
     }
 
     /**
      * 获取插件服务
      *
      * @param serviceClass 插件服务类
-     * @param <T>          插件服务类型
+     * @param <T> 插件服务类型
      * @return 插件服务实例
      */
     public static <T extends PluginService> T getPluginService(Class<T> serviceClass) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceConfig.java
@@ -101,23 +101,22 @@ public class ServiceConfig implements BaseConfig {
      * @return 是否开启了该服务
      */
     public boolean checkServiceEnable(String serviceName) {
-        if ("com.huaweicloud.sermant.implement.service.heartbeat.HeartbeatServiceImpl".equals(serviceName)) {
+        if (ServiceManager.HEARTBEAT_SERVICE_IMPL.equals(serviceName)) {
             return isHeartBeatEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.send.netty.NettyGatewayClient".equals(serviceName)) {
+        if (ServiceManager.NETTY_GATEWAY_CLIENT.equals(serviceName)) {
             return isGatewayEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.dynamicconfig.BufferedDynamicConfigService".equals(
-                serviceName)) {
+        if (ServiceManager.BUFFERED_DYNAMIC_CONFIG_SERVICE.equals(serviceName)) {
             return isDynamicConfigEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.tracing.TracingServiceImpl".equals(serviceName)) {
+        if (ServiceManager.TRACING_SERVICE_IMPL.equals(serviceName)) {
             return isTracingEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.visibility.VisibilityServiceImpl".equals(serviceName)) {
+        if (ServiceManager.VISIBILITY_SERVICE_IMPL.equals(serviceName)) {
             return isVisibilityEnable();
         }
-        if ("com.huaweicloud.sermant.implement.service.inject.InjectServiceImpl".equals(serviceName)) {
+        if (ServiceManager.INJECT_SERVICE_IMPL.equals(serviceName)) {
             return isInjectEnable();
         }
         return false;

--- a/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
+++ b/sermant-backend/src/main/webapp/frontend/src/views/EventsView.vue
@@ -514,11 +514,14 @@ const eventName = reactive({
   GRACEFUL_OFFLINE_BEGIN: "无损下线开始",
   GRACEFUL_OFFLINE_END: "无损下线结束",
   // 路由插件事件
-  ROUTER_RULE_TAKE_EFFECT: "路由插件规则生效",
+  ROUTER_RULE_REFRESH: "路由插件规则刷新",
   SAME_TAG_RULE_MATCH: "同标签优先规则匹配成功",
   SAME_TAG_RULE_MISMATCH: "同标签优先规则匹配失败",
   INSTANCE_REMOVAL: "实例摘除",
-  INSTANCE_RECOVERY: "实例恢复"
+  INSTANCE_RECOVERY: "实例恢复",
+  SPRINGBOOT_REGISTRY: "SpringBoot服务注册",
+  SPRINGBOOT_UNREGISTRY: "SpringBoot服务移除注册",
+  SPRINGBOOT_GRAY_CONFIG_REFRESH: "SpringBoot注册插件灰度规则刷新"
 });
 
 const displayState = reactive({

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventCollector.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/event/RouterEventCollector.java
@@ -64,10 +64,10 @@ public class RouterEventCollector extends EventCollector {
             return;
         }
         String eventDescription = "Service router rule refresh:" + System.lineSeparator() + rule;
-        offerEvent(new Event(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getScope(),
-                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventLevel(),
-                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventType(),
-                new EventInfo(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getName(), eventDescription)));
+        offerEvent(new Event(RouterEventDefinition.ROUTER_RULE_REFRESH.getScope(),
+                RouterEventDefinition.ROUTER_RULE_REFRESH.getEventLevel(),
+                RouterEventDefinition.ROUTER_RULE_REFRESH.getEventType(),
+                new EventInfo(RouterEventDefinition.ROUTER_RULE_REFRESH.getName(), eventDescription)));
     }
 
     /**
@@ -80,10 +80,10 @@ public class RouterEventCollector extends EventCollector {
             return;
         }
         String eventDescription = "Global router rule refresh:" + System.lineSeparator() + rule;
-        offerEvent(new Event(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getScope(),
-                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventLevel(),
-                RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getEventType(),
-                new EventInfo(RouterEventDefinition.ROUTER_RULE_TAKE_EFFECT.getName(), eventDescription)));
+        offerEvent(new Event(RouterEventDefinition.ROUTER_RULE_REFRESH.getScope(),
+                RouterEventDefinition.ROUTER_RULE_REFRESH.getEventLevel(),
+                RouterEventDefinition.ROUTER_RULE_REFRESH.getEventType(),
+                new EventInfo(RouterEventDefinition.ROUTER_RULE_REFRESH.getName(), eventDescription)));
     }
 
     /**

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/config/EffectStategyDynamicConfigListener.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/config/EffectStategyDynamicConfigListener.java
@@ -17,6 +17,7 @@
 package com.huawei.discovery.config;
 
 import com.huawei.discovery.entity.PlugEffectStrategyCache;
+import com.huawei.discovery.event.SpringBootRegistryEventCollector;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
@@ -43,6 +44,7 @@ public class EffectStategyDynamicConfigListener implements DynamicConfigListener
                 + "[%s], " + "content [%s] ",event.getKey(), event.getEventType(), event.getContent()));
         if (StringUtils.equalsIgnoreCase(PlugEffectWhiteBlackConstants.DYNAMIC_CONFIG_LISTENER_KEY, event.getKey())) {
             PlugEffectStrategyCache.INSTANCE.resolve(event.getEventType(), event.getContent());
+            SpringBootRegistryEventCollector.getInstance().collectGrayConfigRefreshEvent(event.getContent());
         }
     }
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventCollector.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventCollector.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.discovery.event;
+
+import com.huawei.discovery.entity.DefaultServiceInstance;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.event.Event;
+import com.huaweicloud.sermant.core.event.EventCollector;
+import com.huaweicloud.sermant.core.event.EventInfo;
+import com.huaweicloud.sermant.core.event.EventManager;
+import com.huaweicloud.sermant.core.event.config.EventConfig;
+
+/**
+ * springboot注册插件事件采集器
+ *
+ * @author lilai
+ * @since 2023-04-14
+ */
+public class SpringBootRegistryEventCollector extends EventCollector {
+    private static volatile SpringBootRegistryEventCollector collector;
+
+    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
+
+    private SpringBootRegistryEventCollector() {
+    }
+
+    /**
+     * 获取springboot注册插件事件采集器单例
+     *
+     * @return springboot注册插件事件采集器单例
+     */
+    public static SpringBootRegistryEventCollector getInstance() {
+        if (collector == null) {
+            synchronized (SpringBootRegistryEventCollector.class) {
+                if (collector == null) {
+                    collector = new SpringBootRegistryEventCollector();
+                    EventManager.registerCollector(SpringBootRegistryEventCollector.getInstance());
+                }
+            }
+        }
+        return collector;
+    }
+
+    /**
+     * 采集服务注册事件
+     *
+     * @param instance 微服务实例
+     */
+    public void collectRegistryEvent(DefaultServiceInstance instance) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Service instance register:" + instance.toString();
+        offerEvent(new Event(SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getScope(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getEventLevel(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getEventType(),
+                new EventInfo(SpringBootRegistryEventDefinition.SPRINGBOOT_REGISTRY.getName(), eventDescription)));
+    }
+
+    /**
+     * 采集服务移除注册事件
+     *
+     * @param instance 微服务实例
+     */
+    public void collectUnRegistryEvent(DefaultServiceInstance instance) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Service instance unregister:" + instance.toString();
+        offerEvent(new Event(SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getScope(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getEventLevel(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getEventType(),
+                new EventInfo(SpringBootRegistryEventDefinition.SPRINGBOOT_UNREGISTRY.getName(), eventDescription)));
+    }
+
+    /**
+     * 采集灰度配置刷新事件
+     *
+     * @param config 灰度配置
+     */
+    public void collectGrayConfigRefreshEvent(String config) {
+        if (!eventConfig.isEnable()) {
+            return;
+        }
+        String eventDescription = "Gray config refresh:" + config;
+        offerEvent(new Event(SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_REFRESH.getScope(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_REFRESH.getEventLevel(),
+                SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_REFRESH.getEventType(),
+                new EventInfo(SpringBootRegistryEventDefinition.SPRINGBOOT_GRAY_CONFIG_REFRESH.getName(),
+                        eventDescription)));
+    }
+}

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventDefinition.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventDefinition.java
@@ -14,34 +14,33 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.router.common.event;
+package com.huawei.discovery.event;
 
 import com.huaweicloud.sermant.core.event.EventLevel;
 import com.huaweicloud.sermant.core.event.EventType;
 
 /**
- * 路由插件事件定义
+ * Springboot注册插件事件定义
  *
  * @author lilai
- * @since 2023-03-28
+ * @since 2023-04-14
  */
-public enum RouterEventDefinition {
+public enum SpringBootRegistryEventDefinition {
     /**
-     * 路由插件规则刷新事件
+     * SpringBoot服务注册事件
      */
-
-    ROUTER_RULE_REFRESH("ROUTER_RULE_REFRESH", EventType.OPERATION, EventLevel.NORMAL),
-
-    /**
-     * 同TAG优先规则匹配生效
-     */
-    SAME_TAG_RULE_MATCH("SAME_TAG_RULE_MATCH", EventType.GOVERNANCE, EventLevel.NORMAL),
+    SPRINGBOOT_REGISTRY("SPRINGBOOT_REGISTRY", EventType.GOVERNANCE, EventLevel.IMPORTANT),
 
     /**
-     * 同TAG优先规则匹配失效
+     * SpringBoot注册插件灰度配置刷新事件
      */
-    SAME_TAG_RULE_MISMATCH("SAME_TAG_RULE_MISMATCH", EventType.GOVERNANCE,
-            EventLevel.NORMAL);
+    SPRINGBOOT_GRAY_CONFIG_REFRESH("SPRINGBOOT_GRAY_CONFIG_REFRESH", EventType.OPERATION, EventLevel.NORMAL),
+
+    /**
+     * SpringBoot服务移除注册事件
+     */
+    SPRINGBOOT_UNREGISTRY("SPRINGBOOT_UNREGISTRY", EventType.GOVERNANCE,
+            EventLevel.IMPORTANT);
 
     private final String name;
 
@@ -49,7 +48,7 @@ public enum RouterEventDefinition {
 
     private final EventLevel eventLevel;
 
-    RouterEventDefinition(String name, EventType eventType, EventLevel eventLevel) {
+    SpringBootRegistryEventDefinition(String name, EventType eventType, EventLevel eventLevel) {
         this.name = name;
         this.eventType = eventType;
         this.eventLevel = eventLevel;
@@ -68,6 +67,6 @@ public enum RouterEventDefinition {
     }
 
     public String getScope() {
-        return "router-plugin";
+        return "springboot-registry-plugin";
     }
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/SpringApplicationInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/SpringApplicationInterceptor.java
@@ -17,6 +17,7 @@
 package com.huawei.discovery.interceptors;
 
 import com.huawei.discovery.entity.RegisterContext;
+import com.huawei.discovery.event.SpringBootRegistryEventCollector;
 import com.huawei.discovery.service.ConfigCenterService;
 import com.huawei.discovery.service.RegistryService;
 
@@ -58,6 +59,8 @@ public class SpringApplicationInterceptor extends AbstractInterceptor {
         if ((logStartupInfo instanceof Boolean) && (Boolean) logStartupInfo && INIT.compareAndSet(false, true)) {
             registryService.registry(RegisterContext.INSTANCE.getServiceInstance());
             configCenterService.init(RegisterContext.INSTANCE.getServiceInstance().getServiceName());
+            SpringBootRegistryEventCollector.getInstance().collectRegistryEvent(RegisterContext.INSTANCE
+                    .getServiceInstance());
         }
         return context;
     }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/registry/RegistryImpl.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/registry/RegistryImpl.java
@@ -17,7 +17,9 @@
 package com.huawei.discovery.service.registry;
 
 import com.huawei.discovery.config.DiscoveryPluginConfig;
+import com.huawei.discovery.entity.RegisterContext;
 import com.huawei.discovery.entity.ServiceInstance;
+import com.huawei.discovery.event.SpringBootRegistryEventCollector;
 import com.huawei.discovery.service.RegistryService;
 import com.huawei.discovery.service.lb.DiscoveryManager;
 
@@ -71,6 +73,8 @@ public class RegistryImpl implements RegistryService {
                 LOGGER.log(Level.WARNING, "Stop lb service failed!", ex);
             } finally {
                 addStatusForHeartbeat();
+                SpringBootRegistryEventCollector.getInstance().collectUnRegistryEvent(RegisterContext.INSTANCE
+                        .getServiceInstance());
             }
         }
     }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/test/java/com/huawei/discovery/service/lb/rule/BaseTest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/test/java/com/huawei/discovery/service/lb/rule/BaseTest.java
@@ -21,6 +21,7 @@ import com.huawei.discovery.config.LbConfig;
 import com.huawei.discovery.service.lb.discovery.zk.ZkClient;
 import com.huawei.discovery.service.lb.utils.CommonUtils;
 
+import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
@@ -48,6 +49,8 @@ public class BaseTest {
 
     protected MockedStatic<PluginConfigManager> pluginConfigManagerMockedStatic;
 
+    protected MockedStatic<ConfigManager> configManagerMockedStatic;
+
     @Before
     public void setUp() {
         pluginConfigManagerMockedStatic = Mockito
@@ -58,6 +61,7 @@ public class BaseTest {
                 .thenReturn(new DiscoveryPluginConfig());
         pluginServiceManagerMockedStatic = Mockito
                 .mockStatic(PluginServiceManager.class);
+        configManagerMockedStatic = Mockito.mockStatic(ConfigManager.class);
     }
 
     @After
@@ -65,6 +69,7 @@ public class BaseTest {
         CommonUtils.cleanServiceStats();
         pluginConfigManagerMockedStatic.close();
         pluginServiceManagerMockedStatic.close();
+        configManagerMockedStatic.close();
     }
 
     /**

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/test/java/com/huawei/discovery/service/registry/RegistryImplTest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/test/java/com/huawei/discovery/service/registry/RegistryImplTest.java
@@ -23,6 +23,8 @@ import com.huawei.discovery.service.lb.discovery.zk.ZkService34;
 import com.huawei.discovery.service.lb.rule.BaseTest;
 import com.huawei.discovery.service.lb.utils.CommonUtils;
 
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.event.config.EventConfig;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
 
@@ -53,6 +55,8 @@ public class RegistryImplTest extends BaseTest {
         MockitoAnnotations.openMocks(this);
         pluginServiceManagerMockedStatic.when(() -> PluginServiceManager.getPluginService(ZkService34.class))
                 .thenReturn(zkService34);
+        configManagerMockedStatic.when(() -> ConfigManager.getConfig(EventConfig.class))
+                .thenReturn(new EventConfig());
         start();
     }
 


### PR DESCRIPTION
【修复issue】#1205

【修改内容】
（1）添加springboot注册插件的注册事件，移除注册事件和灰度配置事件的上报
（2）新增插件服务的stop方法中添加的事件上报
（3）添加插件服务启动事件的上报

【用例描述】
测试过程：
（1）启动backend
（2）启用springboot注册插件来启动服务，并开启事件上报
（3）发布灰度配置
（4）关闭服务
（5）观察backend事件的上报
测试结果：
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/46025350/233236697-4f9a5a7b-b39f-4542-bc1e-8e95cd4b1109.png">


【自测情况】1、本地静态检查通过；2、本地测试通过

【影响范围】无