### PR TITLE
优化springcloud双注册场景，DiscoveryClientInterceptor/DiscoveryClientServiceInterceptor处理逻辑

### DIFF
--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DynamicServerListInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/DynamicServerListInterceptor.java
@@ -26,7 +26,6 @@ import com.huawei.registry.utils.HostUtils;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
-import com.huaweicloud.sermant.core.service.ServiceManager;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
 
 import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
@@ -69,8 +68,8 @@ public class DynamicServerListInterceptor extends RegisterSwitchSupport {
         }
         for (MicroServiceInstance microServiceInstance : microServiceInstances) {
             result.removeIf(originServiceInstance ->
-                            HostUtils.isSameInstance(originServiceInstance.getHost(), originServiceInstance.getPort(),
-                                    microServiceInstance.getHost(), microServiceInstance.getPort()));
+                    HostUtils.isSameInstance(originServiceInstance.getHost(), originServiceInstance.getPort(),
+                            microServiceInstance.getHost(), microServiceInstance.getPort()));
             result.add(new ScServer(microServiceInstance, serverListLoadBalancer.getName()));
         }
         return result;

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/InstanceInterceptorSupport.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/InstanceInterceptorSupport.java
@@ -38,39 +38,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 2022-02-22
  */
 public abstract class InstanceInterceptorSupport extends RegisterSwitchSupport {
-    private final ThreadLocal<Object> threadLocal = new ThreadLocal<>();
-
     /**
      * 类缓存, 避免多次调用loadClass
      */
     private final Map<String, Class<?>> cacheClasses = new ConcurrentHashMap<>();
 
     private RegisterConfig config;
-
-    /**
-     * 标记当前线程方法调用
-     * <p></p>
-     * 默认标记, 确保下游调用不会存在再次mark的场景
-     */
-    protected final void mark() {
-        threadLocal.set(Boolean.TRUE);
-    }
-
-    /**
-     * 默认去除标记
-     */
-    protected final void unMark() {
-        threadLocal.remove();
-    }
-
-    /**
-     * 判断是否被标记
-     *
-     * @return 是否被标记
-     */
-    protected final boolean isMarked() {
-        return threadLocal.get() != null;
-    }
 
     /**
      * 是否开启注册中心迁移，双注册
@@ -100,7 +73,7 @@ public abstract class InstanceInterceptorSupport extends RegisterSwitchSupport {
             Class<?> result = null;
             try {
                 result = ClassLoaderUtils.defineClass(className, contextClassLoader,
-                    ClassLoaderUtils.getClassResource(this.getClass().getClassLoader(), className));
+                        ClassLoaderUtils.getClassResource(this.getClass().getClassLoader(), className));
             } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException | IOException e) {
                 // 有可能已经加载过了，直接用contextClassLoader.loadClass加载
                 try {
@@ -117,17 +90,17 @@ public abstract class InstanceInterceptorSupport extends RegisterSwitchSupport {
      * 构建实例  由子类自行转换
      *
      * @param microServiceInstance 实例信息
-     * @param serviceName          服务名
+     * @param serviceName 服务名
      * @return Object
      */
     protected final Optional<Object> buildInstance(MicroServiceInstance microServiceInstance, String serviceName) {
         final Class<?> serverClass = getInstanceClass(getInstanceClassName());
         try {
             Constructor<?> declaredConstructor = serverClass
-                .getDeclaredConstructor(MicroServiceInstance.class, String.class);
+                    .getDeclaredConstructor(MicroServiceInstance.class, String.class);
             return Optional.of(declaredConstructor.newInstance(microServiceInstance, serviceName));
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
-            | InvocationTargetException ignored) {
+                 | InvocationTargetException ignored) {
             return Optional.empty();
         }
     }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/BaseRegistryTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/BaseRegistryTest.java
@@ -64,7 +64,6 @@ public abstract class BaseRegistryTest<T extends Interceptor> {
                 RegisterServiceCommonConfig.class)).thenReturn(COMMON_CONFIG);
         pluginServiceManagerMockedStatic = Mockito.mockStatic(PluginServiceManager.class);
         serviceManagerMockedStatic = Mockito.mockStatic(ServiceManager.class);
