### PR TITLE
流量标签透传特性：支持跨线程传递标签

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/matcher/MethodMatcher.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/matcher/MethodMatcher.java
@@ -239,6 +239,15 @@ public abstract class MethodMatcher implements ElementMatcher<MethodDescription>
     }
 
     /**
+     * 匹配公有方法，见{@link #methodTypeMatches}
+     *
+     * @return 方法匹配器对象
+     */
+    public static MethodMatcher isPublicMethod() {
+        return methodTypeMatches(MethodType.PUBLIC);
+    }
+
+    /**
      * 匹配符合类型的方法，包括静态方法，构造函数和成员方法三种
      *
      * @param methodType 方法类型

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/matcher/MethodType.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/matcher/MethodType.java
@@ -52,6 +52,15 @@ public enum MethodType {
         public boolean match(MethodDescription methodDescription) {
             return !methodDescription.isStatic() && !methodDescription.isConstructor();
         }
+    },
+    /**
+     * 公有方法
+     */
+    PUBLIC() {
+        @Override
+        public boolean match(MethodDescription methodDescription) {
+            return methodDescription.isPublic();
+        }
     };
 
     /**

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficData.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficData.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.utils.tag;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 流量相关新信息
+ *
+ * @author lilai
+ * @since 2023-07-26
+ */
+public class TrafficData extends TrafficTag {
+    private final String path;
+
+    private final String httpMethod;
+
+    /**
+     * 构造方法
+     *
+     * @param header 请求头/attachments
+     * @param path 请求路径
+     * @param httpMethod 请求方法
+     */
+    public TrafficData(Map<String, List<String>> header, String path, String httpMethod) {
+        super(header);
+        this.path = path;
+        this.httpMethod = httpMethod;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    @Override
+    public String toString() {
+        return "{"
+                + "path='" + path + '\''
+                + ", httpMethod='" + httpMethod + '\''
+                + ", tag='" + getTag() + '\''
+                + '}';
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/tag/TrafficUtils.java
@@ -28,9 +28,24 @@ import java.util.Map;
  * @since 2023-07-17
  */
 public class TrafficUtils {
-    private static final ThreadLocal<TrafficTag> TAG = new ThreadLocal<>();
+    private static ThreadLocal<TrafficTag> tag = new ThreadLocal<>();
+
+    private static ThreadLocal<TrafficData> data = new ThreadLocal<>();
 
     private TrafficUtils() {
+    }
+
+    /**
+     * 如果开启在new Thread时跨线程传递标签，需要把ThreadLocal初始化为InheritableThreadLocal
+     */
+    public static void setInheritableThreadLocal() {
+        if (!(tag instanceof InheritableThreadLocal)) {
+            tag = new InheritableThreadLocal<>();
+        }
+
+        if (!(data instanceof InheritableThreadLocal)) {
+            data = new InheritableThreadLocal<>();
+        }
     }
 
     /**
@@ -39,24 +54,33 @@ public class TrafficUtils {
      * @return 流量标签
      */
     public static TrafficTag getTrafficTag() {
-        return TAG.get();
+        return tag.get();
+    }
+
+    /**
+     * 获取线程中的流量信息
+     *
+     * @return 流量信息
+     */
+    public static TrafficData getTrafficData() {
+        return data.get();
     }
 
     /**
      * 更新线程中的流量标签
      *
-     * @param tag 流量标签map
+     * @param tagMap 流量标签map
      */
-    public static void updateTrafficTag(Map<String, List<String>> tag) {
-        if (MapUtils.isEmpty(tag)) {
+    public static void updateTrafficTag(Map<String, List<String>> tagMap) {
+        if (MapUtils.isEmpty(tagMap)) {
             return;
         }
-        TrafficTag trafficTag = TAG.get();
+        TrafficTag trafficTag = TrafficUtils.tag.get();
         if (trafficTag == null) {
-            TAG.set(new TrafficTag(tag));
+            TrafficUtils.tag.set(new TrafficTag(tagMap));
             return;
         }
-        trafficTag.updateTag(tag);
+        trafficTag.updateTag(tagMap);
     }
 
     /**
@@ -68,13 +92,29 @@ public class TrafficUtils {
         if (trafficTag == null) {
             return;
         }
-        TAG.set(trafficTag);
+        tag.set(trafficTag);
     }
 
     /**
      * 删除线程变量
      */
     public static void removeTrafficTag() {
-        TAG.remove();
+        tag.remove();
+    }
+
+    /**
+     * 流量信息存入线程变量
+     *
+     * @param value 线程变量
+     */
+    public static void setTrafficData(TrafficData value) {
+        data.set(value);
+    }
+
+    /**
+     * 删除流量信息
+     */
+    public static void removeTrafficData() {
+        data.remove();
     }
 }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/NacosHealthInterceptorTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/test/java/com/huawei/registry/interceptors/health/NacosHealthInterceptorTest.java
@@ -50,6 +50,7 @@ public class NacosHealthInterceptorTest extends BaseRegistryTest<NacosHealthInte
     public void doBefore() throws Exception {
         REGISTER_CONFIG.setEnableSpringRegister(true);
         REGISTER_CONFIG.setOpenMigration(true);
+        RegisterDynamicConfig.INSTANCE.setClose(false);
         final ExecuteContext context = interceptor.before(buildContext());
         Assert.assertFalse(context.isSkip());
         RegisterDynamicConfig.INSTANCE.setClose(true);

--- a/sermant-plugins/sermant-tag-transmission/config/config.yaml
+++ b/sermant-plugins/sermant-tag-transmission/config/config.yaml
@@ -1,3 +1,15 @@
-tag.transmission.plugin:
+# 流量标签在各种通道间(http/rpc/消息队列等)传递的配置
+tag.transmission.config:
+  # 是否开启流量标签透传
   enabled: true
+  # 需要透传的流量标签的key
   tagKeys: [id,name]
+
+# 跨线程传递标签的配置,该能力可单独使用
+crossthread.config:
+  # 是否在直接new Thread时传递标签
+  enabled-thread: true
+  # 是否在非定时线程池中传递标签
+  enabled-thread-pool: true
+  # 是否在定时线程池的schedule/scheduleAtFixedRate/scheduleWithFixedDelay方法中传递标签
+  enabled-scheduler: true

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -52,6 +52,21 @@
             <version>${kafka-clients.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/CrossThreadConfig.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/CrossThreadConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.config;
+
+import com.huaweicloud.sermant.core.config.common.ConfigFieldKey;
+import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfig;
+
+/**
+ * 跨线程传递开关配置
+ *
+ * @author lilai
+ * @since 2023-08-02
+ */
+@ConfigTypeKey("crossthread.config")
+public class CrossThreadConfig implements PluginConfig {
+    /**
+     * 是否在非定时线程池中传递标签
+     */
+    @ConfigFieldKey("enabled-thread-pool")
+    private boolean enabledThreadPool;
+
+    /**
+     * 是否在定时线程池的schedule/scheduleAtFixedRate/scheduleWithFixedDelay方法中传递标签
+     */
+    @ConfigFieldKey("enabled-scheduler")
+    private boolean enabledScheduler;
+
+    /**
+     * 是否在直接new Thread时传递标签
+     */
+    @ConfigFieldKey("enabled-thread")
+    private boolean enabledThread;
+
+    public boolean isEnabledThread() {
+        return enabledThread;
+    }
+
+    public void setEnabledThread(boolean enabledThread) {
+        this.enabledThread = enabledThread;
+    }
+
+    public boolean isEnabledThreadPool() {
+        return enabledThreadPool;
+    }
+
+    public void setEnabledThreadPool(boolean enabledThreadPool) {
+        this.enabledThreadPool = enabledThreadPool;
+    }
+
+    public boolean isEnabledScheduler() {
+        return enabledScheduler;
+    }
+
+    public void setEnabledScheduler(boolean enabledScheduler) {
+        this.enabledScheduler = enabledScheduler;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
@@ -24,12 +24,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * 流量标签透传插件配置
+ * 流量标签透传配置
  *
  * @author lilai
  * @since 2023-07-17
  */
-@ConfigTypeKey("tag.transmission.plugin")
+@ConfigTypeKey("tag.transmission.config")
 public class TagTransmissionConfig implements PluginConfig {
     /**
      * 是否开启适配

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/KafkaProducerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/KafkaProducerDeclarer.java
@@ -28,7 +28,7 @@ import com.huaweicloud.sermant.tag.transmission.interceptors.KafkaProducerInterc
  * @author lilai
  * @since 2023-07-18
  */
-public class KafkaProviderDeclarer extends AbstractPluginDeclarer {
+public class KafkaProducerDeclarer extends AbstractPluginDeclarer {
     /**
      * 增强类的全限定名
      */

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/crossthread/ExecutorDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/crossthread/ExecutorDeclarer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.crossthread;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.CrossThreadConfig;
+import com.huaweicloud.sermant.tag.transmission.interceptors.crossthread.ExecutorInterceptor;
+
+/**
+ * 拦截Executor
+ *
+ * @author provenceee
+ * @since 2023-04-20
+ */
+public class ExecutorDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "java.util.concurrent.Executor";
+
+    private static final String INTERCEPT_CLASS = ExecutorInterceptor.class.getCanonicalName();
+
+    private static final String[] METHOD_NAME = {"execute", "submit"};
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isExtendedFrom(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameContains(METHOD_NAME).and(MethodMatcher.isPublicMethod()),
+                        INTERCEPT_CLASS)
+        };
+    }
+
+    @Override
+    public boolean isEnabled() {
+        CrossThreadConfig config = PluginConfigManager.getPluginConfig(CrossThreadConfig.class);
+        if (config.isEnabledThread()) {
+            TrafficUtils.setInheritableThreadLocal();
+            return true;
+        }
+        return config.isEnabledThreadPool();
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/crossthread/ScheduledExecutorServiceDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/crossthread/ScheduledExecutorServiceDeclarer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.crossthread;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.CrossThreadConfig;
+import com.huaweicloud.sermant.tag.transmission.interceptors.crossthread.ScheduledExecutorServiceInterceptor;
+
+/**
+ * ScheduledExecutorService拦截点
+ *
+ * @author provenceee
+ * @since 2023-06-07
+ */
+public class ScheduledExecutorServiceDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "java.util.concurrent.ScheduledExecutorService";
+
+    private static final String INTERCEPT_CLASS = ScheduledExecutorServiceInterceptor.class.getCanonicalName();
+
+    private static final String[] METHOD_NAME = {"schedule", "scheduleAtFixedRate", "scheduleWithFixedDelay"};
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isExtendedFrom(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameContains(METHOD_NAME).and(MethodMatcher.isPublicMethod()),
+                        INTERCEPT_CLASS)
+        };
+    }
+
+    @Override
+    public boolean isEnabled() {
+        CrossThreadConfig config = PluginConfigManager.getPluginConfig(CrossThreadConfig.class);
+        if (config.isEnabledThread()) {
+            TrafficUtils.setInheritableThreadLocal();
+            return true;
+        }
+        return config.isEnabledScheduler();
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/KafkaConsumerRecordInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/KafkaConsumerRecordInterceptor.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
 import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
 
@@ -52,7 +53,9 @@ public class KafkaConsumerRecordInterceptor extends AbstractServerInterceptor {
         if (consumerRecordObject instanceof ConsumerRecord) {
             final ConsumerRecord<?, ?> consumerRecord = (ConsumerRecord<?, ?>) consumerRecordObject;
             Map<String, List<String>> tagMap = extractTagMap(consumerRecord);
-            TrafficUtils.updateTrafficTag(tagMap);
+
+            // 消息队列消费者不会remove线程变量，需要每次set新对象，以保证父子线程之间的变量隔离
+            TrafficUtils.setTrafficTag(new TrafficTag(tagMap));
         }
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqConsumerInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
 import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
 
@@ -74,7 +75,9 @@ public class RocketmqConsumerInterceptor extends AbstractInterceptor {
         if (context.getObject() instanceof Message) {
             Message message = (Message) context.getObject();
             Map<String, List<String>> tag = this.getTagFromMessage(message);
-            TrafficUtils.updateTrafficTag(tag);
+
+            // 消息队列消费者不会remove线程变量，需要每次set新对象，以保证父子线程之间的变量隔离
+            TrafficUtils.setTrafficTag(new TrafficTag(tag));
         }
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/AbstractExecutorInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/AbstractExecutorInterceptor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.crossthread;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.utils.tag.TrafficData;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.wrapper.CallableWrapper;
+import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableAndCallableWrapper;
+import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableWrapper;
+
+import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 线程池拦截器抽象类
+ *
+ * @author provenceee
+ * @since 2023-06-08
+ */
+public abstract class AbstractExecutorInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private final boolean cannotTransmit;
+
+    /**
+     * 构造方法
+     *
+     * @param cannotTransmit 执行方法之前是否需要删除线程变量
+     */
+    protected AbstractExecutorInterceptor(boolean cannotTransmit) {
+        this.cannotTransmit = cannotTransmit;
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments == null || arguments.length == 0 || arguments[0] == null) {
+            return context;
+        }
+        TrafficTag trafficTag = TrafficUtils.getTrafficTag();
+        TrafficData trafficData = TrafficUtils.getTrafficData();
+        if (trafficTag == null && trafficData == null) {
+            return context;
+        }
+
+        Object argument = arguments[0];
+        if (argument instanceof RunnableAndCallableWrapper || argument instanceof RunnableWrapper
+                || argument instanceof CallableWrapper) {
+            return context;
+        }
+        if (argument instanceof Runnable && argument instanceof Callable) {
+            return buildRunnableAndCallableWrapper(context, arguments, trafficTag, trafficData, argument);
+        }
+        if (argument instanceof Runnable) {
+            return buildRunnableWrapper(context, arguments, trafficTag, trafficData, argument);
+        }
+        if (argument instanceof Callable) {
+            return buildCallableWrapper(context, arguments, trafficTag, trafficData, argument);
+        }
+        return context;
+    }
+
+    private ExecuteContext buildCallableWrapper(ExecuteContext context, Object[] arguments, TrafficTag trafficTag,
+            TrafficData trafficData, Object argument) {
+        log(argument, trafficTag, trafficData, CallableWrapper.class.getCanonicalName());
+        arguments[0] = new CallableWrapper<>((Callable<?>) argument, trafficTag, trafficData,
+                cannotTransmit);
+        return context;
+    }
+
+    private ExecuteContext buildRunnableWrapper(ExecuteContext context, Object[] arguments, TrafficTag trafficTag,
+            TrafficData trafficData, Object argument) {
+        log(argument, trafficTag, trafficData, RunnableWrapper.class.getCanonicalName());
+        arguments[0] = new RunnableWrapper<>((Runnable) argument, trafficTag, trafficData,
+                cannotTransmit);
+        return context;
+    }
+
+    private ExecuteContext buildRunnableAndCallableWrapper(ExecuteContext context, Object[] arguments,
+            TrafficTag trafficTag,
+            TrafficData trafficData, Object argument) {
+        log(argument, trafficTag, trafficData, RunnableAndCallableWrapper.class.getCanonicalName());
+        arguments[0] = new RunnableAndCallableWrapper<>((Runnable) argument, (Callable<?>) argument,
+                trafficTag, trafficData, cannotTransmit);
+        return context;
+    }
+
+    private void log(Object argument, TrafficTag trafficTag, TrafficData trafficData, String wrapperClassName) {
+        LOGGER.log(Level.FINE, "Class name is {0}, hash code is {1}, trafficTag is {2}, "
+                        + "trafficData is {3}, will be converted to {4}.",
+                new Object[]{argument.getClass().getName(), Integer.toHexString(argument.hashCode()),
+                        trafficTag, trafficData, wrapperClassName});
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ExecutorInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ExecutorInterceptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.crossthread;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.tag.transmission.config.CrossThreadConfig;
+
+/**
+ * 拦截Executor
+ *
+ * @author provenceee
+ * @since 2023-04-21
+ */
+public class ExecutorInterceptor extends AbstractExecutorInterceptor {
+    /**
+     * 构造方法
+     */
+    public ExecutorInterceptor() {
+        super(!PluginConfigManager.getPluginConfig(CrossThreadConfig.class).isEnabledThreadPool());
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ScheduledExecutorServiceInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ScheduledExecutorServiceInterceptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.crossthread;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.tag.transmission.config.CrossThreadConfig;
+
+/**
+ * 拦截ScheduledExecutorService
+ *
+ * @author provenceee
+ * @since 2023-06-07
+ */
+public class ScheduledExecutorServiceInterceptor extends AbstractExecutorInterceptor {
+    /**
+     * 构造方法
+     */
+    public ScheduledExecutorServiceInterceptor() {
+        super(!PluginConfigManager.getPluginConfig(CrossThreadConfig.class).isEnabledScheduler());
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/AbstractThreadWrapper.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/AbstractThreadWrapper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.wrapper;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.utils.tag.TrafficData;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+
+import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 执行线程的包装抽象类
+ *
+ * @param <T> 泛型
+ * @author provenceee
+ * @since 2023-06-08
+ */
+public abstract class AbstractThreadWrapper<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private final Runnable runnable;
+
+    private final Callable<T> callable;
+
+    private final TrafficTag trafficTag;
+
+    private final TrafficData trafficData;
+
+    private final boolean cannotTransmit;
+
+    /**
+     * 构造方法
+     *
+     * @param runnable runnable
+     * @param callable callable
+     * @param trafficTag 请求标记
+     * @param trafficData 请求数据
+     * @param cannotTransmit 执行方法之前是否需要删除线程变量
+     */
+    public AbstractThreadWrapper(Runnable runnable, Callable<T> callable, TrafficTag trafficTag,
+            TrafficData trafficData, boolean cannotTransmit) {
+        this.runnable = runnable;
+        this.callable = callable;
+        if (cannotTransmit) {
+            this.trafficTag = null;
+            this.trafficData = null;
+        } else {
+            this.trafficTag = trafficTag;
+            this.trafficData = trafficData;
+        }
+        this.cannotTransmit = cannotTransmit;
+    }
+
+    /**
+     * run方法, Runnable的实现类继承该方法
+     */
+    public void run() {
+        try {
+            before(runnable);
+            runnable.run();
+        } finally {
+            after();
+        }
+    }
+
+    /**
+     * call方法，Callable的实现类继承该方法
+     *
+     * @return callable调用结果
+     * @throws Exception 异常
+     */
+    public T call() throws Exception {
+        try {
+            before(callable);
+            return callable.call();
+        } finally {
+            after();
+        }
+    }
+
+    private void before(Object obj) {
+        if (cannotTransmit) {
+            // 当开启普通线程透传，不开启线程池透传时，需要在执行方法之前，删除由InheritableThreadLocal透传的数据
+            TrafficUtils.removeTrafficTag();
+            TrafficUtils.removeTrafficData();
+        }
+        if (trafficTag != null) {
+            TrafficUtils.setTrafficTag(trafficTag);
+        }
+        if (trafficData != null) {
+            TrafficUtils.setTrafficData(trafficData);
+        }
+        LOGGER.log(Level.FINE, "Current thread is {0}, class name is {1}, hash code is {2}, trafficTag is {3}, "
+                        + "trafficData is {4}, will be executed.",
+                new Object[]{Thread.currentThread().getName(), obj.getClass().getName(),
+                        Integer.toHexString(obj.hashCode()), trafficTag, trafficData});
+    }
+
+    private void after() {
+        TrafficUtils.removeTrafficTag();
+        TrafficUtils.removeTrafficData();
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/CallableWrapper.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/CallableWrapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.wrapper;
+
+import com.huaweicloud.sermant.core.utils.tag.TrafficData;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Callable包装类
+ *
+ * @param <T> 泛型
+ * @author provenceee
+ * @since 2023-04-21
+ */
+public class CallableWrapper<T> extends AbstractThreadWrapper<T> implements Callable<T> {
+    /**
+     * 构造方法
+     *
+     * @param callable callable
+     * @param trafficTag 请求标记
+     * @param trafficData 请求数据
+     * @param cannotTransmit 执行方法之前是否需要删除线程变量
+     */
+    public CallableWrapper(Callable<T> callable, TrafficTag trafficTag, TrafficData trafficData,
+            boolean cannotTransmit) {
+        super(null, callable, trafficTag, trafficData, cannotTransmit);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/RunnableAndCallableWrapper.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/RunnableAndCallableWrapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.wrapper;
+
+import com.huaweicloud.sermant.core.utils.tag.TrafficData;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Runnable&Callable包装类，例如reactor.core.scheduler.WorkerTask
+ *
+ * @param <T> 泛型
+ * @author provenceee
+ * @since 2023-04-21
+ */
+public class RunnableAndCallableWrapper<T> extends AbstractThreadWrapper<T> implements Runnable, Callable<T> {
+    /**
+     * 构造方法
+     *
+     * @param runnable runnable
+     * @param callable callable
+     * @param trafficTag 请求标记
+     * @param trafficData 请求数据
+     * @param cannotTransmit 执行方法之前是否需要删除线程变量
+     */
+    public RunnableAndCallableWrapper(Runnable runnable, Callable<T> callable, TrafficTag trafficTag,
+            TrafficData trafficData, boolean cannotTransmit) {
+        super(runnable, callable, trafficTag, trafficData, cannotTransmit);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/RunnableWrapper.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/RunnableWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.wrapper;
+
+import com.huaweicloud.sermant.core.utils.tag.TrafficData;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+
+/**
+ * Runnable包装类
+ *
+ * @param <T> 泛型
+ * @author provenceee
+ * @since 2023-04-21
+ */
+public class RunnableWrapper<T> extends AbstractThreadWrapper<T> implements Runnable {
+    /**
+     * 构造方法
+     *
+     * @param runnable runnable
+     * @param trafficTag 请求标记
+     * @param trafficData 请求数据
+     * @param cannotTransmit 执行方法之前是否需要删除线程变量
+     */
+    public RunnableWrapper(Runnable runnable, TrafficTag trafficTag, TrafficData trafficData, boolean cannotTransmit) {
+        super(runnable, null, trafficTag, trafficData, cannotTransmit);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -15,11 +15,13 @@
 #
 #
 com.huaweicloud.sermant.tag.transmission.declarers.HttpClient4xDeclarer
-
 com.huaweicloud.sermant.tag.transmission.declarers.HttpServletDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.RocketmqConsumerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.RocketmqProducerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.KafkaConsumerRecordDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.KafkaProviderDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.KafkaProducerDeclarer
+
+com.huaweicloud.sermant.tag.transmission.declarers.crossthread.ExecutorDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.crossthread.ScheduledExecutorServiceDeclarer
 
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
@@ -15,3 +15,4 @@
 #
 
 com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig
+com.huaweicloud.sermant.tag.transmission.config.CrossThreadConfig

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/BaseTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/BaseTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.tag.transmission.config.CrossThreadConfig;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * 测试基类
+ *
+ * @author provenceee
+ * @since 2023-06-08
+ */
+public abstract class BaseTest {
+    protected static MockedStatic<PluginConfigManager> mockPluginConfigManager;
+
+    @BeforeClass
+    public static void before() {
+        mockPluginConfigManager = Mockito.mockStatic(PluginConfigManager.class);
+        mockPluginConfigManager.when(() -> PluginConfigManager.getPluginConfig(CrossThreadConfig.class))
+                .thenReturn(new CrossThreadConfig());
+    }
+
+    /**
+     * UT执行后释放mock对象
+     */
+    @AfterClass
+    public static void after() {
+        mockPluginConfigManager.close();
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/RunnableAndCallable.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/RunnableAndCallable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author provenceee
+ * @since 2023-06-13
+ */
+public class RunnableAndCallable implements Runnable, Callable<Object> {
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Object call() {
+        return new Object();
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/ExecutorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/ExecutorInterceptorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.BaseTest;
+import com.huaweicloud.sermant.tag.transmission.RunnableAndCallable;
+import com.huaweicloud.sermant.tag.transmission.interceptors.crossthread.ExecutorInterceptor;
+import com.huaweicloud.sermant.tag.transmission.wrapper.CallableWrapper;
+import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableAndCallableWrapper;
+import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableWrapper;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.Callable;
+
+/**
+ * 测试ExecutorInterceptor
+ *
+ * @author provenceee
+ * @since 2023-05-26
+ */
+public class ExecutorInterceptorTest extends BaseTest {
+    private final ExecutorInterceptor interceptor;
+
+    private final ExecuteContext context;
+
+    private final Object[] arguments;
+
+    public ExecutorInterceptorTest() {
+        arguments = new Object[1];
+        interceptor = new ExecutorInterceptor();
+        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+
+    @Test
+    public void testBefore() {
+        // 测试null
+        interceptor.before(context);
+        Assert.assertNull(context.getArguments()[0]);
+
+        // 测试没有路由数据
+        Runnable runnable = () -> {
+        };
+        arguments[0] = runnable;
+        interceptor.before(context);
+        Assert.assertEquals(runnable, context.getArguments()[0]);
+
+        // 存入路由数据
+        TrafficUtils.updateTrafficTag(Collections.singletonMap("foo", Collections.singletonList("bar")));
+
+        // 测试已经包装过了
+        RunnableWrapper<?> runnableWrapper = new RunnableWrapper<>(null, null, null, false);
+        arguments[0] = runnableWrapper;
+        interceptor.before(context);
+        Assert.assertEquals(runnableWrapper, context.getArguments()[0]);
+
+        // 包装RunnableAndCallable
+        RunnableAndCallable runnableAndCallable = new RunnableAndCallable();
+        arguments[0] = runnableAndCallable;
+        interceptor.before(context);
+        Assert.assertTrue(context.getArguments()[0] instanceof RunnableAndCallableWrapper);
+
+        // 包装Runnable
+        Runnable runnable1 = () -> {
+        };
+        arguments[0] = runnable1;
+        interceptor.before(context);
+        Assert.assertTrue(context.getArguments()[0] instanceof RunnableWrapper);
+
+        // 包装Callable
+        Callable<Object> callable = () -> null;
+        arguments[0] = callable;
+        interceptor.before(context);
+        Assert.assertTrue(context.getArguments()[0] instanceof CallableWrapper);
+    }
+
+    @After
+    public void clear() {
+        TrafficUtils.removeTrafficData();
+        TrafficUtils.removeTrafficTag();
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/ScheduledExecutorServiceInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/ScheduledExecutorServiceInterceptorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.BaseTest;
+import com.huaweicloud.sermant.tag.transmission.RunnableAndCallable;
+import com.huaweicloud.sermant.tag.transmission.interceptors.crossthread.ScheduledExecutorServiceInterceptor;
+import com.huaweicloud.sermant.tag.transmission.wrapper.CallableWrapper;
+import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableAndCallableWrapper;
+import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableWrapper;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.Callable;
+
+/**
+ * 测试ScheduledExecutorService
+ *
+ * @author provenceee
+ * @since 2023-06-13
+ */
+public class ScheduledExecutorServiceInterceptorTest extends BaseTest {
+    private final ScheduledExecutorServiceInterceptor interceptor;
+
+    private final ExecuteContext context;
+
+    private final Object[] arguments;
+
+    public ScheduledExecutorServiceInterceptorTest() {
+        arguments = new Object[1];
+        interceptor = new ScheduledExecutorServiceInterceptor();
+        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+
+    @Test
+    public void testBefore() {
+        // 测试null
+        interceptor.before(context);
+        Assert.assertNull(context.getArguments()[0]);
+
+        // 测试没有路由数据
+        Runnable runnable = () -> {
+        };
+        arguments[0] = runnable;
+        interceptor.before(context);
+        Assert.assertEquals(runnable, context.getArguments()[0]);
+
+        // 存入路由数据
+        TrafficUtils.updateTrafficTag(Collections.singletonMap("foo", Collections.singletonList("bar")));
+
+        // 测试已经包装过了
+        RunnableWrapper<?> runnableWrapper = new RunnableWrapper<>(null, null, null, false);
+        arguments[0] = runnableWrapper;
+        interceptor.before(context);
+        Assert.assertEquals(runnableWrapper, context.getArguments()[0]);
+
+        // 包装RunnableAndCallable
+        RunnableAndCallable runnableAndCallable = new RunnableAndCallable();
+        arguments[0] = runnableAndCallable;
+        interceptor.before(context);
+        Assert.assertTrue(context.getArguments()[0] instanceof RunnableAndCallableWrapper);
+
+        // 包装Runnable
+        Runnable runnable1 = () -> {
+        };
+        arguments[0] = runnable1;
+        interceptor.before(context);
+        Assert.assertTrue(context.getArguments()[0] instanceof RunnableWrapper);
+
+        // 包装Callable
+        Callable<Object> callable = () -> null;
+        arguments[0] = callable;
+        interceptor.before(context);
+        Assert.assertTrue(context.getArguments()[0] instanceof CallableWrapper);
+    }
+
+    @After
+    public void clear() {
+        TrafficUtils.removeTrafficData();
+        TrafficUtils.removeTrafficTag();
+    }
+}


### PR DESCRIPTION
【修复issue】https://github.com/huaweicloud/Sermant/issues/1244

【修改内容】支持跨线程传递标签，该能力可单独使用，可与其他插件配合获取和传递请求信息。
该能力从路由插件中抽出，路由插件后续需相应重构适配。

【用例描述】1、直接new thread创建新线程，测试结果父线程的标签可以在子线程中获取；2、通过ExecutorService的submit、execute方法创建新线程，测试结果父线程的标签可以在子线程中获取；3、通过ScheduledExecutorService的schedule、scheduleAtFixedRate、scheduleWithFixedDelay方法创建新线程，测试结果父线程的标签可以在子线程中获取；

【自测情况】1、本地静态检查通过；2、本地自测通过

【影响范围】当前PR和流量标签透传插件不影响其他插件使用；后续需重构路由插件。