### PR TITLE
流量标签透传特性：httpclient3、Okhttp2、Jdk httpclient补充UT & 优化现有UT

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -44,11 +44,13 @@
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
             <version>${commons-httpclient.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractClientInterceptor.java
@@ -32,11 +32,6 @@ import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
  * @since 2023-07-18
  */
 public abstract class AbstractClientInterceptor<Carrier> extends AbstractInterceptor {
-    /**
-     * 过滤一次处理过程中拦截器的多次调用
-     */
-    protected static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
-
     protected final TagTransmissionConfig tagTransmissionConfig;
 
     /**

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractServerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/AbstractServerInterceptor.java
@@ -32,11 +32,6 @@ import java.util.Map;
  * @since 2023-07-18
  */
 public abstract class AbstractServerInterceptor<Carrier> extends AbstractInterceptor {
-    /**
-     * 过滤一次处理过程中拦截器的多次调用
-     */
-    protected static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
-
     protected final TagTransmissionConfig tagTransmissionConfig;
 
     /**

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
@@ -32,6 +32,11 @@ import java.util.List;
  * @since 2023-08-08
  */
 public class JdkHttpClientInterceptor extends AbstractClientInterceptor<MessageHeader> {
+    /**
+     * 过滤一次处理过程中拦截器的多次调用
+     */
+    protected static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
+
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
         if (LOCK_MARK.get() != null) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
@@ -32,6 +32,11 @@ import java.util.List;
  * @since 2023-08-08
  */
 public class OkHttp2xInterceptor extends AbstractClientInterceptor<Builder> {
+    /**
+     * 过滤一次处理过程中拦截器的多次调用
+     */
+    protected static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
+
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
         if (LOCK_MARK.get() != null) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptor.java
@@ -35,6 +35,11 @@ import javax.servlet.http.HttpServletRequest;
  * @since 2023-07-18
  */
 public class HttpServletInterceptor extends AbstractServerInterceptor<HttpServletRequest> {
+    /**
+     * 过滤一次处理过程中拦截器的多次调用
+     */
+    protected static final ThreadLocal<Boolean> LOCK_MARK = new ThreadLocal<>();
+
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
         if (LOCK_MARK.get() != null) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/BaseInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/BaseInterceptorTest.java
@@ -57,6 +57,7 @@ public class BaseInterceptorTest {
 
     @After
     public void after() {
+        TrafficUtils.removeTrafficTag();
         pluginConfigManagerMockedStatic.close();
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ExecutorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ExecutorInterceptorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.interceptors;
+package com.huaweicloud.sermant.tag.transmission.interceptors.crossthread;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ScheduledExecutorServiceInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ScheduledExecutorServiceInterceptorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.interceptors;
+package com.huaweicloud.sermant.tag.transmission.interceptors.crossthread;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpclient;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
+
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * HttpClient3xInterceptor 单元测试
+ *
+ * @author lilai
+ * @since 2023-08-17
+ */
+public class HttpClient3xInterceptorTest extends BaseInterceptorTest {
+    private final HttpClient3xInterceptor interceptor;
+
+    private final Object[] arguments;
+
+    public HttpClient3xInterceptorTest() {
+        this.interceptor = new HttpClient3xInterceptor();
+        this.arguments = new Object[3];
+    }
+
+    @Test
+    public void testHttpClient3() {
+        ExecuteContext context;
+        ExecuteContext resContext;
+        Map<String, List<String>> addHeaders = new HashMap<>();
+        Map<String, List<String>> tags = new HashMap<>();
+        TrafficUtils.removeTrafficTag();
+
+        // 无Headers无Tags
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(0, ((HttpMethod) resContext.getArguments()[1]).getRequestHeaders().length);
+        TrafficUtils.removeTrafficTag();
+
+        // 有Headers无Tags
+        addHeaders.put("defaultKey", Collections.singletonList("defaultValue"));
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(1, ((HttpMethod) resContext.getArguments()[1]).getRequestHeaders().length);
+        Assert.assertEquals("defaultValue",
+                ((HttpMethod) resContext.getArguments()[1]).getRequestHeaders()[0].getValue()
+        );
+        TrafficUtils.removeTrafficTag();
+
+        // 有Headers有Tags
+        List<String> ids = new ArrayList<>();
+        ids.add("testId001");
+        ids.add("testId002");
+        tags.put("id", ids);
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(1, ((HttpMethod) resContext.getArguments()[1]).getRequestHeaders("id").length);
+        Assert.assertEquals("testId001",
+                ((HttpMethod) resContext.getArguments()[1]).getRequestHeaders("id")[0].getValue());
+        TrafficUtils.removeTrafficTag();
+
+        // 测试TagTransmissionConfig开关关闭时
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(0, ((HttpMethod) resContext.getArguments()[1]).getRequestHeaders("id").length);
+        tagTransmissionConfig.setEnabled(true);
+        TrafficUtils.removeTrafficTag();
+    }
+
+    private ExecuteContext buildContext(Map<String, List<String>> addHeaders) {
+        HttpMethod httpMethod = new GetMethod("sermant.io");
+        for (Map.Entry<String, List<String>> entry : addHeaders.entrySet()) {
+            for (String val : entry.getValue()) {
+                httpMethod.setRequestHeader(entry.getKey(), val);
+            }
+        }
+
+        arguments[1] = httpMethod;
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient4xInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient4xInterceptorTest.java
@@ -14,107 +14,98 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.interceptors;
+package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpclient;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
-import com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka.KafkaProducerInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
 
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 /**
- * 测试KafkaProducerInterceptor
+ * 测试HttpClient4xInterceptor
  *
  * @author tangle
  * @since 2023-07-27
  */
-public class KafkaProducerInterceptorInterceptorTest extends BaseInterceptorTest {
-    private final KafkaProducerInterceptor interceptor;
+public class HttpClient4xInterceptorTest extends BaseInterceptorTest {
+    private final HttpClient4xInterceptor interceptor;
 
     private final Object[] arguments;
 
-    public KafkaProducerInterceptorInterceptorTest() {
-        interceptor = new KafkaProducerInterceptor();
+    public HttpClient4xInterceptorTest() {
+        interceptor = new HttpClient4xInterceptor();
         arguments = new Object[2];
     }
 
     @Test
-    public void testKafkaProducer() {
+    public void testClient() {
         ExecuteContext context;
         ExecuteContext resContext;
         Map<String, List<String>> addHeaders = new HashMap<>();
         Map<String, List<String>> tags = new HashMap<>();
         TrafficUtils.removeTrafficTag();
 
+        // 无Headers无Tags
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(0, ((HttpRequest) resContext.getArguments()[1]).getAllHeaders().length);
+        TrafficUtils.removeTrafficTag();
+
         // 有Headers无Tags
         addHeaders.put("defaultKey", Collections.singletonList("defaultValue"));
         context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
         resContext = interceptor.before(context);
-        Assert.assertEquals(getValuesFromRecord(resContext, "defaultKey"), Collections.singletonList("defaultValue"));
+        Assert.assertEquals(1, ((HttpRequest) resContext.getArguments()[1]).getAllHeaders().length);
+        Assert.assertEquals("defaultValue", ((HttpRequest) resContext.getArguments()[1]).getAllHeaders()[0].getValue());
+        TrafficUtils.removeTrafficTag();
 
         // 有Headers有Tags
         List<String> ids = new ArrayList<>();
         ids.add("testId001");
         ids.add("testId002");
         tags.put("id", ids);
-        TrafficUtils.updateTrafficTag(tags);
         context = buildContext(addHeaders);
-        resContext = interceptor.before(context);
-        Assert.assertEquals(getValuesFromRecord(resContext, "id"), ids);
-
-        // 第二次生产，测试tags是否污染其他消费
-        tags.clear();
-        List<String> names = new ArrayList<>();
-        names.add("testName001");
-        tags.put("name", names);
         TrafficUtils.updateTrafficTag(tags);
-        context = buildContext(addHeaders);
         resContext = interceptor.before(context);
-        Assert.assertEquals(getValuesFromRecord(resContext, "id"), new ArrayList<>());
-        Assert.assertEquals(getValuesFromRecord(resContext, "name"), names);
+        Assert.assertEquals(2, ((HttpRequest) resContext.getArguments()[1]).getHeaders("id").length);
+        Assert.assertEquals("testId001", ((HttpRequest) resContext.getArguments()[1]).getHeaders("id")[0].getValue());
+        TrafficUtils.removeTrafficTag();
 
         // 测试TagTransmissionConfig开关关闭时
         tagTransmissionConfig.setEnabled(false);
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
         resContext = interceptor.before(context);
-        Assert.assertEquals(context, resContext);
-    }
-
-    private List<String> getValuesFromRecord(ExecuteContext resContext, String key) {
-        Headers headers = ((ProducerRecord) resContext.getArguments()[0]).headers();
-        if (headers.headers(key) == null) {
-            return null;
-        }
-        List<String> res = new ArrayList<>();
-        Iterator<Header> iterator = headers.headers(key).iterator();
-        while (iterator.hasNext()) {
-            Header header = iterator.next();
-            byte[] bts = header.value();
-            res.add(new String(bts, Charset.forName("UTF-8")));
-        }
-        return res;
+        Assert.assertEquals(0, ((HttpRequest) resContext.getArguments()[1]).getHeaders("id").length);
+        tagTransmissionConfig.setEnabled(true);
+        TrafficUtils.removeTrafficTag();
     }
 
     private ExecuteContext buildContext(Map<String, List<String>> addHeaders) {
-        ProducerRecord producerRecord = new ProducerRecord<>("topic", "value");
-        Headers headers = producerRecord.headers();
+        HttpRequestBase httpRequestBase = new HttpRequestBase() {
+            @Override
+            public String getMethod() {
+                return null;
+            }
+        };
         for (Map.Entry<String, List<String>> entry : addHeaders.entrySet()) {
             for (String val : entry.getValue()) {
-                headers.add(entry.getKey(), val.getBytes());
+                httpRequestBase.addHeader(entry.getKey(), val);
             }
         }
-        arguments[0] = producerRecord;
+        arguments[1] = httpRequestBase;
         return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.okhttp;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
+
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.Request.Builder;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OkHttp2xInterceptor 单元测试
+ *
+ * @author lilai
+ * @since 2023-08-17
+ */
+public class OkHttp2xInterceptorTest extends BaseInterceptorTest {
+    private final OkHttp2xInterceptor interceptor;
+
+    public OkHttp2xInterceptorTest() {
+        this.interceptor = new OkHttp2xInterceptor();
+    }
+
+    @Test
+    public void testHttpClient3() {
+        ExecuteContext context;
+        ExecuteContext resContext;
+        Builder requestBuilder;
+        Headers.Builder headerBuilder;
+        List<String> nameAndValues;
+        Map<String, List<String>> addHeaders = new HashMap<>();
+        Map<String, List<String>> tags = new HashMap<>();
+        TrafficUtils.removeTrafficTag();
+
+        // 无Headers无Tags
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        requestBuilder = (Builder) resContext.getObject();
+        headerBuilder = (Headers.Builder) ReflectUtils.getFieldValue(requestBuilder, "headers").get();
+        nameAndValues = (List<String>) ReflectUtils.getFieldValue(headerBuilder, "namesAndValues").get();
+        Assert.assertEquals(0, nameAndValues.size());
+        TrafficUtils.removeTrafficTag();
+
+        // 有Headers无Tags
+        addHeaders.put("defaultKey", Collections.singletonList("defaultValue"));
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        requestBuilder = (Builder) resContext.getObject();
+        headerBuilder = (Headers.Builder) ReflectUtils.getFieldValue(requestBuilder, "headers").get();
+        nameAndValues = (List<String>) ReflectUtils.getFieldValue(headerBuilder, "namesAndValues").get();
+        Assert.assertEquals(2, nameAndValues.size());
+        Assert.assertEquals("defaultValue", (headerBuilder.get("defaultKey")));
+        TrafficUtils.removeTrafficTag();
+
+        // 有Headers有Tags
+        List<String> ids = new ArrayList<>();
+        ids.add("testId001");
+        ids.add("testId002");
+        tags.put("id", ids);
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        requestBuilder = (Builder) resContext.getObject();
+        headerBuilder = (Headers.Builder) ReflectUtils.getFieldValue(requestBuilder, "headers").get();
+        nameAndValues = (List<String>) ReflectUtils.getFieldValue(headerBuilder, "namesAndValues").get();
+        Assert.assertEquals(6, nameAndValues.size());
+        Assert.assertEquals("testId002", headerBuilder.get("id"));
+        TrafficUtils.removeTrafficTag();
+
+        // 测试TagTransmissionConfig开关关闭时
+        tagTransmissionConfig.setEnabled(false);
+        addHeaders.clear();
+        context = buildContext(addHeaders);
+        TrafficUtils.updateTrafficTag(tags);
+        resContext = interceptor.before(context);
+        requestBuilder = (Builder) resContext.getObject();
+        headerBuilder = (Headers.Builder) ReflectUtils.getFieldValue(requestBuilder, "headers").get();
+        nameAndValues = (List<String>) ReflectUtils.getFieldValue(headerBuilder, "namesAndValues").get();
+        Assert.assertEquals(0, nameAndValues.size());
+        tagTransmissionConfig.setEnabled(true);
+        TrafficUtils.removeTrafficTag();
+    }
+
+    private ExecuteContext buildContext(Map<String, List<String>> addHeaders) {
+        Builder builder = new Builder();
+        for (Map.Entry<String, List<String>> entry : addHeaders.entrySet()) {
+            for (String val : entry.getValue()) {
+                builder.addHeader(entry.getKey(), val);
+            }
+        }
+
+        return ExecuteContext.forMemberMethod(builder, null, null, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptorTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.interceptors;
+package com.huaweicloud.sermant.tag.transmission.interceptors.http.server;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
-import com.huaweicloud.sermant.tag.transmission.interceptors.http.server.HttpServletInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
 
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.connector.Request;
@@ -39,12 +39,12 @@ import java.util.Map;
  * @author tangle
  * @since 2023-07-27
  */
-public class HttpServletInterceptorInterceptorTest extends BaseInterceptorTest {
+public class HttpServletInterceptorTest extends BaseInterceptorTest {
     private final HttpServletInterceptor interceptor;
 
     private final Object[] arguments;
 
-    public HttpServletInterceptorInterceptorTest() {
+    public HttpServletInterceptorTest() {
         interceptor = new HttpServletInterceptor();
         arguments = new Object[2];
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaConsumerRecordInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaConsumerRecordInterceptorTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.interceptors;
+package com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
-import com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka.KafkaConsumerRecordInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
@@ -37,10 +37,10 @@ import java.util.Map;
  * @author tangle
  * @since 2023-07-27
  */
-public class KafkaConsumerRecordInterceptorInterceptorTest extends BaseInterceptorTest {
+public class KafkaConsumerRecordInterceptorTest extends BaseInterceptorTest {
     private final KafkaConsumerRecordInterceptor interceptor;
 
-    public KafkaConsumerRecordInterceptorInterceptorTest() {
+    public KafkaConsumerRecordInterceptorTest() {
         interceptor = new KafkaConsumerRecordInterceptor();
     }
 
@@ -71,7 +71,7 @@ public class KafkaConsumerRecordInterceptorInterceptorTest extends BaseIntercept
         tags.put("id", ids);
         context = buildContext(addHeaders, tags);
         interceptor.before(context);
-        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag().get("id").size(), 2);
+        Assert.assertEquals(2, TrafficUtils.getTrafficTag().getTag().get("id").size());
         Assert.assertNull(TrafficUtils.getTrafficTag().getTag().get("name"));
 
         // 第二次消费，测试tags是否污染其他消费
@@ -82,7 +82,7 @@ public class KafkaConsumerRecordInterceptorInterceptorTest extends BaseIntercept
         context = buildContext(addHeaders, tags);
         interceptor.before(context);
         Assert.assertNull(TrafficUtils.getTrafficTag().getTag().get("id"));
-        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag().get("name").size(), 1);
+        Assert.assertEquals(1, TrafficUtils.getTrafficTag().getTag().get("name").size());
 
         // 测试TagTransmissionConfig开关关闭时
         TrafficUtils.removeTrafficTag();

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaProducerInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaProducerInterceptorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 测试KafkaProducerInterceptor
+ *
+ * @author tangle
+ * @since 2023-07-27
+ */
+public class KafkaProducerInterceptorTest extends BaseInterceptorTest {
+    private final KafkaProducerInterceptor interceptor;
+
+    private final Object[] arguments;
+
+    public KafkaProducerInterceptorTest() {
+        interceptor = new KafkaProducerInterceptor();
+        arguments = new Object[2];
+    }
+
+    @Test
+    public void testKafkaProducer() {
+        ExecuteContext context;
+        ExecuteContext resContext;
+        Map<String, List<String>> addHeaders = new HashMap<>();
+        Map<String, List<String>> tags = new HashMap<>();
+        TrafficUtils.removeTrafficTag();
+
+        // 有Headers无Tags
+        addHeaders.put("defaultKey", Collections.singletonList("defaultValue"));
+        context = buildContext(addHeaders);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(Collections.singletonList("defaultValue"), getValuesFromRecord(resContext, "defaultKey"));
+
+        // 有Headers有Tags
+        List<String> ids = new ArrayList<>();
+        ids.add("testId001");
+        ids.add("testId002");
+        tags.put("id", ids);
+        TrafficUtils.updateTrafficTag(tags);
+        context = buildContext(addHeaders);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(ids, getValuesFromRecord(resContext, "id"));
+        TrafficUtils.removeTrafficTag();
+
+        // 第二次生产，测试tags是否污染其他消费
+        tags.clear();
+        List<String> names = new ArrayList<>();
+        names.add("testName001");
+        tags.put("name", names);
+        TrafficUtils.updateTrafficTag(tags);
+        context = buildContext(addHeaders);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(0, getValuesFromRecord(resContext, "id").size());
+        Assert.assertEquals(names, getValuesFromRecord(resContext, "name"));
+        TrafficUtils.removeTrafficTag();
+
+        // 测试TagTransmissionConfig开关关闭时
+        tagTransmissionConfig.setEnabled(false);
+        TrafficUtils.updateTrafficTag(tags);
+        context = buildContext(addHeaders);
+        resContext = interceptor.before(context);
+        Assert.assertEquals(0, getValuesFromRecord(resContext, "name").size());
+        tagTransmissionConfig.setEnabled(true);
+        TrafficUtils.removeTrafficTag();
+    }
+
+    private List<String> getValuesFromRecord(ExecuteContext resContext, String key) {
+        Headers headers = ((ProducerRecord) resContext.getArguments()[0]).headers();
+        if (headers.headers(key) == null) {
+            return null;
+        }
+        List<String> res = new ArrayList<>();
+        Iterator<Header> iterator = headers.headers(key).iterator();
+        while (iterator.hasNext()) {
+            Header header = iterator.next();
+            byte[] bts = header.value();
+            res.add(new String(bts, Charset.forName("UTF-8")));
+        }
+        return res;
+    }
+
+    private ExecuteContext buildContext(Map<String, List<String>> addHeaders) {
+        ProducerRecord producerRecord = new ProducerRecord<>("topic", "value");
+        Headers headers = producerRecord.headers();
+        for (Map.Entry<String, List<String>> entry : addHeaders.entrySet()) {
+            for (String val : entry.getValue()) {
+                headers.add(entry.getKey(), val.getBytes());
+            }
+        }
+        arguments[0] = producerRecord;
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqConsumerInterceptorTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.tag.transmission.interceptors;
+package com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
-import com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq.RocketmqConsumerInterceptor;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
 
 import org.apache.rocketmq.common.message.Message;
 import org.junit.Assert;
@@ -44,10 +44,10 @@ import java.util.Map;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(RocketmqConsumerInterceptor.class)
-public class RocketmqConsumerInterceptorInterceptorTest extends BaseInterceptorTest {
+public class RocketmqConsumerInterceptorTest extends BaseInterceptorTest {
     private final RocketmqConsumerInterceptor interceptor;
 
-    public RocketmqConsumerInterceptorInterceptorTest() throws Exception {
+    public RocketmqConsumerInterceptorTest() throws Exception {
         RocketmqConsumerInterceptor interceptorBase = new RocketmqConsumerInterceptor();
         interceptor = PowerMockito.spy(interceptorBase);
         PowerMockito.doReturn(true).when(interceptor, "isRocketMqStackTrace", Mockito.any());
@@ -101,7 +101,7 @@ public class RocketmqConsumerInterceptorInterceptorTest extends BaseInterceptorT
         tags.put("id", Collections.singletonList("testId001"));
         context = buildContext(addHeaders, tags);
         interceptor.before(context);
-        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag().get("id").get(0), "testId001");
+        Assert.assertEquals("testId001", TrafficUtils.getTrafficTag().getTag().get("id").get(0));
         Assert.assertNull(TrafficUtils.getTrafficTag().getTag().get("name"));
 
         // 第二次消费，测试tags是否污染其他消费
@@ -112,7 +112,7 @@ public class RocketmqConsumerInterceptorInterceptorTest extends BaseInterceptorT
         context = buildContext(addHeaders, tags);
         interceptor.before(context);
         Assert.assertNull(TrafficUtils.getTrafficTag().getTag().get("id"));
-        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag().get("name").get(0), "testName001");
+        Assert.assertEquals("testName001", TrafficUtils.getTrafficTag().getTag().get("name").get(0));
 
         // 测试TagTransmissionConfig开关关闭时
         TrafficUtils.removeTrafficTag();


### PR DESCRIPTION

【修复issue】#1244

【修改内容】httpclient3、Okhttp2、Jdk httpclient 拦截器单元测试

【用例描述】详见UT

【自测情况】1、本地静态检查通过；2、当前UT覆盖率crossthread94%，http80%，mq73%

【影响范围】无
