### PR TITLE
流量标签透传特性：支持httpclient4.x

### DIFF
--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -38,9 +38,9 @@ jobs:
           sh apache-servicecomb-service-center-2.1.0-linux-amd64/start-service-center.sh
       - name: download zookeeper
         run: |
-          curl -o apache-zookeeper-3.8.0-bin.tar.gz -L https://dlcdn.apache.org/zookeeper/zookeeper-3.8.0/apache-zookeeper-3.8.0-bin.tar.gz
-          tar -zxf apache-zookeeper-3.8.0-bin.tar.gz
-          bash apache-zookeeper-3.8.0-bin/bin/zkServer.sh start apache-zookeeper-3.8.0-bin/conf/zoo_sample.cfg
+          curl -o apache-zookeeper-3.6.3-bin.tar.gz -L https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
+          tar -zxf apache-zookeeper-3.6.3-bin.tar.gz
+          bash apache-zookeeper-3.6.3-bin/bin/zkServer.sh start apache-zookeeper-3.6.3-bin/conf/zoo_sample.cfg
       - name: Build with Maven
         run: mvn test
       - name: Generate code coverage report

--- a/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
@@ -10,6 +10,7 @@ plugins:
   - mq-consume-deny
   - service-removal
   - service-visibility
+  - tag-transmission
 profiles:
   cse:
     - flowcontrol

--- a/sermant-agentcore/sermant-agentcore-config/config/test/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/plugins.yaml
@@ -10,6 +10,7 @@ plugins:
   - mq-consume-deny
   - service-removal
   - service-visibility
+  - tag-transmission
 profiles:
   cse:
     - flowcontrol

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/CollectionUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/CollectionUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR C¬ONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.utils;
+
+import java.util.Collection;
+
+/**
+ * 集合工具类
+ *
+ * @author lilai
+ * @since 2023-07-17
+ */
+public class CollectionUtils {
+    private CollectionUtils() {
+    }
+
+    /**
+     * 判断集合是否为null或没有元素
+     *
+     * @param collection 集合
+     * @return 是否为空
+     */
+    public static boolean isEmpty(Collection<?> collection) {
+        return collection == null || collection.isEmpty();
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/MapUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/MapUtils.java
@@ -60,4 +60,14 @@ public class MapUtils {
             }
         }
     }
