### PR TITLE
流量标签透传特性：支持rocketMQ4.8+，支持webServlet3.0+

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -17,6 +17,8 @@
         <config.skip.flag>false</config.skip.flag>
         <package.plugin.type>plugin</package.plugin.type>
         <apache-httpclient.version>4.3</apache-httpclient.version>
+        <rocketmq-client.version>4.8.0</rocketmq-client.version>
+        <javax-servlet-api.version>3.0.1</javax-servlet-api.version>
     </properties>
 
     <dependencies>
@@ -34,6 +36,18 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${apache-httpclient.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${javax-servlet-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-client</artifactId>
+            <version>${rocketmq-client.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/HttpServletDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/HttpServletDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.HttpServletInterceptor;
+
+/**
+ * HttpServlet 流量标签透传的增强声明,支持sevlet3.0+
+ *
+ * @author tangle
+ * @since 2023-07-18
+ */
+public class HttpServletDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS = "javax.servlet.http.HttpServlet";
+
+    private static final String INTERCEPT_CLASS = HttpServletInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "service";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isExtendedFrom(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/RocketmqConsumerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/RocketmqConsumerDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.RocketmqConsumerInterceptor;
+
+/**
+ * RocketMQ流量标签透传的消费者增强声明，支持RocketMQ4.8+
+ *
+ * @author tangle
+ * @since 2023-07-19
+ */
+public class RocketmqConsumerDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS = "org.apache.rocketmq.common.message.Message";
+
+    private static final String INTERCEPT_CLASS = RocketmqConsumerInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "getBody";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/RocketmqProducerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/RocketmqProducerDeclarer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.RocketmqProducerInterceptor;
+
+/**
+ * RocketMQ流量标签透传的生产者增强声明，支持RocketMQ4.8+
+ *
+ * @author tangle
+ * @since 2023-07-20
+ */
+public class RocketmqProducerDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS = "org.apache.rocketmq.client.impl.MQClientAPIImpl";
+
+    private static final String INTERCEPT_CLASS = RocketmqProducerInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "sendMessage";
+
+    private static final int PARAM_INDEX = 12;
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME)
+                        .and(MethodMatcher.paramCountEquals(PARAM_INDEX)), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpServletInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpServletInterceptor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * HttpServlet 流量标签透传的拦截器,支持servlet3.0+
+ *
+ * @author tangle
+ * @since 2023-07-18
+ */
+public class HttpServletInterceptor extends AbstractInterceptor {
+    /**
+     * 过滤一次处理过程中拦截器的多次调用
+     */
+    private static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
+
+    private final TagTransmissionConfig tagTransmissionConfig;
+
+    /**
+     * 构造器
+     */
+    public HttpServletInterceptor() {
+        tagTransmissionConfig = PluginConfigManager.getPluginConfig(TagTransmissionConfig.class);
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        if (!tagTransmissionConfig.isEnabled() || LOCK_MARK.get() != null) {
+            return context;
+        }
+        LOCK_MARK.set(Boolean.TRUE);
+
+        Object httpServletRequestObject = context.getArguments()[0];
+        if (httpServletRequestObject instanceof HttpServletRequest) {
+            HttpServletRequest httpServletRequest = (HttpServletRequest) httpServletRequestObject;
+            Map<String, List<String>> tag = new HashMap<>();
+            for (String key : tagTransmissionConfig.getTagKeys()) {
+                Enumeration<String> valuesEnumeration = httpServletRequest.getHeaders(key);
+                if (valuesEnumeration.hasMoreElements()) {
+                    List<String> values = Collections.list(valuesEnumeration);
+                    tag.put(key, values);
+                }
+            }
+            if (!tag.isEmpty()) {
+                TrafficUtils.updateTrafficTag(tag);
+            }
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        LOCK_MARK.remove();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        LOCK_MARK.remove();
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqConsumerInterceptor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
+
+import org.apache.rocketmq.common.message.Message;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RocketMQ流量标签透传的消费者拦截器，支持RocketMQ4.8+
+ *
+ * @author tangle
+ * @since 2023-07-19
+ */
+public class RocketmqConsumerInterceptor extends AbstractInterceptor {
+    /**
+     * getBody拦截方法的所在类名
+     */
+    private static final String ROCKETMQ_SELECT_CLASSNAME = "org.apache.rocketmq.common.message.Message";
+
+    /**
+     * getBody拦截方法应被过滤的前缀
+     */
+    private static final String ROCKETMQ_FILER_PREFIX = "org.apache.rocketmq";
+
+    private final TagTransmissionConfig tagTransmissionConfig;
+
+    /**
+     * 构造器
+     */
+    public RocketmqConsumerInterceptor() {
+        tagTransmissionConfig = PluginConfigManager.getPluginConfig(TagTransmissionConfig.class);
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        if (!tagTransmissionConfig.isEnabled()) {
+            return context;
+        }
+        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+        int stackTraceIdxMax = stackTraceElements.length - 1;
+        for (int i = 0; i < stackTraceElements.length; i++) {
+            if (!ROCKETMQ_SELECT_CLASSNAME.equals(stackTraceElements[i].getClassName())) {
+                continue;
+            }
+            if (i == stackTraceIdxMax || stackTraceElements[i + 1].getClassName()
+                    .startsWith(ROCKETMQ_FILER_PREFIX)) {
+                return context;
+            }
+        }
+        if (context.getObject() instanceof Message) {
+            Message message = (Message) context.getObject();
+            Map<String, List<String>> tag = this.getTagFromMessage(message);
+            TrafficUtils.updateTrafficTag(tag);
+        }
+        return context;
+    }
+
+    /**
+     * 获取message中的流量标签
+     *
+     * @param message 原始properties
+     * @return Map
+     */
+    private Map<String, List<String>> getTagFromMessage(Message message) {
+        Map<String, List<String>> tag = new HashMap<>();
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            String value = message.getProperty(key);
+            if (value != null) {
+                tag.put(key, Collections.singletonList(value));
+            } else {
+                tag.put(key, null);
+            }
+        }
+        return tag;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqProducerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqProducerInterceptor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
+
+import org.apache.rocketmq.common.protocol.header.SendMessageRequestHeader;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RocketMQ流量标签透传的生产者拦截器，支持RocketMQ4.8+
+ *
+ * @author tangle
+ * @since 2023-07-20
+ */
+public class RocketmqProducerInterceptor extends AbstractInterceptor {
+    /**
+     * SendMessageRequestHeader在sendMessage方法中的参数下标
+     */
+    private static final int ARGUMENT_INDEX = 3;
+
+    /**
+     * SendMessageRequestHeader的Properties中键值对的连接符（ASCII值为1）
+     */
+    private static final char LINK_MARK = 1;
+
+    /**
+     * SendMessageRequestHeader的Properties中键值对的分隔符（ASCII值为2）
+     */
+    private static final char SPLIT_MARK = 2;
+
+    private final TagTransmissionConfig tagTransmissionConfig;
+
+    /**
+     * 构造器
+     */
+    public RocketmqProducerInterceptor() {
+        tagTransmissionConfig = PluginConfigManager.getPluginConfig(TagTransmissionConfig.class);
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        if (!tagTransmissionConfig.isEnabled()) {
+            return context;
+        }
+
+        TrafficTag trafficTag = TrafficUtils.getTrafficTag();
+        if (trafficTag == null) {
+            return context;
+        }
+
+        if (context.getArguments()[ARGUMENT_INDEX] instanceof SendMessageRequestHeader) {
+            SendMessageRequestHeader header = (SendMessageRequestHeader) context.getArguments()[ARGUMENT_INDEX];
+            String oldProperties = header.getProperties();
+            String newProperties = this.insertTags2Properties(oldProperties, trafficTag);
+            header.setProperties(newProperties);
+        }
+        return context;
+    }
+
+    /**
+     * 将流量标签插入到properties字符串中 原始properties的格式形如：key1[SOH]value1[STX]key2[SOH]value2，其中[SOH]为ASCII=1的符号，[STX]为ASCII=2的符号
+     *
+     * @param oldProperties 原始properties
+     * @param trafficTag 流量标签
+     * @return String
+     */
+    private String insertTags2Properties(String oldProperties, TrafficTag trafficTag) {
+        Map<String, List<String>> tags = trafficTag.getTag();
+        StringBuilder newProperties = new StringBuilder();
+        for (Map.Entry<String, List<String>> entry : tags.entrySet()) {
+            if (entry.getValue() == null) {
+                continue;
+            }
+            newProperties.append(entry.getKey());
+            newProperties.append(LINK_MARK);
+            newProperties.append(entry.getValue().get(0));
+            newProperties.append(SPLIT_MARK);
+        }
+        if (newProperties.length() == 0) {
+            return oldProperties;
+        }
+        if (oldProperties == null || oldProperties.length() == 0) {
+            newProperties.deleteCharAt(newProperties.length() - 1);
+            return newProperties.toString();
+        }
+        return newProperties.append(oldProperties).toString();
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -15,4 +15,7 @@
 #
 #
 com.huaweicloud.sermant.tag.transmission.declarers.HttpClient4xDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.HttpServletDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.RocketmqConsumerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.RocketmqProducerDeclarer
 


### PR DESCRIPTION
2023-7-21 11:05:56 TangLe

【修复issue】#1244

【修改内容】

1. 新增rocketMQ4.8+的消费者和生产者流量标签透传
2. 新增webServlet3.0+服务端的流量标签透传

【用例描述】后续补充测试用例

【自测情况】1、本地静态检查通过；2、本地自测通过

【影响范围】无