### PR TITLE
流量标签透传插件 dubbo、sofarpc、servicecombrpc UT

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/AbstractRpcInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/AbstractRpcInterceptorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc;
+
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.tag.transmission.interceptors.BaseInterceptorTest;
+
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * rpc模块 单元测试抽象类
+ *
+ * @author daizhenyu
+ * @since 2023-09-06
+ **/
+public abstract class AbstractRpcInterceptorTest extends BaseInterceptorTest {
+    // 构建流量标签的key-value关系，用于构建参数
+    public Map<String, List<String>> fullTrafficTag;
+
+    public AbstractRpcInterceptorTest() {
+    }
+
+    @Before
+    public void beforeTest() {
+        fullTrafficTag = new HashMap<>();
+        fullTrafficTag.put("id", Collections.singletonList("001"));
+        fullTrafficTag.put("name", Collections.singletonList("test001"));
+
+        // 初始化流量标签
+        Map<String, List<String>> tag = new HashMap<>();
+        tag.put("id", Collections.singletonList("001"));
+        tag.put("name", Collections.singletonList("test001"));
+        fullTrafficTag = new HashMap<>(tag);
+        TrafficTag trafficTag = new TrafficTag(tag);
+        doBefore(trafficTag);
+    }
+
+    public abstract void doBefore(TrafficTag trafficTag);
+
+    public Map<String, List<String>> buildExpectTrafficTag(String... keys) {
+        Map<String, List<String>> expectTag = new HashMap<>();
+        for (String key : keys) {
+            expectTag.put(key, fullTrafficTag.get(key));
+        }
+        return expectTag;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboConsumerInterceptorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import com.alibaba.dubbo.rpc.RpcInvocation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AlibabaDubboConsumerInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-09
+ **/
+public class AlibabaDubboConsumerInterceptorTest extends AbstractRpcInterceptorTest {
+    private final AlibabaDubboConsumerInterceptor interceptor = new AlibabaDubboConsumerInterceptor();
+
+    public AlibabaDubboConsumerInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+        TrafficUtils.setTrafficTag(trafficTag);
+    }
+
+    @Test
+    public void testAlibabaDubboConsumer() {
+        // 定义参数
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, String> expectAttachments;
+
+        // RpcInvocation为null
+        context = buildContext(null);
+        returnContext = interceptor.before(context);
+        Assert.assertNull(returnContext.getArguments()[1]);
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        Assert.assertNull(((RpcInvocation) returnContext.getArguments()[1]).getAttachments());
+        tagTransmissionConfig.setEnabled(true);
+
+        // TrafficTag包含完整的流量标签
+        expectAttachments = buildExpectAttachments("id", "name");
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        Assert.assertEquals(expectAttachments, ((RpcInvocation) returnContext.getArguments()[1]).getAttachments());
+
+        // TrafficTag包含部分的流量标签
+        TrafficUtils.getTrafficTag().getTag().remove("id");
+        expectAttachments = buildExpectAttachments("name");
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        Assert.assertEquals(expectAttachments, ((RpcInvocation) returnContext.getArguments()[1]).getAttachments());
+
+        // TrafficTag没有流量标签
+        TrafficUtils.removeTrafficTag();
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        Assert.assertNull(((RpcInvocation) returnContext.getArguments()[1]).getAttachments());
+    }
+
+    private Map<String, String> buildExpectAttachments(String... keys) {
+        Map<String, String> expectAttachments = new HashMap<>();
+        for (String key : keys) {
+            expectAttachments.put(key, fullTrafficTag.get(key).get(0));
+        }
+        return expectAttachments;
+    }
+
+    private ExecuteContext buildContext(RpcInvocation rpcInvocation) {
+        Object[] arguments = new Object[]{null, rpcInvocation};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboProviderInterceptorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.rpc.Invoker;
+import com.alibaba.dubbo.rpc.RpcInvocation;
+import com.alibaba.dubbo.rpc.protocol.dubbo.DubboInvoker;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AlibabaDubboProviderInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-29
+ **/
+public class AlibabaDubboProviderInterceptorTest extends AbstractRpcInterceptorTest {
+    private final AlibabaDubboProviderInterceptor interceptor = new AlibabaDubboProviderInterceptor();
+
+    public AlibabaDubboProviderInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+    }
+
+    @Test
+    public void testAlibabaDubboProvider() {
+        // 定义参数
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, String> attachments;
+        Map<String, List<String>> expectTag;
+
+        // invoker为consumer端
+        context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+
+        // 后续test均为provider端, Invocation对象为null
+        context = buildContext(null, new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+        tagTransmissionConfig.setEnabled(true);
+
+        // Invocation对象的attachments包含全部key
+        attachments = new HashMap<>();
+        attachments.put("id", "001");
+        attachments.put("name", "test001");
+        context = buildContext(new RpcInvocation(), attachments, "provider");
+        returnContext = interceptor.before(context);
+        expectTag = buildExpectTrafficTag("id", "name");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(returnContext);
+
+        // Invocation对象的attachments包含部分流量标签
+        attachments = new HashMap<>();
+        attachments.put("id", "001");
+        context = buildContext(new RpcInvocation(), attachments, "provider");
+        returnContext = interceptor.before(context);
+        expectTag = buildExpectTrafficTag("id");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(returnContext);
+    }
+
+    private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
+        URL url = new URL("http", "127.0.0.1", 8080);
+        url = url.addParameter("side", side);
+        Invoker invoker = new DubboInvoker<>(String.class, url, null);
+        if (rpcInvocation != null) {
+            rpcInvocation.setAttachments(headers);
+        }
+        Object[] arguments = new Object[]{invoker, rpcInvocation};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ApacheDubboConsumerInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-29
+ **/
+public class ApacheDubboConsumerInterceptorTest extends AbstractRpcInterceptorTest {
+    private final ApacheDubboConsumerInterceptor interceptor = new ApacheDubboConsumerInterceptor();
+
+    public ApacheDubboConsumerInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+        TrafficUtils.setTrafficTag(trafficTag);
+    }
+
+    @Test
+    public void testApacheDubboConsumer() {
+        // 定义参数
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, String> expectAttachments;
+
+        // RpcInvocation为null
+        context = buildContext(null);
+        returnContext = interceptor.before(context);
+        Assert.assertNull(returnContext.getArguments()[1]);
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        expectAttachments = buildExpectAttachments();
+        Assert.assertEquals(expectAttachments, ((RpcInvocation) returnContext.getArguments()[1]).getAttachments());
+        tagTransmissionConfig.setEnabled(true);
+
+        // TrafficTag包含完整的流量标签
+        expectAttachments = buildExpectAttachments("id", "name");
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        Assert.assertEquals(((RpcInvocation) returnContext.getArguments()[1]).getAttachments(),
+                expectAttachments);
+
+        // TrafficTag包含部分的流量标签
+        TrafficUtils.getTrafficTag().getTag().remove("id");
+        expectAttachments = buildExpectAttachments("name");
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        Assert.assertEquals(((RpcInvocation) returnContext.getArguments()[1]).getAttachments(),
+                expectAttachments);
+
+        // TrafficTag没有流量标签
+        TrafficUtils.removeTrafficTag();
+        expectAttachments = buildExpectAttachments();
+        context = buildContext(new RpcInvocation());
+        returnContext = interceptor.before(context);
+        Assert.assertEquals(expectAttachments, ((RpcInvocation) returnContext.getArguments()[1]).getAttachments());
+    }
+
+    private Map<String, String> buildExpectAttachments(String... keys) {
+        Map<String, String> expectAttachments = new HashMap<>();
+        for (String key : keys) {
+            expectAttachments.put(key, fullTrafficTag.get(key).get(0));
+        }
+        return expectAttachments;
+    }
+
+    private ExecuteContext buildContext(RpcInvocation rpcInvocation) {
+        Object[] arguments = new Object[]{null, rpcInvocation};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboProviderInterceptorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.protocol.dubbo.DubboInvoker;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ApacheDubboProviderInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-29
+ **/
+public class ApacheDubboProviderInterceptorTest extends AbstractRpcInterceptorTest {
+    private final ApacheDubboProviderInterceptor interceptor = new ApacheDubboProviderInterceptor();
+
+    public ApacheDubboProviderInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+    }
+
+    @Test
+    public void testApacheDubboProvider() {
+        // 定义参数
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, String> attachments;
+        Map<String, List<String>> expectTag;
+
+        // invoker为consumer端
+        context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+
+        // 后续test均为provider端, Invocation对象为null
+        context = buildContext(null, new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+        tagTransmissionConfig.setEnabled(true);
+
+        // Invocation对象的attachments包含全部key
+        attachments = new HashMap<>();
+        attachments.put("id", "001");
+        attachments.put("name", "test001");
+        context = buildContext(new RpcInvocation(), attachments, "provider");
+        returnContext = interceptor.before(context);
+        expectTag = buildExpectTrafficTag("id", "name");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(returnContext);
+
+        // Invocation对象的attachments包含部分流量标签
+        attachments = new HashMap<>();
+        attachments.put("id", "001");
+        context = buildContext(new RpcInvocation(), attachments, "provider");
+        returnContext = interceptor.before(context);
+        expectTag = buildExpectTrafficTag("id");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(returnContext);
+    }
+
+    private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
+        URL url = new URL("http", "127.0.0.1", 8080);
+        url = url.addParameter("side", side);
+        Invoker invoker = new DubboInvoker<>(String.class, url, null);
+        if (rpcInvocation != null) {
+            rpcInvocation.setAttachments(headers);
+        }
+        Object[] arguments = new Object[]{invoker, rpcInvocation};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcConsumerInterceptorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.servicecomb;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import org.apache.servicecomb.core.Invocation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ServiceCombRpcConsumerInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-30
+ **/
+public class ServiceCombRpcConsumerInterceptorTest extends AbstractRpcInterceptorTest {
+    private final ServiceCombRpcConsumerInterceptor interceptor = new ServiceCombRpcConsumerInterceptor();
+
+    public ServiceCombRpcConsumerInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+        TrafficUtils.setTrafficTag(trafficTag);
+    }
+
+    @Test
+    public void testServiceCombRpcConsumer() {
+        // 定义参数
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, String> expectContext;
+
+        // Invocation为null
+        context = buildContext(null);
+        returnContext = interceptor.before(context);
+        Assert.assertNull(returnContext.getArguments()[0]);
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new Invocation());
+        returnContext = interceptor.before(context);
+        expectContext = buildExpectContext();
+        Assert.assertEquals(((Invocation) returnContext.getArguments()[0]).getContext(), expectContext);
+        tagTransmissionConfig.setEnabled(true);
+
+        // TrafficTag包含完整的tag信息
+        context = buildContext(new Invocation());
+        returnContext = interceptor.before(context);
+        expectContext = buildExpectContext("id", "name");
+        Assert.assertEquals(((Invocation) returnContext.getArguments()[0]).getContext(), expectContext);
+
+        // TrafficTag只有部分tag信息
+        context = buildContext(new Invocation());
+        TrafficUtils.getTrafficTag().getTag().remove("id");
+        returnContext = interceptor.before(context);
+        expectContext = buildExpectContext("name");
+        Assert.assertEquals(((Invocation) returnContext.getArguments()[0]).getContext(), expectContext);
+
+        // TrafficTa没有tag信息
+        TrafficUtils.removeTrafficTag();
+        context = buildContext(new Invocation());
+        returnContext = interceptor.before(context);
+        expectContext = buildExpectContext();
+        Assert.assertEquals(((Invocation) returnContext.getArguments()[0]).getContext(), expectContext);
+    }
+
+    private Map<String, String> buildExpectContext(String... keys) {
+        Map<String, String> expectContext = new HashMap<>();
+        for (String key : keys) {
+            expectContext.put(key, fullTrafficTag.get(key).get(0));
+        }
+        return expectContext;
+    }
+
+    private ExecuteContext buildContext(Invocation invocation) {
+        Object[] arguments = new Object[]{invocation};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcProviderInterceptorTest.java
@@ -1,0 +1,114 @@
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.servicecomb;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import org.apache.servicecomb.core.Invocation;
+import org.apache.servicecomb.foundation.vertx.http.HttpServletRequestEx;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+/**
+ * ServiceCombRpcProviderInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-30
+ **/
+public class ServiceCombRpcProviderInterceptorTest extends AbstractRpcInterceptorTest {
+    private final ServiceCombRpcProviderInterceptor interceptor = new ServiceCombRpcProviderInterceptor();
+
+    public ServiceCombRpcProviderInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+    }
+
+    @Test
+    public void testServiceCombRpcProvider() {
+        // 定义参数
+        Invocation invocation;
+        Object[] arguments;
+        Object obj = new Object();
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, List<String>> expectTrafficTag;
+        HttpServletRequestEx requestEx;
+
+        // Invocation 为null
+        context = buildContext(null);
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new Invocation());
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+        tagTransmissionConfig.setEnabled(true);
+
+        // Invocation包含完整的tag
+        invocation = new Invocation();
+        invocation.getContext().put("id", "001");
+        invocation.getContext().put("name", "test001");
+        arguments = new Object[]{invocation};
+        context = ExecuteContext.forMemberMethod(obj, null, arguments, null, null);
+        returnContext = interceptor.before(context);
+        expectTrafficTag = buildExpectTrafficTag("id", "name");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTrafficTag);
+        interceptor.after(returnContext);
+
+        // Invocation包含部分的tag
+        invocation = new Invocation();
+        invocation.getContext().put("id", "001");
+        arguments = new Object[]{invocation};
+        context = ExecuteContext.forMemberMethod(obj, null, arguments, null, null);
+        returnContext = interceptor.before(context);
+        expectTrafficTag = buildExpectTrafficTag("id");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTrafficTag);
+        interceptor.after(returnContext);
+
+        // 使用非servicecombrpc方式调用provider
+        invocation = new Invocation();
+        requestEx = Mockito.mock(HttpServletRequestEx.class);
+        Vector<String> keyVector = new Vector<>();
+        keyVector.add("id");
+        keyVector.add("name");
+        Enumeration<String> headerNames = keyVector.elements();
+        Mockito.when(requestEx.getHeaderNames()).thenReturn(headerNames);
+        Vector<String> idVector = new Vector<>();
+        idVector.add("001");
+        Enumeration<String> ids = idVector.elements();
+        Vector<String> nameVector = new Vector<>();
+        nameVector.add("test001");
+        Enumeration<String> names = nameVector.elements();
+        Mockito.when(requestEx.getHeaders("name")).thenReturn(names);
+        Mockito.when(requestEx.getHeaders("id")).thenReturn(ids);
+        invocation.onStart(requestEx, 1000L);
+        arguments = new Object[]{invocation};
+        context = ExecuteContext.forMemberMethod(obj, null, arguments, null, null);
+        returnContext = interceptor.before(context);
+        expectTrafficTag = buildExpectTrafficTag("id", "name");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTrafficTag);
+        interceptor.after(returnContext);
+    }
+
+    @After
+    public void afterTest() {
+        Mockito.clearAllCaches();
+    }
+
+    private ExecuteContext buildContext(Invocation invocation) {
+        Object[] arguments = new Object[]{invocation};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * SofaRpcClientInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-29
+ **/
+public class SofaRpcClientInterceptorTest extends AbstractRpcInterceptorTest {
+    private final SofaRpcClientInterceptor interceptor = new SofaRpcClientInterceptor();
+
+    public SofaRpcClientInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+        TrafficUtils.setTrafficTag(trafficTag);
+    }
+
+    @Test
+    public void testSofaRpcClient() {
+        // 定义参数
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, Object> expectRequestProps;
+
+        // SofaRequest 为null
+        context = buildContext(null);
+        returnContext = interceptor.before(context);
+        Assert.assertNull(returnContext.getArguments()[0]);
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new SofaRequest());
+        returnContext = interceptor.before(context);
+        Assert.assertNull(((SofaRequest) returnContext.getArguments()[0]).getRequestProps());
+        tagTransmissionConfig.setEnabled(true);
+
+        // SofaRequest不为null,TrafficTag包含完整的流量标签
+        context = buildContext(new SofaRequest());
+        returnContext = interceptor.before(context);
+        expectRequestProps = buildExpectRequestProps("id", "name");
+        Assert.assertEquals(((SofaRequest) returnContext.getArguments()[0]).getRequestProps(), expectRequestProps);
+
+        // TrafficTag只有部分流量标签
+        context = buildContext(new SofaRequest());
+        TrafficUtils.getTrafficTag().getTag().remove("id");
+        returnContext = interceptor.before(context);
+        expectRequestProps = buildExpectRequestProps("name");
+        Assert.assertEquals(((SofaRequest) returnContext.getArguments()[0]).getRequestProps(), expectRequestProps);
+
+        // TrafficTa没有tag信息
+        TrafficUtils.removeTrafficTag();
+        context = buildContext(new SofaRequest());
+        returnContext = interceptor.before(context);
+        Assert.assertNull(((SofaRequest) returnContext.getArguments()[0]).getRequestProps());
+    }
+
+    private Map<String, Object> buildExpectRequestProps(String... keys) {
+        Map<String, Object> expectContext = new HashMap<>();
+        for (String key : keys) {
+            expectContext.put(key, fullTrafficTag.get(key).get(0));
+        }
+        return expectContext;
+    }
+
+    private ExecuteContext buildContext(SofaRequest sofaRequest) {
+        Object[] arguments = new Object[]{sofaRequest};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * SofaRpcServerInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-30
+ **/
+public class SofaRpcServerInterceptorTest extends AbstractRpcInterceptorTest {
+    private final SofaRpcServerInterceptor interceptor = new SofaRpcServerInterceptor();
+
+    public SofaRpcServerInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+    }
+
+    @Test
+    public void testSofaRpcServer() {
+        // 定义参数
+        Map<String, Object> requestProp;
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Map<String, List<String>> expectTrafficTag;
+
+        // SofaRequest 为null
+        context = buildContext(null, null);
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+
+        // 流量标签透传开关关闭
+        tagTransmissionConfig.setEnabled(false);
+        context = buildContext(new SofaRequest(), new HashMap<>());
+        interceptor.before(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+        tagTransmissionConfig.setEnabled(true);
+
+        // SofaRequest包含完整的tag
+        requestProp = new HashMap<>();
+        requestProp.put("id", "001");
+        requestProp.put("name", "test001");
+        context = buildContext(new SofaRequest(), requestProp);
+        returnContext = interceptor.before(context);
+        expectTrafficTag = buildExpectTrafficTag("id", "name");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTrafficTag);
+        interceptor.after(returnContext);
+
+        // SofaRequest包含部分的tag
+        requestProp = new HashMap<>();
+        requestProp.put("id", "001");
+        context = buildContext(new SofaRequest(), requestProp);
+        interceptor.before(context);
+        expectTrafficTag = buildExpectTrafficTag("id");
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTrafficTag);
+        interceptor.after(returnContext);
+    }
+
+    private ExecuteContext buildContext(SofaRequest sofaRequest, Map<String, Object> headers) {
+        if (sofaRequest != null) {
+            sofaRequest.addRequestProps(headers);
+        }
+        Object[] arguments = new Object[]{sofaRequest};
+        return ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/utils/DubboUtilsTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/utils/DubboUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.utils;
+
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+
+/**
+ * DubboUtils工具类测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-09
+ **/
+public class DubboUtilsTest {
+    private static final String ATTACHMENTS_FIELD = "attachments";
+
+    /**
+     * 测试DubboUtils工具类的getAttachmentsByInvocation方法
+     */
+    @Test
+    public void getAttachmentsByInvocationTest() {
+        RpcInvocation rpcInvocation;
+        Optional<Object> expectOptional;
+
+        // 输入对象为null
+        rpcInvocation = null;
+        expectOptional = Optional.empty();
+        Assert.assertEquals(DubboUtils.getAttachmentsByInvocation(rpcInvocation), expectOptional);
+
+        // 输入对象不为空, attachments参数为null
+        rpcInvocation = new RpcInvocation();
+        expectOptional = Optional.empty();
+        Assert.assertEquals(DubboUtils.getAttachmentsByInvocation(rpcInvocation), expectOptional);
+
+        // 输入对象不为空，attachments参数不为null
+        rpcInvocation = new RpcInvocation();
+        rpcInvocation.setAttachment("key", "value");
+        expectOptional = Optional.of(rpcInvocation.getObjectAttachments());
+        Assert.assertEquals(DubboUtils.getAttachmentsByInvocation(rpcInvocation), expectOptional);
+    }
+}


### PR DESCRIPTION
【修复issue】#1244

【修改内容】增加了流量标签透传插件dubbo、sofarpc、servicecombrpc部分 的UT

【用例描述】不需要

【自测情况】1、本地静态检查通过；2、dubbo部分 UT覆盖率为86%，sofarpc部分UT覆盖率为86%，servicecombrpc部分UT覆盖率为87%

【影响范围】无