### PR TITLE
dubbo流量标签透传，支持2.6.x,2.7.x,3.x

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -22,6 +22,8 @@
         <kafka-clients.version>2.7.0</kafka-clients.version>
         <tomcat-embed-core.version>9.0.38</tomcat-embed-core.version>
         <powermock.version>2.0.9</powermock.version>
+        <dubbo.version>3.2.0</dubbo.version>
+        <alibaba.dubbo.version>2.6.12</alibaba.dubbo.version>
     </properties>
 
     <dependencies>
@@ -54,7 +56,18 @@
             <version>${kafka-clients.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!--测试依赖-->
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${alibaba.dubbo.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${dubbo.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/AlibabaDubboConsumerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/AlibabaDubboConsumerDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AlibabaDubboConsumerInterceptor;
+
+/**
+ * dubbo流量标签透传的consumer端增强声明，支持alibaba dubbo2.6.x版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-12
+ **/
+public class AlibabaDubboConsumerDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS_ALIBABA_DUBBO = "com.alibaba.dubbo.rpc.filter.ConsumerContextFilter";
+
+    private static final String INTERCEPT_CLASS = AlibabaDubboConsumerInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "invoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS_ALIBABA_DUBBO);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/AlibabaDubboProviderDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/AlibabaDubboProviderDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AlibabaDubboProviderInterceptor;
+
+/**
+ * dubbo流量标签透传的provider端增强声明，支持alibaba dubbo2.6.x版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-02
+ **/
+public class AlibabaDubboProviderDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS = "com.alibaba.dubbo.monitor.support.MonitorFilter";
+
+    private static final String INTERCEPT_CLASS = AlibabaDubboProviderInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "invoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/ApacheDubboConsumerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/ApacheDubboConsumerDeclarer.java
@@ -1,0 +1,55 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.ApacheDubboConsumerInterceptor;
+
+/**
+ * dubbo流量标签透传的consumer端增强声明，支持dubbo2.7.x, 3.x版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-12
+ **/
+public class ApacheDubboConsumerDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS_APACHE_DUBBO_V3 =
+            "org.apache.dubbo.rpc.cluster.filter.support.ConsumerContextFilter";
+
+    private static final String ENHANCE_CLASS_APACHE_DUBBO_V2 = "org.apache.dubbo.rpc.filter.ConsumerContextFilter";
+
+    private static final String INTERCEPT_CLASS = ApacheDubboConsumerInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "invoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameContains(ENHANCE_CLASS_APACHE_DUBBO_V3, ENHANCE_CLASS_APACHE_DUBBO_V2);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/ApacheDubboProviderDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/ApacheDubboProviderDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.ApacheDubboProviderInterceptor;
+
+/**
+ * dubbo流量标签透传的provider端增强声明，支持dubbo2.7.x, 3.x
+ *
+ * @author daizhenyu
+ * @since 2023-08-02
+ **/
+public class ApacheDubboProviderDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS = "org.apache.dubbo.monitor.support.MonitorFilter";
+
+    private static final String INTERCEPT_CLASS = ApacheDubboProviderInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "invoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AlibabaDubboConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AlibabaDubboConsumerInterceptor.java
@@ -1,0 +1,75 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+
+import com.alibaba.dubbo.rpc.RpcInvocation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * dubbo流量标签透传consumer端的拦截器，支持alibaba dubbo2.6.x版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-12
+ **/
+public class AlibabaDubboConsumerInterceptor extends AbstractClientInterceptor {
+    /**
+     * rpcInvocation参数在invoke方法的参数下标
+     */
+    private static final int ARGUMENT_INDEX = 1;
+
+    /**
+     * ApacheDubboV3ConsumerInterceptor类的无参构造方法
+     */
+    public AlibabaDubboConsumerInterceptor() {
+    }
+
+    private void addTag2Attachment(Object invocation, TrafficTag trafficTag) {
+        if (invocation == null) {
+            return;
+        }
+        if (invocation instanceof RpcInvocation) {
+            RpcInvocation rpcInvocation = (RpcInvocation) invocation;
+            addTag2Attachment(trafficTag.getTag(), rpcInvocation);
+        }
+    }
+
+    private void addTag2Attachment(Map<String, List<String>> tag, RpcInvocation invocation) {
+        for (Map.Entry<String, List<String>> entry : tag.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            invocation.setAttachment(entry.getKey(), entry.getValue().get(0));
+        }
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        this.addTag2Attachment(context.getArguments()[ARGUMENT_INDEX], TrafficUtils.getTrafficTag());
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AlibabaDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AlibabaDubboProviderInterceptor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.RpcInvocation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * dubbo流量标签透传的provider端拦截器，支持alibaba dubbo2.6.x版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-02
+ **/
+public class AlibabaDubboProviderInterceptor extends AbstractServerInterceptor {
+    /**
+     * invoker参数在invoke方法的参数下标
+     */
+    private static final int ARGUMENT_INVOKER_INDEX = 0;
+
+    /**
+     * invocation参数在invoke方法的参数下标
+     */
+    private static final int ARGUMENT_INVOCATION_INDEX = 1;
+
+    /**
+     * dubbo客户端
+     */
+    private static final String DUBBO_CONSUMER = "consumer";
+
+    /**
+     * dubbo服务端
+     */
+    private static final String DUBBO_PROVIDER = "provider";
+
+    /**
+     * 区分dubbo调用端 provider 服务端 consumer 客户端
+     */
+    private static final String DUBBO_SIDE = "side";
+
+    /**
+     * AlibabaDubboProviderInterceptor的无参构造方法
+     */
+    public AlibabaDubboProviderInterceptor() {
+    }
+
+    private boolean isConsumer(ExecuteContext context) {
+        Object invokerArgument = context.getArguments()[ARGUMENT_INVOKER_INDEX];
+        if (!(invokerArgument instanceof Invoker<?>)) {
+            return false;
+        }
+        Invoker<?> invoker = (Invoker<?>) invokerArgument;
+        return isConsumer(invoker);
+    }
+
+    private boolean isConsumer(Invoker<?> invoker) {
+        return DUBBO_CONSUMER.equals(invoker.getUrl().getParameter(DUBBO_SIDE, DUBBO_PROVIDER));
+    }
+
+    private Map<String, List<String>> getTagFromInvocation(RpcInvocation invocation) {
+        Map<String, List<String>> tag = new HashMap<>();
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            String value = invocation.getAttachment(key);
+
+            // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
+            if (value == null) {
+                tag.put(key, null);
+                continue;
+            }
+            tag.put(key, Collections.singletonList(value));
+        }
+        return tag;
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
+
+        Object invocationArgument = context.getArguments()[ARGUMENT_INVOCATION_INDEX];
+        if (invocationArgument instanceof RpcInvocation) {
+            RpcInvocation rpcInvocation = (RpcInvocation) invocationArgument;
+            TrafficUtils.updateTrafficTag(getTagFromInvocation(rpcInvocation));
+        }
+
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/ApacheDubboConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/ApacheDubboConsumerInterceptor.java
@@ -1,0 +1,75 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+
+import org.apache.dubbo.rpc.RpcInvocation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * dubbo流量标签透传consumer端的拦截器，支持dubbo2.7.x, 3.x版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-12
+ **/
+public class ApacheDubboConsumerInterceptor extends AbstractClientInterceptor {
+    /**
+     * rpcInvocation参数在invoke方法的参数下标
+     */
+    private static final int ARGUMENT_INDEX = 1;
+
+    /**
+     * ApacheDubboV3ConsumerInterceptor类的无参构造方法
+     */
+    public ApacheDubboConsumerInterceptor() {
+    }
+
+    private void addTag2Attachment(Object invocation, TrafficTag trafficTag) {
+        if (invocation == null) {
+            return;
+        }
+        if (invocation instanceof RpcInvocation) {
+            RpcInvocation rpcInvocation = (RpcInvocation) invocation;
+            addTag2Attachment(trafficTag.getTag(), rpcInvocation);
+        }
+    }
+
+    private void addTag2Attachment(Map<String, List<String>> tag, RpcInvocation invocation) {
+        for (Map.Entry<String, List<String>> entry : tag.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            invocation.setAttachment(entry.getKey(), entry.getValue().get(0));
+        }
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        this.addTag2Attachment(context.getArguments()[ARGUMENT_INDEX], TrafficUtils.getTrafficTag());
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/ApacheDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/ApacheDubboProviderInterceptor.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.utils.DubboUtils;
+
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcInvocation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * dubbo流量标签透传的provider端拦截器，支持dubbo2.7.x, 3.x
+ *
+ * @author daizhenyu
+ * @since 2023-08-02
+ **/
+public class ApacheDubboProviderInterceptor extends AbstractServerInterceptor {
+    /**
+     * invoker参数在invoke方法的参数下标
+     */
+    private static final int ARGUMENT_INVOKER_INDEX = 0;
+
+    /**
+     * invocation参数在invoke方法的参数下标
+     */
+    private static final int ARGUMENT_INVOCATION_INDEX = 1;
+
+    /**
+     * dubbo客户端
+     */
+    private static final String DUBBO_CONSUMER = "consumer";
+
+    /**
+     * dubbo服务端
+     */
+    private static final String DUBBO_PROVIDER = "provider";
+
+    /**
+     * 区分dubbo调用端 provider 服务端 consumer 客户端
+     */
+    private static final String DUBBO_SIDE = "side";
+
+    /**
+     * ApacheDubboProviderInterceptor的无参构造方法
+     */
+    public ApacheDubboProviderInterceptor() {
+    }
+
+    private boolean isConsumer(ExecuteContext context) {
+        Object invokerArgument = context.getArguments()[ARGUMENT_INVOKER_INDEX];
+        if (!(invokerArgument instanceof Invoker<?>)) {
+            return false;
+        }
+        Invoker<?> invoker = (Invoker<?>) invokerArgument;
+        return isConsumer(invoker);
+    }
+
+    private boolean isConsumer(Invoker<?> invoker) {
+        return DUBBO_CONSUMER.equals(invoker.getUrl().getParameter(DUBBO_SIDE, DUBBO_PROVIDER));
+    }
+
+    private Map<String, List<String>> getTagFromInvocation(RpcInvocation invocation) {
+        Map<String, List<String>> tag = new HashMap<>();
+
+        // 适配不同版本apache dubbo的RpcInvocation的attachments属性泛型不一致情况
+        Map<String, Object> attachments = DubboUtils.getAttachmentsByInvocation(invocation)
+                .filter(obj -> obj instanceof Map)
+                .map(obj -> (Map<String, Object>) obj)
+                .orElse(new HashMap<>());
+
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            Object value = attachments.get(key);
+            if (value instanceof String) {
+                tag.put(key, Collections.singletonList((String) value));
+                continue;
+            }
+
+            // 流量标签的value为null或不为String对象时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
+            tag.put(key, null);
+        }
+        return tag;
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
+
+        Object invocationArgument = context.getArguments()[ARGUMENT_INVOCATION_INDEX];
+        if (invocationArgument instanceof RpcInvocation) {
+            RpcInvocation rpcInvocation = (RpcInvocation) invocationArgument;
+            TrafficUtils.updateTrafficTag(getTagFromInvocation(rpcInvocation));
+        }
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/utils/DubboUtils.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/utils/DubboUtils.java
@@ -1,0 +1,48 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.utils;
+
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import java.util.Optional;
+
+/**
+ * dubbo工具类
+ *
+ * @author daizhenyu
+ * @since 2023-08-03
+ **/
+public class DubboUtils {
+    /**
+     * Rpcinvocation类的attachments属性名称
+     */
+    private static final String ATTACHMENTS_FIELD = "attachments";
+
+    private DubboUtils() {
+
+    }
+
+    /**
+     * 使用反射获取Rpcinvocation对象的attachments属性值
+     *
+     * @param obj Invocation的实现类对象
+     * @return Optional dubbo的attachments属性
+     */
+    public static Optional<Object> getAttachmentsByInvocation(Object obj) {
+        return ReflectUtils.getFieldValue(obj, ATTACHMENTS_FIELD);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -19,8 +19,11 @@ com.huaweicloud.sermant.tag.transmission.declarers.HttpServletDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.RocketmqConsumerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.RocketmqProducerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.KafkaConsumerRecordDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.AlibabaDubboProviderDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.ApacheDubboProviderDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.ApacheDubboConsumerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.AlibabaDubboConsumerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.KafkaProducerDeclarer
-
 com.huaweicloud.sermant.tag.transmission.declarers.crossthread.ExecutorDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.crossthread.ScheduledExecutorServiceDeclarer
 


### PR DESCRIPTION
【修复issue】#1244

【修改内容】
1.增加了ApacheDubboV3ConsumerDeclarer、ApacheDubboV2ConsumerDeclarer和AlibabaDubboConsumerDeclarer类，这三个类是dubbo流量标签透传在consumer端的声明类，分别适配不同的dubbo版本
2.增加了ApacheDubboProviderDeclarer和AlibabaDubboProviderDeclarer类，这两个类是dubbo流量标签透传在provider端的声明类，分别适配不同的dubbo版本
3.增加了AlibabaDubboConsumerInterceptor、AlibabaDubboProviderInterceptor、ApacheDubboProviderInterceptor、ApacheDubboV2ConsumerInterceptor和ApacheDubboV3ConsumerInterceptor五个拦截器，实现在拦截点的增强逻辑来实现流量标签透传功能
4.增加了DubboUtils工具类，作为dubbo流量标签透传的工具类使用

5.修改了pom文件，增加dubbo和单元测试所需的依赖
6.修改了com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer文件
【用例描述】无

【自测情况】本地编译通过，针对dubbo2.6.x、2.7.x和3.x多个版本测试通过

【影响范围】需要修改文档