### PR TITLE
流量标签透传支持sofarpc5.0+版本

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -26,6 +26,7 @@
         <powermock.version>2.0.9</powermock.version>
         <dubbo.version>3.2.0</dubbo.version>
         <alibaba.dubbo.version>2.6.12</alibaba.dubbo.version>
+        <sofa-rpc.version>5.4.0</sofa-rpc.version>
     </properties>
 
     <dependencies>
@@ -78,6 +79,12 @@
             <groupId>org.apache.dubbo</groupId>
             <artifactId>dubbo</artifactId>
             <version>${dubbo.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-all</artifactId>
+            <version>${sofa-rpc.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/sofarpc/SofaRpcClientDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/sofarpc/SofaRpcClientDeclarer.java
@@ -1,0 +1,46 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.sofarpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc.SofaRpcClientInterceptor;
+
+/**
+ * sofarpc client端declarer，支持5.0+版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-22
+ **/
+public class SofaRpcClientDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "com.alipay.sofa.rpc.filter.ConsumerInvoker";
+
+    private static final String METHOD_NAME = "invoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME),
+                new SofaRpcClientInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/sofarpc/SofaRpcServerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/sofarpc/SofaRpcServerDeclarer.java
@@ -1,0 +1,46 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.sofarpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc.SofaRpcServerInterceptor;
+
+/**
+ * sofarpc server端declarer，，支持5.0+版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-22
+ **/
+public class SofaRpcServerDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "com.alipay.sofa.rpc.filter.ProviderInvoker";
+
+    private static final String METHOD_NAME = "invoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME),
+                new SofaRpcServerInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptor.java
@@ -1,0 +1,68 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
+
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+
+import java.util.List;
+
+/**
+ * sofarpc client端interceptor，支持5.0+版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-22
+ **/
+public class SofaRpcClientInterceptor extends AbstractClientInterceptor<SofaRequest> {
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments == null || arguments.length == 0) {
+            return context;
+        }
+        Object argument = arguments[0];
+        if (argument instanceof SofaRequest) {
+            injectTrafficTag2Carrier((SofaRequest) argument);
+        }
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        return context;
+    }
+
+    /**
+     * 向SofaRequest中添加流量标签
+     *
+     * @param sofaRequest sofarpc客服端 标签传递载体
+     */
+    @Override
+    protected void injectTrafficTag2Carrier(SofaRequest sofaRequest) {
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+            sofaRequest.addRequestProp(key, values.get(0));
+        }
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
+
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * sofarpc server端interceptor，支持5.0+版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-22
+ **/
+public class SofaRpcServerInterceptor extends AbstractServerInterceptor<SofaRequest> {
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments == null || arguments.length == 0) {
+            return context;
+        }
+        Object argument = arguments[0];
+        if (argument instanceof SofaRequest) {
+            TrafficUtils.updateTrafficTag(extractTrafficTagFromCarrier((SofaRequest) argument));
+        }
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        TrafficUtils.removeTrafficTag();
+        return context;
+    }
+
+    /**
+     * 从SofaRequest中解析流量标签
+     *
+     * @param sofaRequest sofarpc服务端的流量标签载体
+     * @return 流量标签
+     */
+    @Override
+    protected Map<String, List<String>> extractTrafficTagFromCarrier(SofaRequest sofaRequest) {
+        Map<String, List<String>> tag = new HashMap<>();
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            Object value = sofaRequest.getRequestProp(key);
+            if (value instanceof String) {
+                tag.put(key, Collections.singletonList((String) value));
+                continue;
+            }
+
+            // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
+            tag.put(key, null);
+        }
+        return tag;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -23,6 +23,8 @@ com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.AlibabaDubboProvide
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.ApacheDubboProviderDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.ApacheDubboConsumerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.AlibabaDubboConsumerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.sofarpc.SofaRpcClientDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.sofarpc.SofaRpcServerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.mq.kafka.KafkaProducerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.http.client.httpclient.HttpClient3xDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.http.client.okhttp.OkHttp2xDeclarer


### PR DESCRIPTION
【修复issue】#1244

【修改内容】增加了SofaRpcClientDeclarer、SofaRpcServerDeclarer、SofaRpcClientInterceptor和SofaRpcServerInterceptor，用于拦截sofarpc的客户端和服务端以支持流量标签透传

【用例描述】不涉及

【自测情况】1、本地静态检查通过；2、UT后续补充

【影响范围】后续更新插件使用手册