### PR TITLE
流量标签透传特性：支持 httpclient3、Okhttp2、Jdk httpclient的流量标签透传 & 重构代码结构和风格

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -17,6 +17,8 @@
         <config.skip.flag>false</config.skip.flag>
         <package.plugin.type>plugin</package.plugin.type>
         <apache-httpclient.version>4.3</apache-httpclient.version>
+        <commons-httpclient.version>3.1</commons-httpclient.version>
+        <okhttp.version>2.7.5</okhttp.version>
         <rocketmq-client.version>4.8.0</rocketmq-client.version>
         <javax-servlet-api.version>3.0.1</javax-servlet-api.version>
         <kafka-clients.version>2.7.0</kafka-clients.version>
@@ -37,6 +39,16 @@
             <artifactId>httpclient</artifactId>
             <version>${apache-httpclient.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>${commons-httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/httpclient/HttpClient3xDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/httpclient/HttpClient3xDeclarer.java
@@ -14,39 +14,45 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.http.client.httpclient;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.RocketmqConsumerInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpclient.HttpClient3xInterceptor;
 
 /**
- * RocketMQ流量标签透传的消费者增强声明，支持RocketMQ4.8+
+ * HttpClient 流量标签透传的增强声明, 仅针对3.x版本
  *
- * @author tangle
- * @since 2023-07-19
+ * @author lilai
+ * @since 2023-08-08
  */
-public class RocketmqConsumerDeclarer extends AbstractPluginDeclarer {
+public class HttpClient3xDeclarer extends AbstractPluginDeclarer {
     /**
-     * 增强类的全限定名、拦截器、拦截方法
+     * 增强类的全限定名
      */
-    private static final String ENHANCE_CLASS = "org.apache.rocketmq.common.message.Message";
+    private static final String ENHANCE_CLASSES = "org.apache.commons.httpclient.HttpClient";
 
-    private static final String INTERCEPT_CLASS = RocketmqConsumerInterceptor.class.getCanonicalName();
-
-    private static final String METHOD_NAME = "getBody";
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = HttpClient3xInterceptor.class.getCanonicalName();
 
     @Override
     public ClassMatcher getClassMatcher() {
-        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+        return ClassMatcher.nameEquals(ENHANCE_CLASSES);
     }
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+                InterceptDeclarer.build(MethodMatcher.nameEquals("executeMethod")
+                                .and(MethodMatcher.paramTypesEqual(
+                                        "org.apache.commons.httpclient.HostConfiguration",
+                                        "org.apache.commons.httpclient.HttpMethod",
+                                        "org.apache.commons.httpclient.HttpState")),
+                        INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/httpclient/HttpClient4xDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/httpclient/HttpClient4xDeclarer.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.http.client.httpclient;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.HttpClient4xInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpclient.HttpClient4xInterceptor;
 
 /**
  * HttpClient 流量标签透传的增强声明, 仅针对4.x版本

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/jdk/JdkHttpClientDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/jdk/JdkHttpClientDeclarer.java
@@ -14,39 +14,41 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.http.client.jdk;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.HttpServletInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.http.client.jdk.JdkHttpClientInterceptor;
 
 /**
- * HttpServlet 流量标签透传的增强声明,支持sevlet3.0+
+ * JDK HttpClient 流量标签透传的增强声明
  *
- * @author tangle
- * @since 2023-07-18
+ * @author lilai
+ * @since 2023-08-08
  */
-public class HttpServletDeclarer extends AbstractPluginDeclarer {
+public class JdkHttpClientDeclarer extends AbstractPluginDeclarer {
     /**
-     * 增强类的全限定名、拦截器、拦截方法
+     * 增强类的全限定名
      */
-    private static final String ENHANCE_CLASS = "javax.servlet.http.HttpServlet";
+    private static final String ENHANCE_CLASSES = "sun.net.www.http.HttpClient";
 
-    private static final String INTERCEPT_CLASS = HttpServletInterceptor.class.getCanonicalName();
-
-    private static final String METHOD_NAME = "service";
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = JdkHttpClientInterceptor.class.getCanonicalName();
 
     @Override
     public ClassMatcher getClassMatcher() {
-        return ClassMatcher.isExtendedFrom(ENHANCE_CLASS);
+        return ClassMatcher.nameEquals(ENHANCE_CLASSES);
     }
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+                InterceptDeclarer.build(MethodMatcher.nameEquals("writeRequests"),
+                        INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/okhttp/OkHttp2xDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/client/okhttp/OkHttp2xDeclarer.java
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.http.client.okhttp;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.KafkaProducerInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.http.client.okhttp.OkHttp2xInterceptor;
 
 /**
- * kafka生产消息增强拦截点声明，支持1.x, 2.x, 3.x
+ * OkHttp 流量标签透传的增强声明, 仅针对2.x版本
  *
  * @author lilai
- * @since 2023-07-18
+ * @since 2023-08-08
  */
-public class KafkaProducerDeclarer extends AbstractPluginDeclarer {
+public class OkHttp2xDeclarer extends AbstractPluginDeclarer {
     /**
      * 增强类的全限定名
      */
-    private static final String ENHANCE_CLASSES = "org.apache.kafka.clients.producer.KafkaProducer";
+    private static final String ENHANCE_CLASSES = "com.squareup.okhttp.Request$Builder";
 
     /**
      * 拦截类的全限定名
      */
-    private static final String INTERCEPT_CLASS = KafkaProducerInterceptor.class.getCanonicalName();
+    private static final String INTERCEPT_CLASS = OkHttp2xInterceptor.class.getCanonicalName();
 
     @Override
     public ClassMatcher getClassMatcher() {
@@ -47,7 +47,8 @@ public class KafkaProducerDeclarer extends AbstractPluginDeclarer {
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-                InterceptDeclarer.build(MethodMatcher.nameEquals("doSend"), INTERCEPT_CLASS)
+                InterceptDeclarer.build(MethodMatcher.nameEquals("build"),
+                        INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/server/HttpServletDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/http/server/HttpServletDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.http.server;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.http.server.HttpServletInterceptor;
+
+/**
+ * HttpServlet 流量标签透传的增强声明,支持sevlet3.0+
+ *
+ * @author tangle
+ * @since 2023-07-18
+ */
+public class HttpServletDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS = "javax.servlet.http.HttpServlet";
+
+    private static final String INTERCEPT_CLASS = HttpServletInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "service";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isExtendedFrom(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/kafka/KafkaConsumerRecordDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/kafka/KafkaConsumerRecordDeclarer.java
@@ -14,42 +14,40 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.mq.kafka;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.RocketmqProducerInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka.KafkaConsumerRecordInterceptor;
 
 /**
- * RocketMQ流量标签透传的生产者增强声明，支持RocketMQ4.8+
+ * kafka获取消息内容的拦截点声明，支持1.x, 2.x, 3.x
  *
- * @author tangle
- * @since 2023-07-20
+ * @author lilai
+ * @since 2023-07-18
  */
-public class RocketmqProducerDeclarer extends AbstractPluginDeclarer {
+public class KafkaConsumerRecordDeclarer extends AbstractPluginDeclarer {
     /**
-     * 增强类的全限定名、拦截器、拦截方法
+     * 增强类的全限定名
      */
-    private static final String ENHANCE_CLASS = "org.apache.rocketmq.client.impl.MQClientAPIImpl";
+    private static final String ENHANCE_CLASSES = "org.apache.kafka.clients.consumer.ConsumerRecord";
 
-    private static final String INTERCEPT_CLASS = RocketmqProducerInterceptor.class.getCanonicalName();
-
-    private static final String METHOD_NAME = "sendMessage";
-
-    private static final int PARAM_INDEX = 12;
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = KafkaConsumerRecordInterceptor.class.getCanonicalName();
 
     @Override
     public ClassMatcher getClassMatcher() {
-        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+        return ClassMatcher.nameEquals(ENHANCE_CLASSES);
     }
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME)
-                        .and(MethodMatcher.paramCountEquals(PARAM_INDEX)), INTERCEPT_CLASS)
+                InterceptDeclarer.build(MethodMatcher.nameEquals("value"), INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/kafka/KafkaProducerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/kafka/KafkaProducerDeclarer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.mq.kafka;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka.KafkaProducerInterceptor;
+
+/**
+ * kafka生产消息增强拦截点声明，支持1.x, 2.x, 3.x
+ *
+ * @author lilai
+ * @since 2023-07-18
+ */
+public class KafkaProducerDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名
+     */
+    private static final String ENHANCE_CLASSES = "org.apache.kafka.clients.producer.KafkaProducer";
+
+    /**
+     * 拦截类的全限定名
+     */
+    private static final String INTERCEPT_CLASS = KafkaProducerInterceptor.class.getCanonicalName();
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASSES);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals("doSend"), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/rocketmq/RocketmqConsumerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/rocketmq/RocketmqConsumerDeclarer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.mq.rocketmq;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq.RocketmqConsumerInterceptor;
+
+/**
+ * RocketMQ流量标签透传的消费者增强声明，支持RocketMQ4.8+
+ *
+ * @author tangle
+ * @since 2023-07-19
+ */
+public class RocketmqConsumerDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 增强类的全限定名、拦截器、拦截方法
+     */
+    private static final String ENHANCE_CLASS = "org.apache.rocketmq.common.message.Message";
+
+    private static final String INTERCEPT_CLASS = RocketmqConsumerInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "getBody";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), INTERCEPT_CLASS)
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/rocketmq/RocketmqProducerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/mq/rocketmq/RocketmqProducerDeclarer.java
@@ -14,40 +14,42 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.mq.rocketmq;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.KafkaConsumerRecordInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq.RocketmqProducerInterceptor;
 
 /**
- * kafka获取消息内容的拦截点声明，支持1.x, 2.x, 3.x
+ * RocketMQ流量标签透传的生产者增强声明，支持RocketMQ4.8+
  *
- * @author lilai
- * @since 2023-07-18
+ * @author tangle
+ * @since 2023-07-20
  */
-public class KafkaConsumerRecordDeclarer extends AbstractPluginDeclarer {
+public class RocketmqProducerDeclarer extends AbstractPluginDeclarer {
     /**
-     * 增强类的全限定名
+     * 增强类的全限定名、拦截器、拦截方法
      */
-    private static final String ENHANCE_CLASSES = "org.apache.kafka.clients.consumer.ConsumerRecord";
+    private static final String ENHANCE_CLASS = "org.apache.rocketmq.client.impl.MQClientAPIImpl";
 
-    /**
-     * 拦截类的全限定名
-     */
-    private static final String INTERCEPT_CLASS = KafkaConsumerRecordInterceptor.class.getCanonicalName();
+    private static final String INTERCEPT_CLASS = RocketmqProducerInterceptor.class.getCanonicalName();
+
+    private static final String METHOD_NAME = "sendMessage";
+
+    private static final int PARAM_INDEX = 12;
 
     @Override
     public ClassMatcher getClassMatcher() {
-        return ClassMatcher.nameEquals(ENHANCE_CLASSES);
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
     }
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-                InterceptDeclarer.build(MethodMatcher.nameEquals("value"), INTERCEPT_CLASS)
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME)
+                        .and(MethodMatcher.paramCountEquals(PARAM_INDEX)), INTERCEPT_CLASS)
         };
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/AlibabaDubboConsumerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/AlibabaDubboConsumerDeclarer.java
@@ -14,13 +14,13 @@
  *   limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.AlibabaDubboConsumerInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo.AlibabaDubboConsumerInterceptor;
 
 /**
  * dubbo流量标签透传的consumer端增强声明，支持alibaba dubbo2.6.x版本

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/AlibabaDubboProviderDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/AlibabaDubboProviderDeclarer.java
@@ -14,27 +14,27 @@
  *   limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.ApacheDubboProviderInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo.AlibabaDubboProviderInterceptor;
 
 /**
- * dubbo流量标签透传的provider端增强声明，支持dubbo2.7.x, 3.x
+ * dubbo流量标签透传的provider端增强声明，支持alibaba dubbo2.6.x版本
  *
  * @author daizhenyu
  * @since 2023-08-02
  **/
-public class ApacheDubboProviderDeclarer extends AbstractPluginDeclarer {
+public class AlibabaDubboProviderDeclarer extends AbstractPluginDeclarer {
     /**
      * 增强类的全限定名、拦截器、拦截方法
      */
-    private static final String ENHANCE_CLASS = "org.apache.dubbo.monitor.support.MonitorFilter";
+    private static final String ENHANCE_CLASS = "com.alibaba.dubbo.monitor.support.MonitorFilter";
 
-    private static final String INTERCEPT_CLASS = ApacheDubboProviderInterceptor.class.getCanonicalName();
+    private static final String INTERCEPT_CLASS = AlibabaDubboProviderInterceptor.class.getCanonicalName();
 
     private static final String METHOD_NAME = "invoke";
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/ApacheDubboConsumerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/ApacheDubboConsumerDeclarer.java
@@ -14,13 +14,13 @@
  *   limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.ApacheDubboConsumerInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo.ApacheDubboConsumerInterceptor;
 
 /**
  * dubbo流量标签透传的consumer端增强声明，支持dubbo2.7.x, 3.x版本

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/ApacheDubboProviderDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/dubbo/ApacheDubboProviderDeclarer.java
@@ -14,27 +14,27 @@
  *   limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.declarers;
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo;
 
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
-import com.huaweicloud.sermant.tag.transmission.interceptors.AlibabaDubboProviderInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo.ApacheDubboProviderInterceptor;
 
 /**
- * dubbo流量标签透传的provider端增强声明，支持alibaba dubbo2.6.x版本
+ * dubbo流量标签透传的provider端增强声明，支持dubbo2.7.x, 3.x
  *
  * @author daizhenyu
  * @since 2023-08-02
  **/
-public class AlibabaDubboProviderDeclarer extends AbstractPluginDeclarer {
+public class ApacheDubboProviderDeclarer extends AbstractPluginDeclarer {
     /**
      * 增强类的全限定名、拦截器、拦截方法
      */
-    private static final String ENHANCE_CLASS = "com.alibaba.dubbo.monitor.support.MonitorFilter";
+    private static final String ENHANCE_CLASS = "org.apache.dubbo.monitor.support.MonitorFilter";
 
-    private static final String INTERCEPT_CLASS = AlibabaDubboProviderInterceptor.class.getCanonicalName();
+    private static final String INTERCEPT_CLASS = ApacheDubboProviderInterceptor.class.getCanonicalName();
 
     private static final String METHOD_NAME = "invoke";
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractClientInterceptor.java
@@ -27,10 +27,16 @@ import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
 /**
  * 客户端拦截器抽象类，获取当前线程的流量标签并透传至下游进程，适用于http客户端/rpc客户端/消息队列生产者
  *
+ * @param <Carrier> 标签载体
  * @author lilai
  * @since 2023-07-18
  */
-public abstract class AbstractClientInterceptor extends AbstractInterceptor {
+public abstract class AbstractClientInterceptor<Carrier> extends AbstractInterceptor {
+    /**
+     * 过滤一次处理过程中拦截器的多次调用
+     */
+    protected static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
+
     protected final TagTransmissionConfig tagTransmissionConfig;
 
     /**
@@ -74,4 +80,11 @@ public abstract class AbstractClientInterceptor extends AbstractInterceptor {
      * @return 执行上下文
      */
     protected abstract ExecuteContext doAfter(ExecuteContext context);
+
+    /**
+     * 将标签流量注入载体
+     *
+     * @param carrier 载体
+     */
+    protected abstract void injectTrafficTag2Carrier(Carrier carrier);
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractServerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractServerInterceptor.java
@@ -21,13 +21,22 @@ import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * 服务端拦截器抽象类，获取跨进程的流量标签并在本进程传递，适用于http服务端/rpc服务端/消息队列消费者
  *
+ * @param <Carrier> 流量标签载体
  * @author lilai
  * @since 2023-07-18
  */
-public abstract class AbstractServerInterceptor extends AbstractInterceptor {
+public abstract class AbstractServerInterceptor<Carrier> extends AbstractInterceptor {
+    /**
+     * 过滤一次处理过程中拦截器的多次调用
+     */
+    protected static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
+
     protected final TagTransmissionConfig tagTransmissionConfig;
 
     /**
@@ -65,4 +74,12 @@ public abstract class AbstractServerInterceptor extends AbstractInterceptor {
      * @return 执行上下文
      */
     protected abstract ExecuteContext doAfter(ExecuteContext context);
+
+    /**
+     * 从载体中解析流量标签
+     *
+     * @param carrier 载体
+     * @return 流量标签
+     */
+    protected abstract Map<String, List<String>> extractTrafficTagFromCarrier(Carrier carrier);
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpclient;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
+
+import org.apache.commons.httpclient.HttpMethod;
+
+import java.util.List;
+
+/**
+ * HttpClient 流量标签透传的拦截器, 仅针对3.x版本
+ *
+ * @author lilai
+ * @since 2023-08-08
+ */
+public class HttpClient3xInterceptor extends AbstractClientInterceptor<HttpMethod> {
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        Object httpMethodObject = context.getArguments()[1];
+        if (!(httpMethodObject instanceof HttpMethod)) {
+            return context;
+        }
+        injectTrafficTag2Carrier((HttpMethod) httpMethodObject);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext doAfter(ExecuteContext context) {
+        return context;
+    }
+
+    /**
+     * 向HttpMethod中添加流量标签
+     *
+     * @param httpMethod httpclient 3.x 标签传递载体
+     */
+    @Override
+    protected void injectTrafficTag2Carrier(HttpMethod httpMethod) {
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+
+            // HttpClient 3.x 不支持重复key值
+            httpMethod.setRequestHeader(key, values.get(0));
+        }
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.jdk;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
+
+import sun.net.www.MessageHeader;
+
+import java.util.List;
+
+/**
+ * JDK HttpClient 流量标签透传的拦截器
+ *
+ * @author lilai
+ * @since 2023-08-08
+ */
+public class JdkHttpClientInterceptor extends AbstractClientInterceptor<MessageHeader> {
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        if (LOCK_MARK.get() != null) {
+            return context;
+        }
+        LOCK_MARK.set(Boolean.TRUE);
+
+        Object messageHeaderObject = context.getArguments()[0];
+        if (!(messageHeaderObject instanceof MessageHeader)) {
+            return context;
+        }
+
+        injectTrafficTag2Carrier((MessageHeader) messageHeaderObject);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext doAfter(ExecuteContext context) {
+        LOCK_MARK.remove();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        LOCK_MARK.remove();
+        return context;
+    }
+
+    /**
+     * 向MessageHeader中添加流量标签
+     *
+     * @param messageHeader Jdk HttpClient 标签传递载体
+     */
+    @Override
+    protected void injectTrafficTag2Carrier(MessageHeader messageHeader) {
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+            for (String value : values) {
+                messageHeader.add(key, value);
+            }
+        }
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.okhttp;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
+
+import com.squareup.okhttp.Request.Builder;
+
+import java.util.List;
+
+/**
+ * OkHttp 流量标签透传的拦截器, 仅针对2.x版本
+ *
+ * @author lilai
+ * @since 2023-08-08
+ */
+public class OkHttp2xInterceptor extends AbstractClientInterceptor<Builder> {
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        if (LOCK_MARK.get() != null) {
+            return context;
+        }
+        LOCK_MARK.set(Boolean.TRUE);
+        Object builderObject = context.getObject();
+        if (!(builderObject instanceof Builder)) {
+            return context;
+        }
+        injectTrafficTag2Carrier((Builder) builderObject);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext doAfter(ExecuteContext context) {
+        return context;
+    }
+
+    /**
+     * 向Request.Builder中添加流量标签
+     *
+     * @param builder OkHttp 2.x 标签传递载体
+     */
+    @Override
+    protected void injectTrafficTag2Carrier(Builder builder) {
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+            for (String value : values) {
+                builder.addHeader(key, value);
+            }
+        }
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptor.java
@@ -14,11 +14,12 @@
  *   limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.interceptors;
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
-import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import org.apache.dubbo.rpc.RpcInvocation;
 
@@ -31,41 +32,35 @@ import java.util.Map;
  * @author daizhenyu
  * @since 2023-08-12
  **/
-public class ApacheDubboConsumerInterceptor extends AbstractClientInterceptor {
+public class ApacheDubboConsumerInterceptor extends AbstractClientInterceptor<RpcInvocation> {
     /**
      * rpcInvocation参数在invoke方法的参数下标
      */
     private static final int ARGUMENT_INDEX = 1;
 
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        Object invocationObject = context.getArguments()[ARGUMENT_INDEX];
+        if (!(invocationObject instanceof RpcInvocation)) {
+            return context;
+        }
+        injectTrafficTag2Carrier((RpcInvocation) invocationObject);
+        return context;
+    }
+
     /**
-     * ApacheDubboV3ConsumerInterceptor类的无参构造方法
+     * 向RpcInvocation中添加流量标签
+     *
+     * @param invocation Apache Dubbo 标签传递载体
      */
-    public ApacheDubboConsumerInterceptor() {
-    }
-
-    private void addTag2Attachment(Object invocation, TrafficTag trafficTag) {
-        if (invocation == null) {
-            return;
-        }
-        if (invocation instanceof RpcInvocation) {
-            RpcInvocation rpcInvocation = (RpcInvocation) invocation;
-            addTag2Attachment(trafficTag.getTag(), rpcInvocation);
-        }
-    }
-
-    private void addTag2Attachment(Map<String, List<String>> tag, RpcInvocation invocation) {
-        for (Map.Entry<String, List<String>> entry : tag.entrySet()) {
-            if (entry.getKey() == null || entry.getValue() == null) {
+    @Override
+    protected void injectTrafficTag2Carrier(RpcInvocation invocation) {
+        for (Map.Entry<String, List<String>> entry : TrafficUtils.getTrafficTag().getTag().entrySet()) {
+            if (entry.getKey() == null || CollectionUtils.isEmpty(entry.getValue())) {
                 continue;
             }
             invocation.setAttachment(entry.getKey(), entry.getValue().get(0));
         }
-    }
-
-    @Override
-    protected ExecuteContext doBefore(ExecuteContext context) {
-        this.addTag2Attachment(context.getArguments()[ARGUMENT_INDEX], TrafficUtils.getTrafficTag());
-        return context;
     }
 
     @Override

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -14,16 +14,20 @@
 # limitations under the License.
 #
 #
-com.huaweicloud.sermant.tag.transmission.declarers.HttpClient4xDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.HttpServletDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.RocketmqConsumerDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.RocketmqProducerDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.KafkaConsumerRecordDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.AlibabaDubboProviderDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.ApacheDubboProviderDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.ApacheDubboConsumerDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.AlibabaDubboConsumerDeclarer
-com.huaweicloud.sermant.tag.transmission.declarers.KafkaProducerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.http.client.httpclient.HttpClient4xDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.http.server.HttpServletDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.mq.rocketmq.RocketmqConsumerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.mq.rocketmq.RocketmqProducerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.mq.kafka.KafkaConsumerRecordDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.AlibabaDubboProviderDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.ApacheDubboProviderDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.ApacheDubboConsumerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.AlibabaDubboConsumerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.mq.kafka.KafkaProducerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.http.client.httpclient.HttpClient3xDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.http.client.okhttp.OkHttp2xDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.http.client.jdk.JdkHttpClientDeclarer
+
 com.huaweicloud.sermant.tag.transmission.declarers.crossthread.ExecutorDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.crossthread.ScheduledExecutorServiceDeclarer
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpClient4XInterceptorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpClient4XInterceptorInterceptorTest.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpclient.HttpClient4xInterceptor;
 
 import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpRequestBase;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpServletInterceptorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/HttpServletInterceptorInterceptorTest.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.http.server.HttpServletInterceptor;
 
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.connector.Request;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/KafkaConsumerRecordInterceptorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/KafkaConsumerRecordInterceptorInterceptorTest.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka.KafkaConsumerRecordInterceptor;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/KafkaProducerInterceptorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/KafkaProducerInterceptorInterceptorTest.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka.KafkaProducerInterceptor;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqConsumerInterceptorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqConsumerInterceptorInterceptorTest.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq.RocketmqConsumerInterceptor;
 
 import org.apache.rocketmq.common.message.Message;
 import org.junit.Assert;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqProducerInterceptorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/RocketmqProducerInterceptorInterceptorTest.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq.RocketmqProducerInterceptor;
 
 import org.apache.rocketmq.common.protocol.header.SendMessageRequestHeader;
 import org.junit.Assert;


### PR DESCRIPTION
【修复issue】#1244

【修改内容】
(1)支持 httpclient3、Okhttp2、JDK httpclient的流量标签透传
(2) 重构代码结构和风格，抽象标签注入和解析方法

【用例描述】1、分别使用 httpclient3、Okhttp2、JDK httpclient发送 http 请求，Sermant 拦截并注入流量标签，查看服务端接受请求 header 中是否携带流量标签。

【自测情况】1、本地静态检查通过；2、本地自测通过；3、UT 待下一个 PR补充

【影响范围】无