### PR TITLE
支持JDK11

### DIFF
--- a/.github/actions/common/dubbo/action.yml
+++ b/.github/actions/common/dubbo/action.yml
@@ -3,10 +3,10 @@ description: "do something common for all test"
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ env.javaVersion }}
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: ${{ env.javaVersion }}
         distribution: 'adopt'
         cache: maven
     - name: download middlewares

--- a/.github/actions/common/spring/action.yml
+++ b/.github/actions/common/spring/action.yml
@@ -3,10 +3,10 @@ description: "do something common for all test"
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ env.javaVersion }}
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: ${{ env.javaVersion }}
         distribution: 'adopt'
         cache: maven
     - name: download zookeeper

--- a/.github/actions/scenarios/backend/memory/action.yml
+++ b/.github/actions/scenarios/backend/memory/action.yml
@@ -3,10 +3,10 @@ description: "Auto test for Backend"
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ env.javaVersion }}
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
+        java-version: ${{ env.javaVersion }}
         distribution: 'adopt'
         cache: maven
     - name: Set up python

--- a/.github/workflows/backend_integration_test.yml
+++ b/.github/workflows/backend_integration_test.yml
@@ -58,6 +58,9 @@ jobs:
     needs: [ build-agent-and-cache, download-midwares-and-cache ]
     steps:
       - uses: actions/checkout@v2
+      - name: set java version to environment
+        run: |
+          echo "javaVersion=8" >> $GITHUB_ENV
       - name: start backend use memory test
         uses: ./.github/actions/scenarios/backend/memory
       - name: start backend use redis test

--- a/.github/workflows/dubbo_integration_test.yml
+++ b/.github/workflows/dubbo_integration_test.yml
@@ -100,6 +100,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 100
+      - name: set java version to environment
+        run: |
+          echo "javaVersion=8" >> $GITHUB_ENV
       - name: common operations
         uses: ./.github/actions/common/dubbo
       - name: (dubbo router) test for ${{ matrix.dubbo-version }}-${{ matrix.dubbo-versions }}

--- a/.github/workflows/spring_integration_test_1.yml
+++ b/.github/workflows/spring_integration_test_1.yml
@@ -133,6 +133,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 100
+      - name: set java version to environment
+        run: |
+          echo "javaVersion=8" >> $GITHUB_ENV
       - name: common operations
         uses: ./.github/actions/common/spring
       - name: (graceful) test for springboot=${{ matrix.springBootVersion }} springCloudVersion=${{ matrix.springCloudVersion }}

