### PR TITLE
JDK17支持：升级Lombok版本、ByteBuddy版本、新增Shenandoah收集器指标信息

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <xerces.version>2.12.1</xerces.version>
         <snake.yaml.version>1.32</snake.yaml.version>
         <zookeeper.version>3.6.3</zookeeper.version>
-        <lombok.version>1.18.10</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <asm.version>8.0.1</asm.version>
         <common.io.version>1.3.2</common.io.version>
         <org.jacoco.version>0.8.8</org.jacoco.version>

--- a/sermant-agentcore/sermant-agentcore-core/pom.xml
+++ b/sermant-agentcore/sermant-agentcore-core/pom.xml
@@ -43,7 +43,7 @@
         <sermant.basedir>${pom.basedir}/../..</sermant.basedir>
         <package.temp.dir>${sermant.basedir}/${sermant.name}-${project.version}</package.temp.dir>
 
-        <byte.buddy.version>1.10.14</byte.buddy.version>
+        <byte.buddy.version>1.12.19</byte.buddy.version>
 
         <shade.plugin.version>3.2.4</shade.plugin.version>
         <source.plugin.version>3.0.1</source.plugin.version>

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/BufferedAgentBuilder.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/BufferedAgentBuilder.java
@@ -247,9 +247,10 @@ public class BufferedAgentBuilder {
 
                 @Override
                 public Builder<?> transform(Builder<?> builder, TypeDescription typeDescription,
-                        ClassLoader classLoader, JavaModule module) {
+                        ClassLoader classLoader,
+                        JavaModule module, ProtectionDomain protectionDomain) {
                     return new DefaultTransformer(abstractPluginDeclarer.getInterceptDeclarers(classLoader))
-                            .transform(builder, typeDescription, classLoader, module);
+                            .transform(builder, typeDescription, classLoader, module, protectionDomain);
                 }
 
                 @Override

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/collector/PluginCollectorManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/collector/PluginCollectorManager.java
@@ -24,10 +24,11 @@ import com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDescription;
 import com.huaweicloud.sermant.core.plugin.agent.transformer.DefaultTransformer;
 
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.DynamicType.Builder;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.JavaModule;
 
+import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -117,10 +118,11 @@ public class PluginCollectorManager {
             }
 
             @Override
-            public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDescription,
-                    ClassLoader classLoader, JavaModule module) {
+            public Builder<?> transform(Builder<?> builder, TypeDescription typeDescription,
+                    ClassLoader classLoader,
+                    JavaModule module, ProtectionDomain protectionDomain) {
                 return new DefaultTransformer(declarer.getInterceptDeclarers(classLoader))
-                        .transform(builder, typeDescription, classLoader, module);
+                        .transform(builder, typeDescription, classLoader, module, protectionDomain);
             }
         };
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/transformer/DefaultTransformer.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/transformer/DefaultTransformer.java
@@ -31,10 +31,12 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.method.MethodList;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.DynamicType.Builder;
 import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.utility.JavaModule;
 
 import java.lang.reflect.InvocationTargetException;
+import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -68,12 +70,13 @@ public class DefaultTransformer implements AgentBuilder.Transformer {
     }
 
     @Override
