### PR TITLE
修改动态配置UT失败问题

### DIFF
--- a/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/SpringEventPublisherTest.java
+++ b/sermant-plugins/sermant-dynamic-config/dynamic-config-plugin/src/test/java/com/huawei/dynamic/config/source/SpringEventPublisherTest.java
@@ -20,10 +20,15 @@ package com.huawei.dynamic.config.source;
 import com.huawei.dynamic.config.DynamicConfiguration;
 import com.huawei.dynamic.config.RefreshNotifier;
 
+import com.huaweicloud.sermant.core.operation.OperationManager;
+import com.huaweicloud.sermant.core.operation.converter.api.YamlConverter;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.implement.operation.converter.YamlConverterImpl;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -41,6 +46,14 @@ public class SpringEventPublisherTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
+    private MockedStatic<OperationManager> operationManagerMockedStatic;
+
+    @Before
+    public void setUp() {
+        operationManagerMockedStatic = Mockito.mockStatic(OperationManager.class);
+        operationManagerMockedStatic.when(() -> OperationManager.getOperation(YamlConverter.class)).thenReturn(new YamlConverterImpl());
+    }
+
     @Test
     public void test() {
         MockitoAnnotations.openMocks(this);
@@ -57,5 +70,10 @@ public class SpringEventPublisherTest {
             Mockito.verify(applicationEventPublisher, Mockito.times(1)).publishEvent(Mockito.any());
             originConfigCenterDisableListenerTest.getListeners().clear();
         }
+    }
+
+    @After
+    public void tearDown() {
+        operationManagerMockedStatic.close();
     }
 }

--- a/sermant-plugins/sermant-service-removal/removal-service/src/test/java/com/huaweicloud/sermant/service/RequestDataCountTaskTest.java
+++ b/sermant-plugins/sermant-service-removal/removal-service/src/test/java/com/huaweicloud/sermant/service/RequestDataCountTaskTest.java
@@ -21,6 +21,7 @@ import com.huaweicloud.sermant.config.RemovalConfig;
 import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.service.ServiceManager;
 import com.huaweicloud.sermant.entity.InstanceInfo;
+import com.huaweicloud.sermant.entity.RequestCountData;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -28,6 +29,7 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Iterator;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -84,10 +86,12 @@ public class RequestDataCountTaskTest {
         Thread.sleep(15000);
         InstanceInfo info = InstanceCache.INSTANCE_MAP.get(KEY);
         Assert.assertTrue(info != null && info.getCountDataList().size() > 0);
-        info.getCountDataList().forEach(requestCountData -> {
+        Iterator<RequestCountData> requestCountDataIterator = info.getCountDataList().iterator();
+        while (requestCountDataIterator.hasNext()) {
+            RequestCountData requestCountData = requestCountDataIterator.next();
             Assert.assertEquals(REQ_NUM, requestCountData.getRequestNum());
             Assert.assertEquals(REQ_FAIL_NUM, requestCountData.getRequestFailNum());
-        });
+        }
     }
 
     @AfterClass


### PR DESCRIPTION
【修复issue】#1229

【修改内容】1、修改动态配置UT

【用例描述】
1、修改动态配置插件的UT实例化失败的问题
2、修改离群集成插件的UT出现统计数据遍历失败的情况。

【自测情况】1、本地自测通过

【影响范围】1、对用户的使用没有影响（