+
+    /**
+     * 判断Map是否为null或没有键值对
+     *
+     * @param map map
+     * @return 是否为空
+     */
+    public static boolean isEmpty(Map<?, ?> map) {
+        return map == null || map.isEmpty();
+    }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficTag.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficTag.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR C¬ONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.utils.tag;
+
+import com.huaweicloud.sermant.core.utils.MapUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 流量标签
+ *
+ * @author lilai
+ * @since 2023-07-17
+ */
+public class TrafficTag {
+    private final Map<String, List<String>> tag;
+
+    /**
+     * 构造方法
+     *
+     * @param tag 流量标签 http请求的header/dubbo请求的attachment/消息队列header或properties
+     */
+    public TrafficTag(Map<String, List<String>> tag) {
+        this.tag = MapUtils.isEmpty(tag) ? new HashMap<>() : tag;
+    }
+
+    public Map<String, List<String>> getTag() {
+        return tag;
+    }
+
+    /**
+     * 更新流量标签
+     *
+     * @param map 流量标签
+     */
+    public void updateTag(Map<String, List<String>> map) {
+        this.tag.putAll(map);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR C¬ONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.utils.tag;
+
+import com.huaweicloud.sermant.core.utils.MapUtils;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 流量中包含的请求信息
+ *
+ * @author lilai
+ * @since 2023-07-17
+ */
+public class TrafficUtils {
+    private static final ThreadLocal<TrafficTag> TAG = new ThreadLocal<>();
+
+    private TrafficUtils() {
+    }
+
+    /**
+     * 获取线程中的流量标签
+     *
+     * @return 流量标签
+     */
+    public static TrafficTag getTrafficTag() {
+        return TAG.get();
+    }
+
+    /**
+     * 更新线程中的流量标签
+     *
+     * @param tag 流量标签map
+     */
+    public static void updateTrafficTag(Map<String, List<String>> tag) {
+        if (MapUtils.isEmpty(tag)) {
+            return;
+        }
+        TrafficTag trafficTag = TAG.get();
+        if (trafficTag == null) {
+            TAG.set(new TrafficTag(tag));
+            return;
+        }
+        trafficTag.updateTag(tag);
+    }
+
+    /**
+     * 重设线程中的流量标签
+     *
+     * @param trafficTag 流量标签
+     */
+    public static void setTrafficTag(TrafficTag trafficTag) {
+        if (trafficTag == null) {
+            return;
+        }
+        TAG.set(trafficTag);
+    }
+
+    /**
+     * 删除线程变量
+     */
+    public static void removeTrafficTag() {
+        TAG.remove();
+    }
+}

--- a/sermant-common/src/main/java/com/huaweicloud/common/Application.java
+++ b/sermant-common/src/main/java/com/huaweicloud/common/Application.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.huawei.common;
+package com.huaweicloud.common;
 
 /**
  * JavaDoc启动类

--- a/sermant-plugins/pom.xml
+++ b/sermant-plugins/pom.xml
@@ -41,6 +41,7 @@
                 <module>sermant-service-visibility</module>
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
+                <module>sermant-tag-transmission</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -72,6 +73,7 @@
                 <module>sermant-service-visibility</module>
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
+                <module>sermant-tag-transmission</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -103,6 +105,7 @@
                 <module>sermant-service-visibility</module>
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
+                <module>sermant-tag-transmission</module>
             </modules>
         </profile>
     </profiles>

--- a/sermant-plugins/sermant-tag-transmission/config/config.yaml
+++ b/sermant-plugins/sermant-tag-transmission/config/config.yaml
@@ -1,0 +1,3 @@
+tag.transmission.plugin:
+  enabled: true
+  tagKeys: [id,name]

--- a/sermant-plugins/sermant-tag-transmission/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-plugins</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sermant-tag-transmission</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>tag-transmission-plugin</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <sermant.basedir>${pom.basedir}/../../..</sermant.basedir>
+        <package.plugin.name>tag-transmission</package.plugin.name>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>agent</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>tag-transmission-plugin</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>test</id>
+            <modules>
+                <module>tag-transmission-plugin</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>release</id>
+            <modules>
+                <module>tag-transmission-plugin</module>
+            </modules>
+        </profile>
+    </profiles>
+
+</project>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-tag-transmission</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>tag-transmission-plugin</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>plugin</package.plugin.type>
+        <apache-httpclient.version>4.3</apache-httpclient.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${apache-httpclient.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.config;
+
+import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 流量标签透传插件配置
+ *
+ * @author lilai
+ * @since 2023-07-17
+ */
+@ConfigTypeKey("tag.transmission.plugin")
+public class TagTransmissionConfig implements PluginConfig {
+    /**
+     * 是否开启适配
+     */
+    private boolean enabled;
+
+    /**
+     * 需要透传的标签的key
+     */
+    private List<String> tagKeys = new ArrayList<>();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public List<String> getTagKeys() {
+        return tagKeys;
+    }
+
+    public void setTagKeys(List<String> tagKeys) {
+        this.tagKeys = tagKeys;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/HttpClient4xDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/HttpClient4xDeclarer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.HttpClient4xInterceptor;
+
+/**
+ * HttpClient 流量标签透传的增强声明, 仅针对4.x版本
+ *
+ * @author lilai
+ * @since 2023-07-17
+ */
+public class HttpClient4xDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名 http请求
+     */
+    private static final String[] ENHANCE_CLASSES = {
+            "org.apache.http.impl.client.AbstractHttpClient",
+            "org.apache.http.impl.client.DefaultRequestDirector",
+            "org.apache.http.impl.client.InternalHttpClient",
+            "org.apache.http.impl.client.MinimalHttpClient"
+    };
+
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = HttpClient4xInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameContains(ENHANCE_CLASSES);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameContains("doExecute", "execute")
+                                .and(MethodMatcher.paramTypesEqual(
+                                        "org.apache.http.HttpHost",
+                                        "org.apache.http.HttpRequest",
+                                        "org.apache.http.protocol.HttpContext")),
+                        INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpClient4xInterceptor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
+
+import org.apache.http.HttpRequest;
+
+import java.util.List;
+
+/**
+ * HttpClient 流量标签透传的拦截器, 仅针对4.x版本
+ *
+ * @author lilai
+ * @since 2023-07-17
+ */
+public class HttpClient4xInterceptor extends AbstractInterceptor {
+    private final TagTransmissionConfig tagTransmissionConfig;
+
+    /**
+     * 构造器
+     */
+    public HttpClient4xInterceptor() {
+        tagTransmissionConfig = PluginConfigManager.getPluginConfig(TagTransmissionConfig.class);
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        if (!tagTransmissionConfig.isEnabled()) {
+            return context;
+        }
+
+        TrafficTag trafficTag = TrafficUtils.getTrafficTag();
+        if (trafficTag == null) {
+            return context;
+        }
+
+        Object httpRequestObject = context.getArguments()[1];
+        if (httpRequestObject instanceof HttpRequest) {
+            final HttpRequest httpRequest = (HttpRequest) httpRequestObject;
+            for (String key : tagTransmissionConfig.getTagKeys()) {
+                List<String> values = trafficTag.getTag().get(key);
+                if (CollectionUtils.isEmpty(values)) {
+                    continue;
+                }
+                for (String value : values) {
+                    httpRequest.addHeader(key, value);
+                }
+            }
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+com.huaweicloud.sermant.tag.transmission.declarers.HttpClient4xDeclarer
+

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig


### PR DESCRIPTION
【修复issue】#1244

【修改内容】

1、新增流量标签透传插件
2、支持httpclient4.x客户端的流量标签透传

【用例描述】后续补充测试用例

【自测情况】1、本地静态检查通过；2、本地自测通过

【影响范围】无

