### PR TITLE
动态配置核心服务支持nacos：客户端包装类、异常类、监听器实体类

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -37,6 +37,7 @@ dynamic.config.userName=
 dynamic.config.password=
 dynamic.config.privateKey=
 dynamic.config.enableAuth=false
+dynamic.config.requestTimeout=3000
 
 # heartbeat config
 heartbeat.interval=30000

--- a/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
@@ -37,6 +37,7 @@ dynamic.config.userName=
 dynamic.config.password=
 dynamic.config.privateKey=
 dynamic.config.enableAuth=false
+dynamic.config.requestTimeout=3000
 
 # heartbeat config
 heartbeat.interval=30000

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/config/DynamicConfig.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/config/DynamicConfig.java
@@ -36,6 +36,8 @@ public class DynamicConfig implements BaseConfig {
 
     private static final int CONNECT_RETRY_TIMES = 5;
 
+    private static final int REQUEST_TIMEOUT = 3000;
+
     /**
      * 服务器连接超时时间
      */
@@ -79,6 +81,12 @@ public class DynamicConfig implements BaseConfig {
     private String privateKey;
 
     private boolean enableAuth = false;
+
+    /**
+     * 请求超时时间，nacos每次getConfig需要设置一个超时时间
+     */
+    @ConfigFieldKey("requestTimeout")
+    private int requestTimeout = REQUEST_TIMEOUT;
 
     public int getTimeoutValue() {
         return timeoutValue;
@@ -158,5 +166,13 @@ public class DynamicConfig implements BaseConfig {
 
     public void setEnableAuth(boolean enableAuth) {
         this.enableAuth = enableAuth;
+    }
+
+    public int getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    public void setRequestTimeout(int requestTimeout) {
+        this.requestTimeout = requestTimeout;
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/pom.xml
+++ b/sermant-agentcore/sermant-agentcore-implement/pom.xml
@@ -28,6 +28,7 @@
         <gpg.plugin.version>3.0.1</gpg.plugin.version>
         <javadoc.plugin.version>3.3.2</javadoc.plugin.version>
         <nexus.staging.plugin.version>1.6.7</nexus.staging.plugin.version>
+        <nacos.version>2.1.0</nacos.version>
     </properties>
 
     <dependencies>
@@ -81,6 +82,11 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-client</artifactId>
+            <version>${nacos.version}</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosBufferedClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosBufferedClient.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.config.DynamicConfig;
+import com.huaweicloud.sermant.core.utils.AesUtil;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.listener.Listener;
+import com.alibaba.nacos.api.exception.NacosException;
+
+import java.io.Closeable;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@link ConfigService}的包装，封装nacos原生api，提供更易用的api
+ *
+ * @author tangle
+ * @since 2023-08-17
+ */
+public class NacosBufferedClient implements Closeable {
+    /**
+     * configService连接状态type
+     */
+    public static final String KEY_CONNECTED = "UP";
+
+    /**
+     * 日志
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    /**
+     * 动态配置信息
+     */
+    private static final DynamicConfig CONFIG = ConfigManager.getConfig(DynamicConfig.class);
+
+    private ConfigService configService;
+
+    /**
+     * 新建NacosBufferedClient，初始化nacos客户端
+     *
+     * @param connectString 连接字符串，必须形如：{@code host:port[(,host:port)...]}
+     * @param sessionTimeout 会话超时时间
+     * @param namespace 命名空间
+     * @throws NacosInitException 依赖动态配置情况下，nacos初始化失败，需要中断Sermant
+     */
+    public NacosBufferedClient(String connectString, int sessionTimeout, String namespace) {
+        Properties properties = createProperties(connectString, sessionTimeout, namespace);
+        createConfigService(connectString, properties);
+    }
+
+    /**
+     * 新建NacosBufferedClient，初始化nacos客户端
+     *
+     * @param connectString 连接字符串，必须形如：{@code host:port[(,host:port)...]}
+     * @param sessionTimeout 会话超时时间
+     * @param namespace 命名空间
+     * @param userName 已加密的用户名
+     * @param password 已加密的密码
+     * @throws NacosInitException 依赖动态配置情况下，nacos初始化失败，需要中断Sermant
+     */
+    public NacosBufferedClient(String connectString, int sessionTimeout, String namespace, String userName,
+            String password) {
+        Properties properties = createProperties(connectString, sessionTimeout, namespace, userName, password);
+        createConfigService(connectString, properties);
+    }
+
+    /**
+     * 获取配置
+     *
+     * @param key 配置名称
+     * @param group 配置所在组
+     * @return 配置内容
+     */
+    public String getConfig(String key, String group) {
+        try {
+            final String data = this.configService.getConfig(key, group, CONFIG.getRequestTimeout());
+            return data == null ? "" : data;
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, "Nacos getConfig exception, msg is: {0}", e.getMessage());
+            return "";
+        }
+    }
+
+    /**
+     * 发布配置
+     *
+     * @param key 配置名称
+     * @param group 配置所在组
+     * @param content 配置内容
+     * @return 是否发布成功
+     */
+    public boolean publishConfig(String key, String group, String content) {
+        try {
+            return this.configService.publishConfig(key, group, content);
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, "Nacos publishConfig exception, msg is: {0}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 删除配置
+     *
+     * @param key 配置名称
+     * @param group 配置所在组
+     * @return 是否删除成功
+     */
+    public boolean removeConfig(String key, String group) {
+        try {
+            return this.configService.removeConfig(key, group);
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, "Nacos removeConfig exception, msg is: {0}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 添加监听
+     *
+     * @param key 配置名称
+     * @param group 配置所在组
+     * @param listener 监听器
+     * @return 是否提那家成功
+     */
+    public boolean addListener(String key, String group, Listener listener) {
+        try {
+            this.configService.addListener(key, group, listener);
+            return true;
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, "Nacos addListener exception, msg is: {0}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 移除监听
+     *
+     * @param key 配置名称
+     * @param group 配置所在组
+     * @param listener 监听器
+     */
+    public void removeListener(String key, String group, Listener listener) {
+        this.configService.removeListener(key, group, listener);
+    }
+
+    /**
+     * 构建Properties
+     *
+     * @param connectString 连接字符串，必须形如：{@code host:port[(,host:port)...]}
+     * @param sessionTimeout 会话超时时间
+     * @param namespace 命名空间
+     * @return Properties
+     */
+    private Properties createProperties(String connectString, int sessionTimeout, String namespace) {
+        Properties properties = new Properties();
+        properties.setProperty(PropertyKeyConst.SERVER_ADDR, connectString);
+        properties.setProperty(PropertyKeyConst.NAMESPACE, namespace);
+        properties.setProperty(PropertyKeyConst.CONFIG_LONG_POLL_TIMEOUT, String.valueOf(sessionTimeout));
+        return properties;
+    }
+
+    /**
+     * 构建Properties
+     *
+     * @param connectString 连接字符串，必须形如：{@code host:port[(,host:port)...]}
+     * @param sessionTimeout 会话超时时间
+     * @param namespace 命名空间
+     * @param userName 已加密的用户名
+     * @param password 已加密的密码
+     * @return Properties
+     */
+    private Properties createProperties(String connectString, int sessionTimeout, String namespace, String userName,
+            String password) {
+        Properties properties = this.createProperties(connectString, sessionTimeout, namespace);
+        properties.setProperty(PropertyKeyConst.USERNAME,
+                String.valueOf(AesUtil.decrypt(CONFIG.getPrivateKey(), userName)));
+        properties.setProperty(PropertyKeyConst.PASSWORD,
+                String.valueOf(AesUtil.decrypt(CONFIG.getPrivateKey(), password)));
+        return properties;
+    }
+
+    /**
+     * 构建configService
+     *
+     * @param connectString 连接字符串，必须形如：{@code host:port[(,host:port)...]}
+     * @param properties 构建需要的配置
+     * @throws NacosInitException nacos连接失败
+     */
+    private void createConfigService(String connectString, Properties properties) {
+        try {
+            if (!connect(properties)) {
+                LOGGER.log(Level.SEVERE, "Nacos connection reaches the maximum number of retries");
+                throw new NacosInitException(connectString);
+            }
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, "Nacos connection exception, msg is: {0}", e.getMessage());
+            throw new NacosInitException(connectString);
+        }
+    }
+
+    /**
+     * 连接nacos
+     *
+     * @param properties nacosClient连接配置信息
+     * @return nacos连接状态
+     * @throws NacosException nacos初始化异常
+     */
+    private boolean connect(Properties properties) throws NacosException {
+        int tryNum = 0;
+        while (tryNum++ <= CONFIG.getConnectRetryTimes()) {
+            configService = NacosFactory.createConfigService(properties);
+            if (KEY_CONNECTED.equals(configService.getServerStatus())) {
+                return true;
+            }
+            try {
+                Thread.sleep(CONFIG.getConnectTimeout());
+                LOGGER.log(Level.INFO, "The {0} times to retry to connect to nacos", tryNum);
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.SEVERE, "Nacos connection sleep exception, msg is: {0}", e.getMessage());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void close() {
+        try {
+            configService.shutDown();
+        } catch (NacosException e) {
+            LOGGER.log(Level.SEVERE, "Nacos close exception, msg is: {0}", e.getMessage());
+        }
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosInitException.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosInitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,23 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.core.service.dynamicconfig.common;
-
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
 
 /**
+ * Nacos连接异常
  *
- * Enum for DynamicConfigType,
- * Currently support ZooKeeper, Kie, Nop.
- * Probably will support Nacos, etcd in the future.
- *
+ * @author tangle
+ * @since 2023-08-17
  */
-public enum DynamicConfigServiceType {
+public class NacosInitException extends RuntimeException {
+    private static final long serialVersionUID = -5916948812185593365L;
 
     /**
-     * zookeeper 配置中心
+     * nacos连接失败
+     *
+     * @param connectString 连接字符串
      */
-    ZOOKEEPER,
-
-    /**
-     * servicecomb-kie 配置中心
-     */
-    KIE,
-
-    /**
-     * Nacos 配置中心
-     */
-    NACOS,
-    /**
-     * 配置中心无实现
-     */
-    NOP;
-
+    public NacosInitException(String connectString) {
+        super("Connect to " + connectString + " failed. ");
+    }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosListener.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosListener.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+
+import com.alibaba.nacos.api.config.listener.Listener;
+
+import java.util.Map;
+
+/**
+ * Nacos监听器包装类
+ *
+ * @author tangle
+ * @since 2023-08-17
+ */
+public class NacosListener {
+    /**
+     * 监听器类型：GROUP和KEY两种类型
+     */
+    private String type;
+
+    /**
+     * 监听器组
+     */
+    private String group;
+
+    /**
+     * 监听器key和对应的nacos监听器组成的Map
+     */
+    private Map<String, Listener> keyListener;
+
+    /**
+     * 当前监听器所对应的动态配置监听器
+     */
+    private DynamicConfigListener dynamicConfigListener;
+
+    /**
+     * 构造函数初始化监听器
+     *
+     * @param type 监听器类型
+     * @param group 监听器组名
+     * @param keyListener 监听器的key和对应的nacos提供的监听器组成的map
+     * @param dynamicConfigListener 动态配置监听器
+     */
+    public NacosListener(String type, String group, Map<String, Listener> keyListener,
+            DynamicConfigListener dynamicConfigListener) {
+        this.type = type;
+        this.group = group;
+        this.keyListener = keyListener;
+        this.dynamicConfigListener = dynamicConfigListener;
+    }
+
+    public DynamicConfigListener getDynamicConfigListener() {
+        return dynamicConfigListener;
+    }
+
+    public void setDynamicConfigListener(
+            DynamicConfigListener dynamicConfigListener) {
+        this.dynamicConfigListener = dynamicConfigListener;
+    }
+
+    public Map<String, Listener> getKeyListener() {
+        return keyListener;
+    }
+
+    public void setKeyListener(Map<String, Listener> keyListener) {
+        this.keyListener = keyListener;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+}


### PR DESCRIPTION
【修复issue】#1289

【修改内容】
1. 增加了动态配置核心服务nacos客户端包装类
2. 增加了nacos连接异常类
3. 增加了nacos监听器实体类
4. 修改了动态配置参数：增加一个请求超时（nacos每次getConfig需要发送一次请求，默认3000毫秒）

【用例描述】后续补充测试用例

【自测情况】1、本地静态检查通过；2、本地自测通过

【影响范围】无
