### PR TITLE
修复全链路灰度发布场景下，restTemplate无法向网关传递标签请求头的bug

### DIFF
--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/ClientHttpRequestDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/ClientHttpRequestDeclarer.java
@@ -17,18 +17,18 @@
 package com.huaweicloud.sermant.router.spring.declarer;
 
 /**
- * ClientHttpRequestInterceptor增强类，发起restTemplate请求方法
+ * ClientHttpRequest增强类，发起restTemplate请求方法
  *
  * @author provenceee
  * @since 2022-07-12
  */
 public class ClientHttpRequestDeclarer extends AbstractDeclarer {
-    private static final String ENHANCE_CLASS = "org.springframework.http.client.ClientHttpRequestInterceptor";
+    private static final String ENHANCE_CLASS = "org.springframework.http.client.ClientHttpRequest";
 
     private static final String INTERCEPT_CLASS
         = "com.huaweicloud.sermant.router.spring.interceptor.ClientHttpRequestInterceptor";
 
-    private static final String METHOD_NAME = "intercept";
+    private static final String METHOD_NAME = "execute";
 
     /**
      * 构造方法

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/test/java/com/huaweicloud/sermant/router/spring/interceptor/ClientHttpRequestInterceptorTest.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/test/java/com/huaweicloud/sermant/router/spring/interceptor/ClientHttpRequestInterceptorTest.java
@@ -45,12 +45,10 @@ public class ClientHttpRequestInterceptorTest {
 
     public ClientHttpRequestInterceptorTest() {
         interceptor = new ClientHttpRequestInterceptor();
-        Object[] arguments = new Object[1];
         MockClientHttpRequest request = new MockClientHttpRequest();
         request.getHeaders().add("bar", "bar2");
         request.getHeaders().add("bar3", "bar3");
-        arguments[0] = request;
-        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+        context = ExecuteContext.forMemberMethod(request, null, null, null, null);
     }
 
     /**
@@ -82,7 +80,6 @@ public class ClientHttpRequestInterceptorTest {
         Assert.assertEquals("bar2", headerData.get("bar").get(0));
         Assert.assertEquals("foo1", headerData.get("foo").get(0));
         Assert.assertEquals("bar3", headerData.get("bar3").get(0));
-
     }
 
     /**


### PR DESCRIPTION
【修复issue】 #1255 

【修改内容】修改了restTemplate拦截点，从仅拦截点服务名调用的场景传递请求头，修改为服务名+ip调用的场景传递请求头

【用例描述】功能不变，不需要修改用例

【自测情况】集成测试可以保证正确性，这个功能已经在1.1.x的版本中支持了，本pr只是同步相关代码

【影响范围】不涉及