-
     }
 
     @AfterClass
@@ -79,7 +78,6 @@ public abstract class BaseRegistryTest<T extends Interceptor> {
     }
 
     /**
-     *
      * @return 测试拦截器
      */
     protected abstract T getInterceptor();
@@ -98,12 +96,29 @@ public abstract class BaseRegistryTest<T extends Interceptor> {
      * 构建基本的context
      *
      * @param arguments 参数
-     * @param target  对象
+     * @param target 对象
      * @return context
      * @throws NoSuchMethodException 不会抛出
      */
     protected ExecuteContext buildContext(Object target, Object[] arguments) throws NoSuchMethodException {
         return ExecuteContext.forMemberMethod(target, String.class.getDeclaredMethod("trim"),
                 arguments, null, null);
+    }
+
+    /**
+     * 构建基本的context
+     *
+     * @param arguments 参数
+     * @param target 对象
+     * @param result ExecuteContext的result
+     * @return context
+     * @throws NoSuchMethodException 不会抛出
+     */
+    protected ExecuteContext buildContext(Object target, Object[] arguments, Object result)
+            throws NoSuchMethodException {
+        ExecuteContext context = ExecuteContext.forMemberMethod(target, String.class.getDeclaredMethod("trim"),
+                arguments, null, null);
+        context.changeResult(result);
+        return context;
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/DiscoveryClientInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/DiscoveryClientInterceptorTest.java
@@ -25,6 +25,7 @@ import com.huawei.registry.services.RegisterCenterService;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
 import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,9 +37,12 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.cloud.client.discovery.composite.reactive.ReactiveCompositeDiscoveryClient;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperServiceInstance;
+
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -49,6 +53,7 @@ import java.util.List;
  */
 public class DiscoveryClientInterceptorTest extends BaseRegistryTest<DiscoveryClientInterceptor> {
     private final List<MicroServiceInstance> instanceList = new ArrayList<>();
+
     private final List<ServiceInstance> zkInstanceList = new ArrayList<>();
 
     private final String serviceName = "test";
@@ -72,29 +77,60 @@ public class DiscoveryClientInterceptorTest extends BaseRegistryTest<DiscoveryCl
         instanceList.add(test.buildInstance(8002));
         zkInstanceList.add(new ZookeeperServiceInstance(serviceName, test.buildZkInstance(8003)));
         zkInstanceList.add(new ZookeeperServiceInstance(serviceName, test.buildZkInstance(8004)));
-        Mockito.when(registerCenterService.getServerList(serviceName)).thenReturn(instanceList);
-        Mockito.when(client.getInstances(serviceName)).thenReturn(zkInstanceList);
-        Mockito.when(reactiveDiscoveryClient.getInstances(serviceName)).thenReturn(Flux.fromIterable(zkInstanceList));
+        zkInstanceList.add(new ZookeeperServiceInstance(serviceName, test.buildZkInstance(8005)));
     }
 
     @Test
     public void doBefore() throws NoSuchMethodException {
+        Mockito.when(registerCenterService.getServerList(serviceName)).thenReturn(instanceList);
+
+        // isEmpty为false，isAvailable为true的普通场景
         RegisterContext.INSTANCE.setAvailable(true);
         REGISTER_CONFIG.setEnableSpringRegister(true);
         REGISTER_CONFIG.setOpenMigration(true);
         RegisterDynamicConfig.INSTANCE.setClose(false);
-        final ExecuteContext context = interceptor.doBefore(buildContext(client, new Object[]{serviceName}));
-        Assert.assertTrue(context.isSkip());
-        Assert.assertTrue(context.getResult() instanceof List);
-        Assert.assertEquals(((List<?>) context.getResult()).size(), zkInstanceList.size() + instanceList.size());
+        final ExecuteContext context = interceptor.doBefore(
+                buildContext(client, new Object[]{serviceName}, zkInstanceList));
+        final ExecuteContext contextResult = interceptor.doAfter(context);
+        Assert.assertTrue(contextResult.getResult() instanceof List);
+        Assert.assertEquals(((List<?>) contextResult.getResult()).size(), zkInstanceList.size() + instanceList.size());
 
-        final ExecuteContext fluxContext = interceptor.doBefore(buildContext(reactiveDiscoveryClient, new Object[]{serviceName}));
-        Assert.assertTrue(fluxContext.isSkip());
-        Assert.assertTrue(fluxContext.getResult() instanceof Flux);
-        final List<?> block = ((Flux<?>) fluxContext.getResult()).collectList().block();
+        // isEmpty为false，isAvailable为true的isWebfLux场景
+        final ExecuteContext fluxContext = interceptor.doBefore(buildContext(reactiveDiscoveryClient,
+                new Object[]{serviceName}, Flux.fromIterable(zkInstanceList)));
+        final ExecuteContext fluxContextResult = interceptor.doAfter(fluxContext);
+        Assert.assertTrue(fluxContextResult.getResult() instanceof Flux);
+        final List<?> block = ((Flux<?>) fluxContextResult.getResult()).collectList().block();
         Assert.assertNotNull(block);
         Assert.assertEquals(block.size(), zkInstanceList.size() + instanceList.size());
+
+        // isEmpty为false，isAvailable为false场景
         RegisterContext.INSTANCE.setAvailable(false);
+        final ExecuteContext notAvailableContext = interceptor.doBefore(
+                buildContext(client, new Object[]{serviceName}, zkInstanceList));
+        Assert.assertTrue(notAvailableContext.isSkip());
+        Assert.assertTrue(CollectionUtils.isEmpty((Collection<?>) notAvailableContext.getResult()));
+        final ExecuteContext notAvailableContextResult = interceptor.doAfter(notAvailableContext);
+        Assert.assertTrue(notAvailableContextResult.getResult() instanceof List);
+        Assert.assertEquals(((List<?>) notAvailableContextResult.getResult()).size(), instanceList.size());
+
+        // isEmpty为true，isAvailable为true场景
+        RegisterContext.INSTANCE.setAvailable(true);
+        Mockito.when(registerCenterService.getServerList(serviceName)).thenReturn(Collections.emptyList());
+        final ExecuteContext contextWithEmptyList = interceptor.doBefore(
+                buildContext(client, new Object[]{serviceName}, zkInstanceList));
+        final ExecuteContext contextWithEmptyListResult = interceptor.doAfter(contextWithEmptyList);
+        Assert.assertTrue(contextWithEmptyListResult.getResult() instanceof List);
+        Assert.assertEquals(((List<?>) contextWithEmptyListResult.getResult()).size(), zkInstanceList.size());
+
+        // isEmpty为true，isAvailable为false场景
+        Mockito.when(registerCenterService.getServerList(serviceName)).thenReturn(Collections.emptyList());
+        final ExecuteContext contextWithEmptyListx = interceptor.doBefore(
+                buildContext(client, new Object[]{serviceName}, zkInstanceList));
+        final ExecuteContext contextWithEmptyListResultx = interceptor.doAfter(contextWithEmptyListx);
+        Assert.assertTrue(contextWithEmptyListResultx.getResult() instanceof List);
+        Assert.assertEquals(((List<?>) contextWithEmptyListResultx.getResult()).size(), zkInstanceList.size());
+
         REGISTER_CONFIG.setEnableSpringRegister(false);
         REGISTER_CONFIG.setOpenMigration(false);
     }


### PR DESCRIPTION
【修复issue】#1242

【修改内容】
1、修改了com.huawei.registry.interceptors.DiscoveryClientInterceptor/DiscoveryClientServiceInterceptor的拦截逻辑，去掉线程变量，修改合并方式
2、修改了相应的UT

【用例描述】功能不变，不需要修改用例

【自测情况】本地静态检查通过、UT通过

【影响范围】不涉及