-    public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder, TypeDescription typeDesc,
-            ClassLoader classLoader, JavaModule module) {
+    public Builder<?> transform(Builder<?> builder, TypeDescription typeDescription,
+            ClassLoader classLoader,
+            JavaModule module, ProtectionDomain protectionDomain) {
         if (interceptDeclarers == null || interceptDeclarers.length == 0) {
             return builder;
         }
-        return enhanceMethods(builder, typeDesc, classLoader);
+        return enhanceMethods(builder, typeDescription, classLoader);
     }
 
     /**

--- a/sermant-backend/pom.xml
+++ b/sermant-backend/pom.xml
@@ -18,7 +18,7 @@
         <io.netty.version>4.1.86.Final</io.netty.version>
         <spring-boot.version>2.6.1</spring-boot.version>
         <protobuf-java.version>3.9.1</protobuf-java.version>
-        <lombok.version>1.18.12</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <fastjson.version>1.2.83</fastjson.version>
         <commons-lang.version>2.6</commons-lang.version>
         <junit.version>4.13.1</junit.version>

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnum.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnum.java
@@ -24,7 +24,6 @@ package com.huaweicloud.integration.common;
  * @since 2022-08-02
  */
 public enum MetricEnum {
-
     /**
      * JVM内存指标信息
      */
@@ -74,26 +73,6 @@ public enum MetricEnum {
      * 非堆内存提交
      */
     NON_HEAP_MEMORY_COMMITTED("non_heap_memory_committed", "the number is committed of non heap memory"),
-
-    /**
-     * codeCache初始值
-     */
-    CODE_CACHE_INIT("code_cache_init", "the number is init of code cache"),
-
-    /**
-     * codecCache 最大值
-     */
-    CODE_CACHE_MAX("code_cache_max", "the number is max of code cache"),
-
-    /**
-     * codeCache使用值
-     */
-    CODE_CACHE_USED("code_cache_used", "the number is used of code cache"),
-
-    /**
-     * codeCache提交值
-     */
-    CODE_CACHE_COMMITTED("code_cache_committed", "the committed is init of code cache"),
 
     /**
      * meta space 初始值

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnumJDK12.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnumJDK12.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.integration.common;
+
+/**
+ * JDK12及以上版本独有性能指标枚举类
+ *
+ * @author tangle
+ * @version 1.0.0
+ * @since 2023-09-04
+ */
+public enum MetricEnumJDK12 {
+    /**
+     * JDK9存储其他类型编译代码的codeCache初始值
+     */
+    NON_NMETHODS_INIT("non_nmethods_init", "the number is init of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache使用值
+     */
+    NON_NMETHODS_USED("non_nmethods_used", "the number is used of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache最大值
+     */
+    NON_NMETHODS_MAX("non_nmethods_max", "the number is max of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache提交值
+     */
+    NON_NMETHODS_COMMITTED("non_nmethods_committed", "the number is committed of non_nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache初始值
+     */
+    PROFILED_NMETHODS_INIT("profiled_nmethods_init", "the number is init of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache使用值
+     */
+    PROFILED_NMETHODS_USED("profiled_nmethods_used", "the number is used of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache最大值
+     */
+    PROFILED_NMETHODS_MAX("profiled_nmethods_max", "the number is max of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache提交值
+     */
+    PROFILED_NMETHODS_COMMITTED("profiled_nmethods_committed", "the number is committed of profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache初始值
+     */
+    NON_PROFILED_NMETHODS_INIT("non_profiled_nmethods_init", "the number is init of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache使用值
+     */
+    NON_PROFILED_NMETHODS_USED("non_profiled_nmethods_used", "the number is used of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache最大值
+     */
+    NON_PROFILED_NMETHODS_MAX("non_profiled_nmethods_max", "the number is max of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache提交值
+     */
+    NON_PROFILED_NMETHODS_COMMITTED("non_profiled_nmethods_committed",
+            "the number is committed of non-profiled nmethods"),
+
+    /**
+     * JDK9的Epsilon收集器初始值
+     */
+    EPSILON_HEAP_INIT("epsilon_heap_init", "the number is init of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器使用值
+     */
+    EPSILON_HEAP_USED("epsilon_heap_used", "the number is used of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器最大值
+     */
+    EPSILON_HEAP_MAX("epsilon_heap_max", "the number is max of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器提交值
+     */
+    EPSILON_HEAP_COMMITTED("epsilon_heap_committed", "the number is committed of Epsilon Heap"),
+    /**
+     * JDK12的Shenandoah收集器初始值
+     */
+    SHENANDOAH_INIT("shenandoah_init", "the number is init of Shenandoah"),
+
+    /**
+     * JDK12的Shenandoah收集器使用值
+     */
+    SHENANDOAH_USED("shenandoah_used", "the number is used of Shenandoah"),
+
+    /**
+     * JDK12的Shenandoah收集器最大值
+     */
+    SHENANDOAH_MAX("shenandoah_max", "the number is max of Shenandoah"),
+
+    /**
+     * JDK12的Shenandoah收集器提交值
+     */
+    SHENANDOAH_COMMITTED("shenandoah_committed", "the number is committed of Shenandoah");
+
+    /**
+     * 名称
+     */
+    private String name;
+
+    /**
+     * 描述
+     */
+    private String disc;
+
+    MetricEnumJDK12(String name, String disc) {
+        this.name = name;
+        this.disc = disc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisc() {
+        return disc;
+    }
+}

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnumJDK8.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnumJDK8.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.integration.common;
+
+/**
+ * JDK8独有性能指标枚举类
+ *
+ * @author tangle
+ * @version 1.0.0
+ * @since 2023-09-04
+ */
+public enum MetricEnumJDK8 {
+    /**
+     * codeCache初始值
+     */
+    CODE_CACHE_INIT("code_cache_init", "the number is init of code cache"),
+
+    /**
+     * codecCache 最大值
+     */
+    CODE_CACHE_MAX("code_cache_max", "the number is max of code cache"),
+
+    /**
+     * codeCache使用值
+     */
+    CODE_CACHE_USED("code_cache_used", "the number is used of code cache"),
+
+    /**
+     * codeCache提交值
+     */
+    CODE_CACHE_COMMITTED("code_cache_committed", "the committed is init of code cache");
+
+    /**
+     * 名称
+     */
+    private String name;
+
+    /**
+     * 描述
+     */
+    private String disc;
+
+    MetricEnumJDK8(String name, String disc) {
+        this.name = name;
+        this.disc = disc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisc() {
+        return disc;
+    }
+}

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnumJDK9.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/common/MetricEnumJDK9.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.integration.common;
+
+/**
+ * JDK9及以上版本独有性能指标枚举类
+ *
+ * @author tangle
+ * @version 1.0.0
+ * @since 2023-09-04
+ */
+public enum MetricEnumJDK9 {
+    /**
+     * JDK9存储其他类型编译代码的codeCache初始值
+     */
+    NON_NMETHODS_INIT("non_nmethods_init", "the number is init of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache使用值
+     */
+    NON_NMETHODS_USED("non_nmethods_used", "the number is used of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache最大值
+     */
+    NON_NMETHODS_MAX("non_nmethods_max", "the number is max of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache提交值
+     */
+    NON_NMETHODS_COMMITTED("non_nmethods_committed", "the number is committed of non_nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache初始值
+     */
+    PROFILED_NMETHODS_INIT("profiled_nmethods_init", "the number is init of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache使用值
+     */
+    PROFILED_NMETHODS_USED("profiled_nmethods_used", "the number is used of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache最大值
+     */
+    PROFILED_NMETHODS_MAX("profiled_nmethods_max", "the number is max of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache提交值
+     */
+    PROFILED_NMETHODS_COMMITTED("profiled_nmethods_committed", "the number is committed of profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache初始值
+     */
+    NON_PROFILED_NMETHODS_INIT("non_profiled_nmethods_init", "the number is init of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache使用值
+     */
+    NON_PROFILED_NMETHODS_USED("non_profiled_nmethods_used", "the number is used of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache最大值
+     */
+    NON_PROFILED_NMETHODS_MAX("non_profiled_nmethods_max", "the number is max of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache提交值
+     */
+    NON_PROFILED_NMETHODS_COMMITTED("non_profiled_nmethods_committed",
+            "the number is committed of non-profiled nmethods"),
+
+    /**
+     * JDK9的Epsilon收集器初始值
+     */
+    EPSILON_HEAP_INIT("epsilon_heap_init", "the number is init of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器使用值
+     */
+    EPSILON_HEAP_USED("epsilon_heap_used", "the number is used of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器最大值
+     */
+    EPSILON_HEAP_MAX("epsilon_heap_max", "the number is max of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器提交值
+     */
+    EPSILON_HEAP_COMMITTED("epsilon_heap_committed", "the number is committed of Epsilon Heap");
+
+    /**
+     * 名称
+     */
+    private String name;
+
+    /**
+     * 描述
+     */
+    private String disc;
+
+    MetricEnumJDK9(String name, String disc) {
+        this.name = name;
+        this.disc = disc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisc() {
+        return disc;
+    }
+}

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/monitor/MonitorTest.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/com/huaweicloud/integration/monitor/MonitorTest.java
@@ -18,6 +18,9 @@
 package com.huaweicloud.integration.monitor;
 
 import com.huaweicloud.integration.common.MetricEnum;
+import com.huaweicloud.integration.common.MetricEnumJDK12;
+import com.huaweicloud.integration.common.MetricEnumJDK8;
+import com.huaweicloud.integration.common.MetricEnumJDK9;
 import com.huaweicloud.integration.utils.RequestUtils;
 
 import org.junit.jupiter.api.Test;
@@ -51,19 +54,7 @@ public class MonitorTest {
 
     private static final int JDK9_VERSION_INDEX = 9;
 
-    private static final Set<String> JDK8_MONOPOLIZE_INDEX_SET = new HashSet<>(
-            Arrays.asList("code_cache_init", "code_cache_max",
-                    "code_cache_used", "code_cache_committed"));
-
-    private static final Set<String> JDK9PLUS_MONOPOLIZE_INDEX_SET = new HashSet<>(Arrays.asList("non_nmethods_init",
-            "non_nmethods_max",
-            "non_nmethods_used", "non_nmethods_committed",
-            "profiled_nmethods_init", "profiled_nmethods_max",
-            "profiled_nmethods_used", "profiled_nmethods_committed",
-            "non_profiled_nmethods_init", "non_profiled_nmethods_max",
-            "non_profiled_nmethods_used", "non_profiled_nmethods_committed",
-            "epsilon_heap_init", "epsilon_heap_max",
-            "epsilon_heap_used", "epsilon_heap_committed"));
+    private static final int JDK12_VERSION_INDEX = 12;
 
     @Test
     public void testMonitor() {
@@ -81,23 +72,42 @@ public class MonitorTest {
             }
         }
         Assert.notEmpty(map, "解析响应结果获取指标信息失败");
+        // 遍历所有版本公共指标
         for (MetricEnum metricEnum : MetricEnum.values()) {
             String metricEnumName = metricEnum.getName();
-            // 当JDK大于8时，JDK8独有的指标则忽略
-            if (javaVersionGreaterThanJDK8() && JDK8_MONOPOLIZE_INDEX_SET.contains(metricEnumName)) {
-                continue;
-            }
-            // 当JDK小于等于8时，JDK9及以上版本独有的指标则忽略
-            if (!javaVersionGreaterThanJDK8() && JDK9PLUS_MONOPOLIZE_INDEX_SET.contains(metricEnumName)) {
-                continue;
-            }
             Assert.isTrue(map.containsKey(metricEnumName), "缺少指标信息" + metricEnumName);
+        }
+        // 根据java版本遍历独有指标
+        checkJdkVersionMetric(map);
+    }
+
+    /**
+     * 根据java版本遍历独有指标
+     * @param metricMap 采集到的指标map
+     */
+    private void checkJdkVersionMetric(Map<String, Double> metricMap) {
+        final int javaVersion = getJavaVersion();
+        if (javaVersion < JDK9_VERSION_INDEX) {
+            for (MetricEnumJDK8 metricEnum : MetricEnumJDK8.values()) {
+                String metricEnumName = metricEnum.getName();
+                Assert.isTrue(metricMap.containsKey(metricEnumName), "缺少指标信息" + metricEnumName);
+            }
+        } else if (javaVersion < JDK12_VERSION_INDEX) {
+            for (MetricEnumJDK9 metricEnum : MetricEnumJDK9.values()) {
+                String metricEnumName = metricEnum.getName();
+                Assert.isTrue(metricMap.containsKey(metricEnumName), "缺少指标信息" + metricEnumName);
+            }
+        } else {
+            for (MetricEnumJDK12 metricEnum : MetricEnumJDK12.values()) {
+                String metricEnumName = metricEnum.getName();
+                Assert.isTrue(metricMap.containsKey(metricEnumName), "缺少指标信息" + metricEnumName);
+            }
         }
     }
 
-    private boolean javaVersionGreaterThanJDK8() {
+    private int getJavaVersion() {
         String javaVersion[] = System.getProperty("java.version").split("\\.");
-        return Integer.valueOf(javaVersion[0]) >= JDK9_VERSION_INDEX;
+        return Integer.valueOf(javaVersion[0]);
     }
 
     @Test

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnum.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnum.java
@@ -76,26 +76,6 @@ public enum MetricEnum {
     NON_HEAP_MEMORY_COMMITTED("non_heap_memory_committed", "the number is committed of non heap memory"),
 
     /**
-     * codeCache初始值
-     */
-    CODE_CACHE_INIT("code_cache_init", "the number is init of code cache"),
-
-    /**
-     * codecCache 最大值
-     */
-    CODE_CACHE_MAX("code_cache_max", "the number is max of code cache"),
-
-    /**
-     * codeCache使用值
-     */
-    CODE_CACHE_USED("code_cache_used", "the number is used of code cache"),
-
-    /**
-     * codeCache提交值
-     */
-    CODE_CACHE_COMMITTED("code_cache_committed", "the committed is init of code cache"),
-
-    /**
      * meta space 初始值
      */
     META_SPACE_INIT("meta_space_init", "the number is init of meta space"),

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnumJDK12.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnumJDK12.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.intergration.common;
+
+/**
+ * JDK12及以上版本独有性能指标枚举类
+ *
+ * @author tangle
+ * @version 1.0.0
+ * @since 2023-09-04
+ */
+public enum MetricEnumJDK12 {
+    /**
+     * JDK9存储其他类型编译代码的codeCache初始值
+     */
+    NON_NMETHODS_INIT("non_nmethods_init", "the number is init of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache使用值
+     */
+    NON_NMETHODS_USED("non_nmethods_used", "the number is used of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache最大值
+     */
+    NON_NMETHODS_MAX("non_nmethods_max", "the number is max of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache提交值
+     */
+    NON_NMETHODS_COMMITTED("non_nmethods_committed", "the number is committed of non_nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache初始值
+     */
+    PROFILED_NMETHODS_INIT("profiled_nmethods_init", "the number is init of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache使用值
+     */
+    PROFILED_NMETHODS_USED("profiled_nmethods_used", "the number is used of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache最大值
+     */
+    PROFILED_NMETHODS_MAX("profiled_nmethods_max", "the number is max of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache提交值
+     */
+    PROFILED_NMETHODS_COMMITTED("profiled_nmethods_committed", "the number is committed of profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache初始值
+     */
+    NON_PROFILED_NMETHODS_INIT("non_profiled_nmethods_init", "the number is init of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache使用值
+     */
+    NON_PROFILED_NMETHODS_USED("non_profiled_nmethods_used", "the number is used of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache最大值
+     */
+    NON_PROFILED_NMETHODS_MAX("non_profiled_nmethods_max", "the number is max of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache提交值
+     */
+    NON_PROFILED_NMETHODS_COMMITTED("non_profiled_nmethods_committed",
+            "the number is committed of non-profiled nmethods"),
+
+    /**
+     * JDK9的Epsilon收集器初始值
+     */
+    EPSILON_HEAP_INIT("epsilon_heap_init", "the number is init of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器使用值
+     */
+    EPSILON_HEAP_USED("epsilon_heap_used", "the number is used of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器最大值
+     */
+    EPSILON_HEAP_MAX("epsilon_heap_max", "the number is max of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器提交值
+     */
+    EPSILON_HEAP_COMMITTED("epsilon_heap_committed", "the number is committed of Epsilon Heap"),
+    /**
+     * JDK12的Shenandoah收集器初始值
+     */
+    SHENANDOAH_INIT("shenandoah_init", "the number is init of Shenandoah"),
+
+    /**
+     * JDK12的Shenandoah收集器使用值
+     */
+    SHENANDOAH_USED("shenandoah_used", "the number is used of Shenandoah"),
+
+    /**
+     * JDK12的Shenandoah收集器最大值
+     */
+    SHENANDOAH_MAX("shenandoah_max", "the number is max of Shenandoah"),
+
+    /**
+     * JDK12的Shenandoah收集器提交值
+     */
+    SHENANDOAH_COMMITTED("shenandoah_committed", "the number is committed of Shenandoah");
+
+    /**
+     * 名称
+     */
+    private String name;
+
+    /**
+     * 描述
+     */
+    private String disc;
+
+    MetricEnumJDK12(String name, String disc) {
+        this.name = name;
+        this.disc = disc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisc() {
+        return disc;
+    }
+}

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnumJDK8.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnumJDK8.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.intergration.common;
+
+/**
+ * JDK8独有性能指标枚举类
+ *
+ * @author tangle
+ * @version 1.0.0
+ * @since 2023-09-04
+ */
+public enum MetricEnumJDK8 {
+    /**
+     * codeCache初始值
+     */
+    CODE_CACHE_INIT("code_cache_init", "the number is init of code cache"),
+
+    /**
+     * codecCache 最大值
+     */
+    CODE_CACHE_MAX("code_cache_max", "the number is max of code cache"),
+
+    /**
+     * codeCache使用值
+     */
+    CODE_CACHE_USED("code_cache_used", "the number is used of code cache"),
+
+    /**
+     * codeCache提交值
+     */
+    CODE_CACHE_COMMITTED("code_cache_committed", "the committed is init of code cache");
+
+    /**
+     * 名称
+     */
+    private String name;
+
+    /**
+     * 描述
+     */
+    private String disc;
+
+    MetricEnumJDK8(String name, String disc) {
+        this.name = name;
+        this.disc = disc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisc() {
+        return disc;
+    }
+}

--- a/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnumJDK9.java
+++ b/sermant-integration-tests/spring-test/spring-intergration-test/src/test/java/com/huaweicloud/intergration/common/MetricEnumJDK9.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.intergration.common;
+
+/**
+ * JDK9及以上版本独有性能指标枚举类
+ *
+ * @author tangle
+ * @version 1.0.0
+ * @since 2023-09-04
+ */
+public enum MetricEnumJDK9 {
+    /**
+     * JDK9存储其他类型编译代码的codeCache初始值
+     */
+    NON_NMETHODS_INIT("non_nmethods_init", "the number is init of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache使用值
+     */
+    NON_NMETHODS_USED("non_nmethods_used", "the number is used of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache最大值
+     */
+    NON_NMETHODS_MAX("non_nmethods_max", "the number is max of non_nmethods"),
+
+    /**
+     * JDK9存储其他类型编译代码的codeCache提交值
+     */
+    NON_NMETHODS_COMMITTED("non_nmethods_committed", "the number is committed of non_nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache初始值
+     */
+    PROFILED_NMETHODS_INIT("profiled_nmethods_init", "the number is init of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache使用值
+     */
+    PROFILED_NMETHODS_USED("profiled_nmethods_used", "the number is used of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache最大值
+     */
+    PROFILED_NMETHODS_MAX("profiled_nmethods_max", "the number is max of profiled nmethods"),
+
+    /**
+     * JDK9存储经过性能分析的编译代码的codeCache提交值
+     */
+    PROFILED_NMETHODS_COMMITTED("profiled_nmethods_committed", "the number is committed of profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache初始值
+     */
+    NON_PROFILED_NMETHODS_INIT("non_profiled_nmethods_init", "the number is init of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache使用值
+     */
+    NON_PROFILED_NMETHODS_USED("non_profiled_nmethods_used", "the number is used of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache最大值
+     */
+    NON_PROFILED_NMETHODS_MAX("non_profiled_nmethods_max", "the number is max of non-profiled nmethods"),
+
+    /**
+     * JDK9存储未经过性能分析的编译代码的codeCache提交值
+     */
+    NON_PROFILED_NMETHODS_COMMITTED("non_profiled_nmethods_committed",
+            "the number is committed of non-profiled nmethods"),
+
+    /**
+     * JDK9的Epsilon收集器初始值
+     */
+    EPSILON_HEAP_INIT("epsilon_heap_init", "the number is init of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器使用值
+     */
+    EPSILON_HEAP_USED("epsilon_heap_used", "the number is used of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器最大值
+     */
+    EPSILON_HEAP_MAX("epsilon_heap_max", "the number is max of Epsilon Heap"),
+
+    /**
+     * JDK9的Epsilon收集器提交值
+     */
+    EPSILON_HEAP_COMMITTED("epsilon_heap_committed", "the number is committed of Epsilon Heap");
+
+    /**
+     * 名称
+     */
+    private String name;
+
+    /**
+     * 描述
+     */
+    private String disc;
+
+    MetricEnumJDK9(String name, String disc) {
+        this.name = name;
+        this.disc = disc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisc() {
+        return disc;
+    }
+}

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MemoryType.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MemoryType.java
@@ -159,7 +159,14 @@ public enum MemoryType {
      */
     EPSILON_HEAP("Epsilon Heap", MetricEnum.EPSILON_HEAP_INIT, MetricEnum.EPSILON_HEAP_USED,
             MetricEnum.EPSILON_HEAP_MAX,
-            MetricEnum.EPSILON_HEAP_COMMITTED);
+            MetricEnum.EPSILON_HEAP_COMMITTED),
+
+    /**
+     * JDK17的Shenandoah收集器指标枚举
+     */
+    SHENANDOAH("Shenandoah", MetricEnum.SHENANDOAH_INIT, MetricEnum.SHENANDOAH_USED,
+            MetricEnum.SHENANDOAH_MAX,
+            MetricEnum.SHENANDOAH_COMMITTED);
 
     /**
      * 类型

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricEnum.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/common/MetricEnum.java
@@ -409,7 +409,27 @@ public enum MetricEnum {
     /**
      * JDK11的Epsilon收集器提交值
      */
-    EPSILON_HEAP_COMMITTED("epsilon_heap_committed", "the number is committed of Epsilon Heap");
+    EPSILON_HEAP_COMMITTED("epsilon_heap_committed", "the number is committed of Epsilon Heap"),
+
+    /**
+     * JDK17的Shenandoah收集器初始值
+     */
+    SHENANDOAH_INIT("shenandoah_init", "the number is init of Shenandoah"),
+
+    /**
+     * JDK17的Shenandoah收集器使用值
+     */
+    SHENANDOAH_USED("shenandoah_used", "the number is used of Shenandoah"),
+
+    /**
+     * JDK17的Shenandoah收集器最大值
+     */
+    SHENANDOAH_MAX("shenandoah_max", "the number is max of Shenandoah"),
+
+    /**
+     * JDK17的Shenandoah收集器提交值
+     */
+    SHENANDOAH_COMMITTED("shenandoah_committed", "the number is committed of Shenandoah");
 
     /**
      * 名称

--- a/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/service/collector/JvmCollectorService.java
+++ b/sermant-plugins/sermant-monitor/monitor-service/src/main/java/com/huawei/monitor/service/collector/JvmCollectorService.java
@@ -49,7 +49,7 @@ import java.util.Set;
  */
 public class JvmCollectorService extends SwitchService implements PluginService {
     private static final Set<String> NEW_GEN_NAME_SET = new HashSet<>(Arrays.asList("PS Scavenge", "ParNew", "Copy",
-            "G1 Young Generation", "ZGC Cycles"));
+            "G1 Young Generation", "ZGC Cycles", "Shenandoah Cycles"));
 
     /**
      * JDK11中不分代的Epsilon GC的名称


### PR DESCRIPTION
【修复issue】#1283

【修改内容】
1. 升级了Lombok版本1.18.10至1.18.22 (此版本起开始支持JDK17)
2. 升级了ByteBuddy版本1.10.14至1.12.19 (1.10.21版本起开始支持JDK17)
3. 修改了monitor插件中性能指标，增加了JDK17新增的Shenandoah收集器指标

【用例描述】修改了monitor集成测试性能指标遍历。原因：JDK17后新增了一些指标，需要根据不同版本适配更改

【自测情况】本地静态检查通过；UT通过；

【影响范围】monitor可采集的指标更改，文档需要更新