--- a/.github/workflows/spring_integration_test_2.yml
+++ b/.github/workflows/spring_integration_test_2.yml
@@ -122,6 +122,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 100
+      - name: set java version to environment
+        run: |
+          echo "javaVersion=8" >> $GITHUB_ENV
       - name: common operations
         uses: ./.github/actions/common/spring
       - name: (spring router) test for springboot=${{ matrix.springBootVersion }} springCloudVersion=${{ matrix.springCloudVersion }}

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/monitor/MonitorTest.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/monitor/MonitorTest.java
@@ -25,7 +25,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.Set;
 
 /**
  * 监控测试类
@@ -46,6 +49,22 @@ public class MonitorTest {
 
     private static final String TPS = "tps";
 
+    private static final int JDK9_VERSION_INDEX = 9;
+
+    private static final Set<String> JDK8_MONOPOLIZE_INDEX_SET = new HashSet<>(
+            Arrays.asList("code_cache_init", "code_cache_max",
+                    "code_cache_used", "code_cache_committed"));
+
+    private static final Set<String> JDK9PLUS_MONOPOLIZE_INDEX_SET = new HashSet<>(Arrays.asList("non_nmethods_init",
+            "non_nmethods_max",
+            "non_nmethods_used", "non_nmethods_committed",
+            "profiled_nmethods_init", "profiled_nmethods_max",
+            "profiled_nmethods_used", "profiled_nmethods_committed",
+            "non_profiled_nmethods_init", "non_profiled_nmethods_max",
+            "non_profiled_nmethods_used", "non_profiled_nmethods_committed",
+            "epsilon_heap_init", "epsilon_heap_max",
+            "epsilon_heap_used", "epsilon_heap_committed"));
+
     @Test
     public void testMonitor() {
         String string = RequestUtils.get(URL, new HashMap<>(), String.class);
@@ -63,8 +82,22 @@ public class MonitorTest {
         }
         Assertions.assertFalse(map.isEmpty(), "解析响应结果获取指标信息失败");
         for (MetricEnum metricEnum : MetricEnum.values()) {
-            Assertions.assertTrue(map.containsKey(metricEnum.getName()), "缺少指标信息" + metricEnum.getName());
+            String metricEnumName = metricEnum.getName();
+            // 当JDK大于8时，JDK8独有的指标则忽略
+            if (javaVersionGreaterThanJDK8() && JDK8_MONOPOLIZE_INDEX_SET.contains(metricEnumName)) {
+                continue;
+            }
+            // 当JDK小于等于8时，JDK9及以上版本独有的指标则忽略
+            if (!javaVersionGreaterThanJDK8() && JDK9PLUS_MONOPOLIZE_INDEX_SET.contains(metricEnumName)) {
+                continue;
+            }
+            Assertions.assertTrue(map.containsKey(metricEnumName), "缺少指标信息" + metricEnumName);
         }
+    }
+
+    private boolean javaVersionGreaterThanJDK8() {
+        String javaVersion[] = System.getProperty("java.version").split("\\.");
+        return Integer.valueOf(javaVersion[0]) >= JDK9_VERSION_INDEX;
     }
 
     @Test

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MemoryType.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MemoryType.java
@@ -26,7 +26,6 @@ import java.util.Optional;
  * @since 2022-08-02
  */
 public enum MemoryType {
-
     /**
      * 堆内存
      */
@@ -111,19 +110,19 @@ public enum MemoryType {
     OLD_EDEN_SPACE_SERIAL("Tenured Gen", MetricEnum.OLD_GEN_INIT, MetricEnum.OLD_GEN_USED, MetricEnum.OLD_GEN_MAX,
             MetricEnum.OLD_GEN_COMMITTED),
     /**
-     * SERIAL年轻代Eden指标信息
+     * G1年轻代Eden指标信息
      */
     EDEN_SPACE_G1("G1 Eden Space", MetricEnum.EDEN_INIT, MetricEnum.EDEN_USED, MetricEnum.EDEN_MAX,
             MetricEnum.EDEN_COMMITTED),
 
     /**
-     * SERIAL年轻代Survivor指标信息
+     * G1年轻代Survivor指标信息
      */
     SURVIVOR_SPACE_G1("G1 Survivor Space", MetricEnum.SURVIVOR_INIT, MetricEnum.SURVIVOR_USED,
             MetricEnum.SURVIVOR_MAX, MetricEnum.SURVIVOR_COMMITTED),
 
     /**
-     * SERIAL老年代指标枚举
+     * G1老年代指标枚举
      */
     OLD_EDEN_SPACE_G1("G1 Old Gen", MetricEnum.OLD_GEN_INIT, MetricEnum.OLD_GEN_USED, MetricEnum.OLD_GEN_MAX,
             MetricEnum.OLD_GEN_COMMITTED),
@@ -131,7 +130,36 @@ public enum MemoryType {
      * CodeCache内存池
      */
     CODE_CACHE_G1("CodeCache", MetricEnum.CODE_CACHE_INIT, MetricEnum.CODE_CACHE_USED, MetricEnum.CODE_CACHE_MAX,
-            MetricEnum.CODE_CACHE_COMMITTED);
+            MetricEnum.CODE_CACHE_COMMITTED),
+
+    /**
+     * JDK11存储经过性能分析的编译代码的codeCache内存池
+     */
+    PROFILED_NMETHODS("CodeHeap 'profiled nmethods'", MetricEnum.PROFILED_NMETHODS_INIT,
+            MetricEnum.PROFILED_NMETHODS_USED,
+            MetricEnum.PROFILED_NMETHODS_MAX,
+            MetricEnum.PROFILED_NMETHODS_COMMITTED),
+
+    /**
+     * JDK11存储未经过性能分析的编译代码的codeCache内存池
+     */
+    NON_PROFILED_NMETHODS("CodeHeap 'non-profiled nmethods'", MetricEnum.NON_PROFILED_NMETHODS_INIT,
+            MetricEnum.NON_PROFILED_NMETHODS_USED, MetricEnum.NON_PROFILED_NMETHODS_MAX,
+            MetricEnum.NON_PROFILED_NMETHODS_COMMITTED),
+
+    /**
+     * JDK11存储其他类型编译代码的codeCache内存池
+     */
+    NON_NMETHODS("CodeHeap 'non-nmethods'", MetricEnum.NON_NMETHODS_INIT, MetricEnum.NON_NMETHODS_USED,
+            MetricEnum.NON_NMETHODS_MAX,
+            MetricEnum.NON_NMETHODS_COMMITTED),
+
+    /**
+     * Epsilon收集器指标枚举
+     */
+    EPSILON_HEAP("Epsilon Heap", MetricEnum.EPSILON_HEAP_INIT, MetricEnum.EPSILON_HEAP_USED,
+            MetricEnum.EPSILON_HEAP_MAX,
+            MetricEnum.EPSILON_HEAP_COMMITTED);
 
     /**
      * 类型
@@ -161,10 +189,10 @@ public enum MemoryType {
     /**
      * 构造方法
      *
-     * @param type          类型
-     * @param initEnum      初始化枚举
-     * @param usedEnum      已使用对应的枚举
-     * @param maxEnum       最大值对应的枚举
+     * @param type 类型
+     * @param initEnum 初始化枚举
+     * @param usedEnum 已使用对应的枚举
+     * @param maxEnum 最大值对应的枚举
      * @param committedEnum 提交值对应的枚举
      */
     MemoryType(String type, MetricEnum initEnum, MetricEnum usedEnum, MetricEnum maxEnum, MetricEnum committedEnum) {

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricEnum.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricEnum.java
@@ -24,7 +24,6 @@ package com.huawei.monitor.common;
  * @since 2022-08-02
  */
 public enum MetricEnum {
-
     /**
      * JVM内存指标信息
      */
@@ -329,7 +328,88 @@ public enum MetricEnum {
     /**
      * 平均响应时间
      */
-    AVG_RESPONSE_TIME("avg_response_time", "the number is  number of response time");
+    AVG_RESPONSE_TIME("avg_response_time", "the number is number of response time"),
+
+    /**
+     * JDK11存储其他类型编译代码的codeCache初始值
+     */
+    NON_NMETHODS_INIT("non_nmethods_init", "the number is init of non_nmethods"),
+
+    /**
+     * JDK11存储其他类型编译代码的codeCache使用值
+     */
+    NON_NMETHODS_USED("non_nmethods_used", "the number is used of non_nmethods"),
+
+    /**
+     * JDK11存储其他类型编译代码的codeCache最大值
+     */
+    NON_NMETHODS_MAX("non_nmethods_max", "the number is max of non_nmethods"),
+
+    /**
+     * JDK11存储其他类型编译代码的codeCache提交值
+     */
+    NON_NMETHODS_COMMITTED("non_nmethods_committed", "the number is committed of non_nmethods"),
+
+    /**
+     * JDK11存储经过性能分析的编译代码的codeCache初始值
+     */
+    PROFILED_NMETHODS_INIT("profiled_nmethods_init", "the number is init of profiled nmethods"),
+
+    /**
+     * JDK11存储经过性能分析的编译代码的codeCache使用值
+     */
+    PROFILED_NMETHODS_USED("profiled_nmethods_used", "the number is used of profiled nmethods"),
+
+    /**
+     * JDK11存储经过性能分析的编译代码的codeCache最大值
+     */
+    PROFILED_NMETHODS_MAX("profiled_nmethods_max", "the number is max of profiled nmethods"),
+
+    /**
+     * JDK11存储经过性能分析的编译代码的codeCache提交值
+     */
+    PROFILED_NMETHODS_COMMITTED("profiled_nmethods_committed", "the number is committed of profiled nmethods"),
+
+    /**
+     * JDK11存储未经过性能分析的编译代码的codeCache初始值
+     */
+    NON_PROFILED_NMETHODS_INIT("non_profiled_nmethods_init", "the number is init of non-profiled nmethods"),
+
+    /**
+     * JDK11存储未经过性能分析的编译代码的codeCache使用值
+     */
+    NON_PROFILED_NMETHODS_USED("non_profiled_nmethods_used", "the number is used of non-profiled nmethods"),
+
+    /**
+     * JDK11存储未经过性能分析的编译代码的codeCache最大值
+     */
+    NON_PROFILED_NMETHODS_MAX("non_profiled_nmethods_max", "the number is max of non-profiled nmethods"),
+
+    /**
+     * JDK11存储未经过性能分析的编译代码的codeCache提交值
+     */
+    NON_PROFILED_NMETHODS_COMMITTED("non_profiled_nmethods_committed",
+            "the number is committed of non-profiled nmethods"),
+
+    /**
+     * JDK11的Epsilon收集器初始值
+     */
+    EPSILON_HEAP_INIT("epsilon_heap_init", "the number is init of Epsilon Heap"),
+
+    /**
+     * JDK11的Epsilon收集器使用值
+     */
+    EPSILON_HEAP_USED("epsilon_heap_used", "the number is used of Epsilon Heap"),
+
+    /**
+     * JDK11的Epsilon收集器最大值
+     */
+    EPSILON_HEAP_MAX("epsilon_heap_max", "the number is max of Epsilon Heap"),
+
+    /**
+     * JDK11的Epsilon收集器提交值
+     */
+    EPSILON_HEAP_COMMITTED("epsilon_heap_committed", "the number is committed of Epsilon Heap");
 
     /**
      * 名称


### PR DESCRIPTION
【修复issue】#1283

【修改内容】
1. 修改了monitor插件中性能指标，增加了JDK11新增的指标
2. 修改了monitor插件中GC相关的指标处理方式，适应JDK11新增的GC
3. 修改了部分流水线文件

【用例描述】修改了monitor集成测试性能指标遍历。原因：JDK11后删除了一些指标新增了一些指标，需要根据不同版本适配更改

【自测情况】本地静态检查通过；UT通过；

【影响范围】monitor可采集的指标更改，文档需要更新