### PR TITLE
流量标签透传插件支持grpc框架

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/pom.xml
@@ -26,6 +26,8 @@
         <powermock.version>2.0.9</powermock.version>
         <dubbo.version>3.2.0</dubbo.version>
         <alibaba.dubbo.version>2.6.12</alibaba.dubbo.version>
+        <grpc.version>1.52.1</grpc.version>
+        <protobuf.version>3.18.0</protobuf.version>
         <sofa-rpc.version>5.4.0</sofa-rpc.version>
         <servicecomb-java-chassis.version>2.6.0</servicecomb-java-chassis.version>
     </properties>
@@ -70,6 +72,18 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka-clients.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/grpc/ClientCallImplDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/grpc/ClientCallImplDeclarer.java
@@ -1,0 +1,46 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.grpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc.ClientCallImplInterceptor;
+
+/**
+ * grpc client端Declarer，拦截header参数注入流量标签，支持grpc 1.13+版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-21
+ **/
+public class ClientCallImplDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "io.grpc.internal.ClientCallImpl";
+
+    private static final String METHOD_NAMES = "start";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAMES),
+                new ClientCallImplInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/grpc/GrpcServerDeclarer.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/declarers/rpc/grpc/GrpcServerDeclarer.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.declarers.rpc.grpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc.GrpcServerInterceptor;
+
+/**
+ * grpc server端declare，支持grpc 1.13+版本
+ *
+ * @author daizhenyu
+ * @since 2023-08-15
+ **/
+public class GrpcServerDeclarer extends AbstractPluginDeclarer {
+    private static final String ENHANCE_CLASS = "io.grpc.internal.AbstractServerImplBuilder";
+
+    private static final String METHOD_NAME = "build";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals(METHOD_NAME), new GrpcServerInterceptor())
+        };
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/enumeration/SpecialExecutor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/enumeration/SpecialExecutor.java
@@ -1,0 +1,68 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.enumeration;
+
+/**
+ * 特殊的线程池枚举类，该类线程池不会使用新线程执行方法
+ *
+ * @author daizhenyu
+ * @since 2023-09-04
+ **/
+public enum SpecialExecutor {
+    /**
+     * grpc的ThreadlessExecutor线程池。
+     * 对于该线程池，主线程会创建子线程提交线程任务，然后主线程执行。
+     * ThreadlessExecutor协调两个线程的任务,形成生产消费的模式
+     */
+    THREAD_LESS_EXECUTOR("ThreadlessExecutor"),
+
+    /**
+     * grpc的SynchronizationContext线程池。
+     * 对于该线程池，并不会使用新的线程执行线程任务，而是在调用该线程池的线程中依次执行线程池队列的任务。
+     */
+    SYNCHRONIZATION_CONTEXT("SynchronizationContext"),
+
+    /**
+     * 用于getSpecialExecutorByName方法寻找不到合适的线程池枚举对象时返回返回值
+     */
+    OTHER_EXECUTORS("otherExecutors");
+
+    private final String executorName;
+
+    SpecialExecutor(String executorName) {
+        this.executorName = executorName;
+    }
+
+    public String getExecutorName() {
+        return this.executorName;
+    }
+
+    /**
+     * 用于根据线程池名称获取线程池枚举对象
+     *
+     * @param name 线程池名称
+     * @return SpecialExecutor对象
+     */
+    public static SpecialExecutor getSpecialExecutorByName(String name) {
+        for (SpecialExecutor value : values()) {
+            if (value.getExecutorName().equals(name)) {
+                return value;
+            }
+        }
+        return OTHER_EXECUTORS;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
+
+import io.grpc.Metadata;
+
+import java.util.List;
+
+/**
+ * grpc使用DynamicMessage调用服务端，拦截header参数注入流量标签
+ *
+ * @author daizhenyu
+ * @since 2023-08-21
+ **/
+public class ClientCallImplInterceptor extends AbstractClientInterceptor<Metadata> {
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+
+        // 被拦截方法的入参数量为2
+        if (arguments == null || arguments.length <= 1) {
+            return context;
+        }
+        Object metadataObject = arguments[1];
+        if (metadataObject instanceof Metadata) {
+            injectTrafficTag2Carrier((Metadata) metadataObject);
+        }
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        return context;
+    }
+
+    @Override
+    protected void injectTrafficTag2Carrier(Metadata header) {
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+            header.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), values.get(0));
+        }
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/GrpcServerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/GrpcServerInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
+
+import io.grpc.Metadata;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * grpc 服务端拦截器
+ *
+ * @author daizhenyu
+ * @since 2023-08-15
+ **/
+public class GrpcServerInterceptor extends AbstractServerInterceptor<Metadata> {
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        Object object = context.getObject();
+        if (object == null) {
+            return context;
+        }
+        if (object instanceof ServerBuilder) {
+            ServerBuilder<?> builder = (ServerBuilder) object;
+            ServerInterceptor interceptor = new ServerHeaderInterceptor();
+            builder.intercept(interceptor);
+        }
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context) {
+        return context;
+    }
+
+    @Override
+    protected Map<String, List<String>> extractTrafficTagFromCarrier(Metadata metadata) {
+        return new HashMap<>();
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
+
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * grpc内部的server interceptor，从grpc的header中提取流量标签
+ *
+ * @author daizhenyu
+ * @since 2023-08-15
+ **/
+public class ServerHeaderInterceptor implements ServerInterceptor {
+    protected final TagTransmissionConfig tagTransmissionConfig;
+
+    /**
+     * 构造方法
+     */
+    public ServerHeaderInterceptor() {
+        tagTransmissionConfig = PluginConfigManager.getPluginConfig(TagTransmissionConfig.class);
+    }
+
+    /**
+     * 使用grpc提供的server端拦截器获取header中的流量标签
+     */
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            final Metadata requestHeaders,
+            ServerCallHandler<ReqT, RespT> next) {
+        // 处理header
+        if (requestHeaders != null) {
+            extractTrafficTagFromCarrier(requestHeaders);
+        }
+        return next.startCall(new SimpleForwardingServerCall<ReqT, RespT>(call) {
+        }, requestHeaders);
+    }
+
+    private void extractTrafficTagFromCarrier(Metadata requestHeaders) {
+        Map<String, List<String>> tag = new HashMap<>();
+        for (String key : tagTransmissionConfig.getTagKeys()) {
+            String value = requestHeaders.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
+
+            // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
+            if (value == null) {
+                tag.put(key, null);
+                continue;
+            }
+            tag.put(key, Collections.singletonList(value));
+        }
+        TrafficUtils.updateTrafficTag(tag);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/pojo/TrafficMessage.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/pojo/TrafficMessage.java
@@ -1,0 +1,65 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.pojo;
+
+import com.huaweicloud.sermant.core.utils.tag.TrafficData;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+
+/**
+ * TrafficMessage，包含TrafficTag和TrafficData
+ *
+ * @author daizhenyu
+ * @since 2023-09-05
+ **/
+public class TrafficMessage {
+    private TrafficTag trafficTag;
+
+    private TrafficData trafficData;
+
+    /**
+     * 无参构造方法
+     */
+    public TrafficMessage() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param trafficTag 流量标签
+     * @param trafficData 流量数据
+     */
+    public TrafficMessage(TrafficTag trafficTag, TrafficData trafficData) {
+        this.trafficTag = trafficTag;
+        this.trafficData = trafficData;
+    }
+
+    public void setTrafficData(TrafficData trafficData) {
+        this.trafficData = trafficData;
+    }
+
+    public void setTrafficTag(TrafficTag trafficTag) {
+        this.trafficTag = trafficTag;
+    }
+
+    public TrafficTag getTrafficTag() {
+        return trafficTag;
+    }
+
+    public TrafficData getTrafficData() {
+        return trafficData;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/CallableWrapper.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/CallableWrapper.java
@@ -16,8 +16,7 @@
 
 package com.huaweicloud.sermant.tag.transmission.wrapper;
 
-import com.huaweicloud.sermant.core.utils.tag.TrafficData;
-import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.tag.transmission.pojo.TrafficMessage;
 
 import java.util.concurrent.Callable;
 
@@ -33,12 +32,12 @@ public class CallableWrapper<T> extends AbstractThreadWrapper<T> implements Call
      * 构造方法
      *
      * @param callable callable
-     * @param trafficTag 请求标记
-     * @param trafficData 请求数据
+     * @param trafficMessage 流量信息
      * @param cannotTransmit 执行方法之前是否需要删除线程变量
+     * @param executorName 线程池名称
      */
-    public CallableWrapper(Callable<T> callable, TrafficTag trafficTag, TrafficData trafficData,
-            boolean cannotTransmit) {
-        super(null, callable, trafficTag, trafficData, cannotTransmit);
+    public CallableWrapper(Callable<T> callable, TrafficMessage trafficMessage,
+            boolean cannotTransmit, String executorName) {
+        super(null, callable, trafficMessage, cannotTransmit, executorName);
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/RunnableAndCallableWrapper.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/wrapper/RunnableAndCallableWrapper.java
@@ -16,8 +16,7 @@
 
 package com.huaweicloud.sermant.tag.transmission.wrapper;
 
-import com.huaweicloud.sermant.core.utils.tag.TrafficData;
-import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.tag.transmission.pojo.TrafficMessage;
 
 import java.util.concurrent.Callable;
 
@@ -34,12 +33,12 @@ public class RunnableAndCallableWrapper<T> extends AbstractThreadWrapper<T> impl
      *
      * @param runnable runnable
      * @param callable callable
-     * @param trafficTag 请求标记
-     * @param trafficData 请求数据
+     * @param trafficMessage 流量信息
      * @param cannotTransmit 执行方法之前是否需要删除线程变量
+     * @param executorName 线程池名称
      */
-    public RunnableAndCallableWrapper(Runnable runnable, Callable<T> callable, TrafficTag trafficTag,
-            TrafficData trafficData, boolean cannotTransmit) {
-        super(runnable, callable, trafficTag, trafficData, cannotTransmit);
+    public RunnableAndCallableWrapper(Runnable runnable, Callable<T> callable, TrafficMessage trafficMessage,
+            boolean cannotTransmit, String executorName) {
+        super(runnable, callable, trafficMessage, cannotTransmit, executorName);
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -25,6 +25,8 @@ com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.ApacheDubboConsumer
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.dubbo.AlibabaDubboConsumerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.sofarpc.SofaRpcClientDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.sofarpc.SofaRpcServerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.grpc.GrpcServerDeclarer
+com.huaweicloud.sermant.tag.transmission.declarers.rpc.grpc.ClientCallImplDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.servicecomb.ServiceCombRpcConsumerDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.rpc.servicecomb.ServiceCombRpcProviderDeclarer
 com.huaweicloud.sermant.tag.transmission.declarers.mq.kafka.KafkaProducerDeclarer

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ExecutorInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ExecutorInterceptorTest.java
@@ -21,6 +21,7 @@ import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
 import com.huaweicloud.sermant.tag.transmission.BaseTest;
 import com.huaweicloud.sermant.tag.transmission.RunnableAndCallable;
 import com.huaweicloud.sermant.tag.transmission.interceptors.crossthread.ExecutorInterceptor;
+import com.huaweicloud.sermant.tag.transmission.pojo.TrafficMessage;
 import com.huaweicloud.sermant.tag.transmission.wrapper.CallableWrapper;
 import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableAndCallableWrapper;
 import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableWrapper;
@@ -68,7 +69,8 @@ public class ExecutorInterceptorTest extends BaseTest {
         TrafficUtils.updateTrafficTag(Collections.singletonMap("foo", Collections.singletonList("bar")));
 
         // 测试已经包装过了
-        RunnableWrapper<?> runnableWrapper = new RunnableWrapper<>(null, null, null, false);
+        TrafficMessage trafficMessage = new TrafficMessage(null, null);
+        RunnableWrapper<?> runnableWrapper = new RunnableWrapper<>(null, trafficMessage, false, null);
         arguments[0] = runnableWrapper;
         interceptor.before(context);
         Assert.assertEquals(runnableWrapper, context.getArguments()[0]);

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ScheduledExecutorServiceInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/crossthread/ScheduledExecutorServiceInterceptorTest.java
@@ -21,6 +21,7 @@ import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
 import com.huaweicloud.sermant.tag.transmission.BaseTest;
 import com.huaweicloud.sermant.tag.transmission.RunnableAndCallable;
 import com.huaweicloud.sermant.tag.transmission.interceptors.crossthread.ScheduledExecutorServiceInterceptor;
+import com.huaweicloud.sermant.tag.transmission.pojo.TrafficMessage;
 import com.huaweicloud.sermant.tag.transmission.wrapper.CallableWrapper;
 import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableAndCallableWrapper;
 import com.huaweicloud.sermant.tag.transmission.wrapper.RunnableWrapper;
@@ -68,7 +69,8 @@ public class ScheduledExecutorServiceInterceptorTest extends BaseTest {
         TrafficUtils.updateTrafficTag(Collections.singletonMap("foo", Collections.singletonList("bar")));
 
         // 测试已经包装过了
-        RunnableWrapper<?> runnableWrapper = new RunnableWrapper<>(null, null, null, false);
+        TrafficMessage trafficMessage = new TrafficMessage(null, null);
+        RunnableWrapper<?> runnableWrapper = new RunnableWrapper<>(null, trafficMessage, false, null);
         arguments[0] = runnableWrapper;
         interceptor.before(context);
         Assert.assertEquals(runnableWrapper, context.getArguments()[0]);


### PR DESCRIPTION
【修复issue】#1244

【修改内容】1. 增加了流量标签透传插件支持grpc框架的声明器和拦截器，用于拦截grpc的客户端和服务端透传流量标签。2. 修改了跨线程流量标签透传模块，增加了runnable包装类处理特殊线程池的逻辑，避免误删线程内的流量标签。

【用例描述】不涉及

【自测情况】1、本地静态检查清理通过；2、UT后续pr补充

【影响范围】1、插件使用手册