### PR TITLE
流量标签透传特性：支持标签键的前缀后缀匹配方式

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/config/config.yaml
+++ b/sermant-plugins/sermant-tag-transmission/config/config.yaml
@@ -4,8 +4,8 @@ tag.transmission.config:
   enabled: true
   # 需要透传的流量标签的key的匹配规则, 支持等于、前缀、后缀匹配
   matchRule:
-    # 等于匹配
-    equals: ["id", "name"]
+    # 精确匹配
+    exact: ["id", "name"]
     # 前缀匹配
     prefix: []
     # 后缀匹配

--- a/sermant-plugins/sermant-tag-transmission/config/config.yaml
+++ b/sermant-plugins/sermant-tag-transmission/config/config.yaml
@@ -2,8 +2,14 @@
 tag.transmission.config:
   # 是否开启流量标签透传
   enabled: true
-  # 需要透传的流量标签的key
-  tagKeys: [id,name]
+  # 需要透传的流量标签的key的匹配规则, 支持等于、前缀、后缀匹配
+  matchRule:
+    # 等于匹配
+    equals: ["id", "name"]
+    # 前缀匹配
+    prefix: []
+    # 后缀匹配
+    suffix: []
 
 # 跨线程传递标签的配置,该能力可单独使用
 crossthread.config:

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
@@ -58,7 +58,7 @@ public class TagTransmissionConfig implements PluginConfig {
     public String toString() {
         return "TagTransmissionConfig{"
                 + "enabled=" + enabled
-                + ", tagKeys=" + matchRule
+                + ", matchRule=" + matchRule
                 + '}';
     }
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/TagTransmissionConfig.java
@@ -18,10 +18,11 @@ package com.huaweicloud.sermant.tag.transmission.config;
 
 import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfig;
-import com.huaweicloud.sermant.core.utils.CollectionUtils;
+import com.huaweicloud.sermant.core.utils.MapUtils;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 流量标签透传配置
@@ -37,9 +38,9 @@ public class TagTransmissionConfig implements PluginConfig {
     private boolean enabled;
 
     /**
-     * 需要透传的标签的key
+     * 需要透传的标签的key的规则
      */
-    private List<String> tagKeys = new ArrayList<>();
+    private Map<String, List<String>> matchRule = new HashMap<>();
 
     public boolean isEnabled() {
         return enabled;
@@ -49,23 +50,23 @@ public class TagTransmissionConfig implements PluginConfig {
         this.enabled = enabled;
     }
 
-    public List<String> getTagKeys() {
-        return tagKeys;
-    }
-
-    public void setTagKeys(List<String> tagKeys) {
-        this.tagKeys = tagKeys;
-    }
-
     public boolean isEffect() {
-        return enabled && !CollectionUtils.isEmpty(tagKeys);
+        return enabled && !MapUtils.isEmpty(matchRule);
     }
 
     @Override
     public String toString() {
         return "TagTransmissionConfig{"
                 + "enabled=" + enabled
-                + ", tagKeys=" + tagKeys
+                + ", tagKeys=" + matchRule
                 + '}';
+    }
+
+    public Map<String, List<String>> getMatchRule() {
+        return matchRule;
+    }
+
+    public void setMatchRule(Map<String, List<String>> matchRule) {
+        this.matchRule = matchRule;
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/EqualsMatchStrategy.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/EqualsMatchStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.config.strategy;
+
+import java.util.List;
+
+/**
+ * 等于匹配策略
+ *
+ * @author lilai
+ * @since 2023-09-07
+ */
+public class EqualsMatchStrategy implements MatchStrategy {
+    @Override
+    public boolean isMatch(String key, List<String> keyConfigs) {
+        return keyConfigs.stream().anyMatch(configKey -> configKey.equals(key));
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/ExactMatchStrategy.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/ExactMatchStrategy.java
@@ -19,14 +19,14 @@ package com.huaweicloud.sermant.tag.transmission.config.strategy;
 import java.util.List;
 
 /**
- * 等于匹配策略
+ * 精确匹配策略
  *
  * @author lilai
  * @since 2023-09-07
  */
-public class EqualsMatchStrategy implements MatchStrategy {
+public class ExactMatchStrategy implements MatchStrategy {
     @Override
     public boolean isMatch(String key, List<String> keyConfigs) {
-        return keyConfigs.stream().anyMatch(configKey -> configKey.equals(key));
+        return keyConfigs.stream().anyMatch(key::equals);
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/MatchStrategy.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/MatchStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.config.strategy;
+
+import java.util.List;
+
+/**
+ * 需要透传的key的匹配策略接口
+ *
+ * @author lilai
+ * @since 2023-09-07
+ */
+public interface MatchStrategy {
+    /**
+     * 请求中或线程变量中的key是否匹配配置中要透传的规则
+     *
+     * @param key 被匹配的键
+     * @param keyConfigs key的匹配配置
+     * @return 匹配结果
+     */
+    boolean isMatch(String key, List<String> keyConfigs);
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/PrefixMatchStrategy.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/PrefixMatchStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.config.strategy;
+
+import java.util.List;
+
+/**
+ * 前缀匹配策略
+ *
+ * @author lilai
+ * @since 2023-09-07
+ */
+public class PrefixMatchStrategy implements MatchStrategy {
+    @Override
+    public boolean isMatch(String key, List<String> keyConfigs) {
+        return keyConfigs.stream().anyMatch(key::startsWith);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/SuffixMatchStrategy.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/SuffixMatchStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.config.strategy;
+
+import java.util.List;
+
+/**
+ * 后缀匹配策略
+ *
+ * @author lilai
+ * @since 2023-09-07
+ */
+public class SuffixMatchStrategy implements MatchStrategy {
+    @Override
+    public boolean isMatch(String key, List<String> keyConfigs) {
+        return keyConfigs.stream().anyMatch(key::endsWith);
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/TagKeyMatcher.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/TagKeyMatcher.java
@@ -34,14 +34,14 @@ public class TagKeyMatcher {
     private static final TagTransmissionConfig CONFIG = PluginConfigManager.getPluginConfig(
             TagTransmissionConfig.class);
 
-    private static final String EQUALS_RULE_KEY = "equals";
+    private static final String EXACT_RULE_KEY = "exact";
 
     private static final String PREFIX_RULE_KEY = "prefix";
 
     private static final String SUFFIX_RULE_KEY = "suffix";
 
     static {
-        STRATEGY_MAP.put(EQUALS_RULE_KEY, new EqualsMatchStrategy());
+        STRATEGY_MAP.put(EXACT_RULE_KEY, new ExactMatchStrategy());
         STRATEGY_MAP.put(PREFIX_RULE_KEY, new PrefixMatchStrategy());
         STRATEGY_MAP.put(SUFFIX_RULE_KEY, new SuffixMatchStrategy());
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/TagKeyMatcher.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/config/strategy/TagKeyMatcher.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.config.strategy;
+
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 流量标签是否需要透传的匹配器
+ *
+ * @author lilai
+ * @since 2023-09-07
+ */
+public class TagKeyMatcher {
+    private static final Map<String, MatchStrategy> STRATEGY_MAP = new HashMap<>();
+
+    private static final TagTransmissionConfig CONFIG = PluginConfigManager.getPluginConfig(
+            TagTransmissionConfig.class);
+
+    private static final String EQUALS_RULE_KEY = "equals";
+
+    private static final String PREFIX_RULE_KEY = "prefix";
+
+    private static final String SUFFIX_RULE_KEY = "suffix";
+
+    static {
+        STRATEGY_MAP.put(EQUALS_RULE_KEY, new EqualsMatchStrategy());
+        STRATEGY_MAP.put(PREFIX_RULE_KEY, new PrefixMatchStrategy());
+        STRATEGY_MAP.put(SUFFIX_RULE_KEY, new SuffixMatchStrategy());
+    }
+
+    private TagKeyMatcher() {
+    }
+
+    /**
+     * 是否匹配配置中需要透传的key的规则
+     *
+     * @param key 被匹配的key
+     * @return 匹配结果
+     */
+    public static boolean isMatch(String key) {
+        for (String rule : CONFIG.getMatchRule().keySet()) {
+            MatchStrategy matchStrategy = STRATEGY_MAP.get(rule);
+            if (matchStrategy.isMatch(key, CONFIG.getMatchRule().get(rule))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpcl
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import org.apache.commons.httpclient.HttpMethod;
@@ -54,7 +55,10 @@ public class HttpClient3xInterceptor extends AbstractClientInterceptor<HttpMetho
      */
     @Override
     protected void injectTrafficTag2Carrier(HttpMethod httpMethod) {
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient3xInterceptor.java
@@ -61,6 +61,7 @@ public class HttpClient3xInterceptor extends AbstractClientInterceptor<HttpMetho
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                httpMethod.setRequestHeader(key, null);
                 continue;
             }
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient4xInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.httpcl
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import org.apache.http.HttpRequest;
@@ -54,7 +55,10 @@ public class HttpClient4xInterceptor extends AbstractClientInterceptor<HttpReque
      */
     @Override
     protected void injectTrafficTag2Carrier(HttpRequest httpRequest) {
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/httpclient/HttpClient4xInterceptor.java
@@ -61,6 +61,7 @@ public class HttpClient4xInterceptor extends AbstractClientInterceptor<HttpReque
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                httpRequest.addHeader(key, null);
                 continue;
             }
             for (String value : values) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.jdk;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import sun.net.www.MessageHeader;
@@ -72,7 +73,10 @@ public class JdkHttpClientInterceptor extends AbstractClientInterceptor<MessageH
      */
     @Override
     protected void injectTrafficTag2Carrier(MessageHeader messageHeader) {
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/jdk/JdkHttpClientInterceptor.java
@@ -79,6 +79,7 @@ public class JdkHttpClientInterceptor extends AbstractClientInterceptor<MessageH
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                messageHeader.add(key, null);
                 continue;
             }
             for (String value : values) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
@@ -70,6 +70,7 @@ public class OkHttp2xInterceptor extends AbstractClientInterceptor<Builder> {
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                builder.addHeader(key, null);
                 continue;
             }
             for (String value : values) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/client/okhttp/OkHttp2xInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.http.client.okhttp
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import com.squareup.okhttp.Request.Builder;
@@ -63,7 +64,10 @@ public class OkHttp2xInterceptor extends AbstractClientInterceptor<Builder> {
      */
     @Override
     protected void injectTrafficTag2Carrier(Builder builder) {
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptor.java
@@ -88,13 +88,14 @@ public class HttpServletInterceptor extends AbstractServerInterceptor<HttpServle
                 continue;
             }
             Enumeration<String> valuesEnumeration = httpServletRequest.getHeaders(key);
-            if (valuesEnumeration == null) {
-                continue;
-            }
-            if (valuesEnumeration.hasMoreElements()) {
+            if (valuesEnumeration != null && valuesEnumeration.hasMoreElements()) {
                 List<String> values = Collections.list(valuesEnumeration);
                 tagMap.put(key, values);
+                continue;
             }
+
+            // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
+            tagMap.put(key, null);
         }
         return tagMap;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/http/server/HttpServletInterceptor.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.http.server;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
 
 import java.util.Collections;
@@ -80,7 +81,12 @@ public class HttpServletInterceptor extends AbstractServerInterceptor<HttpServle
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(HttpServletRequest httpServletRequest) {
         Map<String, List<String>> tagMap = new HashMap<>();
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        Enumeration<String> keyEnumeration = httpServletRequest.getHeaderNames();
+        while (keyEnumeration.hasMoreElements()) {
+            String key = keyEnumeration.nextElement();
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             Enumeration<String> valuesEnumeration = httpServletRequest.getHeaders(key);
             if (valuesEnumeration == null) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaConsumerRecordInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaConsumerRecordInterceptor.java
@@ -81,6 +81,10 @@ public class KafkaConsumerRecordInterceptor extends AbstractServerInterceptor<Co
         Map<String, List<String>> headerMap = new HashMap<>();
         for (Header header : consumerRecord.headers()) {
             String key = header.key();
+            if (header.value() == null) {
+                headerMap.computeIfAbsent(key, k -> null);
+                continue;
+            }
             String value = new String(header.value(), StandardCharsets.UTF_8);
             headerMap.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
         }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaConsumerRecordInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaConsumerRecordInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -66,9 +67,11 @@ public class KafkaConsumerRecordInterceptor extends AbstractServerInterceptor<Co
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(ConsumerRecord<?, ?> consumerRecord) {
         Map<String, List<String>> headerMap = convertHeaders(consumerRecord);
-        List<String> tagKeys = tagTransmissionConfig.getTagKeys();
         Map<String, List<String>> tagMap = new HashMap<>();
-        for (String key : tagKeys) {
+        for (String key : headerMap.keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             tagMap.put(key, headerMap.get(key));
         }
         return tagMap;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaProducerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaProducerInterceptor.java
@@ -64,6 +64,7 @@ public class KafkaProducerInterceptor extends AbstractClientInterceptor<Producer
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                headers.add(key, null);
                 continue;
             }
             for (String value : values) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaProducerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/kafka/KafkaProducerInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.mq.kafka;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -57,7 +58,10 @@ public class KafkaProducerInterceptor extends AbstractClientInterceptor<Producer
     @Override
     protected void injectTrafficTag2Carrier(ProducerRecord<?, ?> producerRecord) {
         Headers headers = producerRecord.headers();
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqConsumerInterceptor.java
@@ -87,11 +87,11 @@ public class RocketmqConsumerInterceptor extends AbstractServerInterceptor<Messa
                 continue;
             }
             String value = message.getProperty(key);
-            if (value != null) {
-                tagMap.put(key, Collections.singletonList(value));
-            } else {
+            if (value == null || "null".equals(value)) {
                 tagMap.put(key, null);
+                continue;
             }
+            tagMap.put(key, Collections.singletonList(value));
         }
         return tagMap;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqConsumerInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
 
 import org.apache.rocketmq.common.message.Message;
@@ -27,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * RocketMQ流量标签透传的消费者拦截器，支持RocketMQ4.8+
@@ -76,7 +78,14 @@ public class RocketmqConsumerInterceptor extends AbstractServerInterceptor<Messa
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(Message message) {
         Map<String, List<String>> tagMap = new HashMap<>();
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        if (message.getProperties() == null) {
+            return tagMap;
+        }
+        Set<String> keySet = message.getProperties().keySet();
+        for (String key : keySet) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             String value = message.getProperty(key);
             if (value != null) {
                 tagMap.put(key, Collections.singletonList(value));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqProducerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqProducerInterceptor.java
@@ -82,6 +82,10 @@ public class RocketmqProducerInterceptor extends AbstractClientInterceptor<SendM
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                newProperties.append(key);
+                newProperties.append(LINK_MARK);
+                newProperties.append((String) null);
+                newProperties.append(SPLIT_MARK);
                 continue;
             }
             newProperties.append(key);

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqProducerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/mq/rocketmq/RocketmqProducerInterceptor.java
@@ -17,14 +17,14 @@
 package com.huaweicloud.sermant.tag.transmission.interceptors.mq.rocketmq;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
-import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import org.apache.rocketmq.common.protocol.header.SendMessageRequestHeader;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * RocketMQ流量标签透传的生产者拦截器，支持RocketMQ4.8+
@@ -64,7 +64,7 @@ public class RocketmqProducerInterceptor extends AbstractClientInterceptor<SendM
     @Override
     protected void injectTrafficTag2Carrier(SendMessageRequestHeader header) {
         String oldProperties = header.getProperties();
-        String newProperties = this.insertTags2Properties(oldProperties, TrafficUtils.getTrafficTag());
+        String newProperties = this.insertTags2Properties(oldProperties);
         header.setProperties(newProperties);
     }
 
@@ -72,19 +72,21 @@ public class RocketmqProducerInterceptor extends AbstractClientInterceptor<SendM
      * 将流量标签插入到properties字符串中 原始properties的格式形如：key1[SOH]value1[STX]key2[SOH]value2，其中[SOH]为ASCII=1的符号，[STX]为ASCII=2的符号
      *
      * @param oldProperties 原始properties
-     * @param trafficTag 流量标签
      * @return String
      */
-    private String insertTags2Properties(String oldProperties, TrafficTag trafficTag) {
-        Map<String, List<String>> tags = trafficTag.getTag();
+    private String insertTags2Properties(String oldProperties) {
         StringBuilder newProperties = new StringBuilder();
-        for (Map.Entry<String, List<String>> entry : tags.entrySet()) {
-            if (entry.getValue() == null) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
                 continue;
             }
-            newProperties.append(entry.getKey());
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+            newProperties.append(key);
             newProperties.append(LINK_MARK);
-            newProperties.append(entry.getValue().get(0));
+            newProperties.append(values.get(0));
             newProperties.append(SPLIT_MARK);
         }
         if (newProperties.length() == 0) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboConsumerInterceptor.java
@@ -66,6 +66,7 @@ public class AlibabaDubboConsumerInterceptor extends AbstractClientInterceptor<R
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                invocation.setAttachment(key, null);
                 continue;
             }
             invocation.setAttachment(key, values.get(0));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboConsumerInterceptor.java
@@ -19,12 +19,12 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import com.alibaba.dubbo.rpc.RpcInvocation;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * dubbo流量标签透传consumer端的拦截器，支持alibaba dubbo2.6.x版本
@@ -60,11 +60,15 @@ public class AlibabaDubboConsumerInterceptor extends AbstractClientInterceptor<R
      */
     @Override
     protected void injectTrafficTag2Carrier(RpcInvocation invocation) {
-        for (Map.Entry<String, List<String>> entry : TrafficUtils.getTrafficTag().getTag().entrySet()) {
-            if (entry.getKey() == null || CollectionUtils.isEmpty(entry.getValue())) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
                 continue;
             }
-            invocation.setAttachment(entry.getKey(), entry.getValue().get(0));
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+            invocation.setAttachment(key, values.get(0));
         }
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboProviderInterceptor.java
@@ -92,6 +92,9 @@ public class AlibabaDubboProviderInterceptor extends AbstractServerInterceptor<R
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(RpcInvocation invocation) {
         Map<String, List<String>> tag = new HashMap<>();
+        if (invocation.getAttachments() == null) {
+            return tag;
+        }
         Set<String> keySet = invocation.getAttachments().keySet();
         for (String key : keySet) {
             if (!TagKeyMatcher.isMatch(key)) {

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/AlibabaDubboProviderInterceptor.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
 
 import com.alibaba.dubbo.rpc.Invoker;
@@ -27,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * dubbo流量标签透传的provider端拦截器，支持alibaba dubbo2.6.x版本
@@ -90,7 +92,11 @@ public class AlibabaDubboProviderInterceptor extends AbstractServerInterceptor<R
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(RpcInvocation invocation) {
         Map<String, List<String>> tag = new HashMap<>();
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        Set<String> keySet = invocation.getAttachments().keySet();
+        for (String key : keySet) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             String value = invocation.getAttachment(key);
 
             // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptor.java
@@ -61,6 +61,7 @@ public class ApacheDubboConsumerInterceptor extends AbstractClientInterceptor<Rp
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                invocation.setAttachment(key, null);
                 continue;
             }
             invocation.setAttachment(key, values.get(0));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboConsumerInterceptor.java
@@ -19,12 +19,12 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import org.apache.dubbo.rpc.RpcInvocation;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * dubbo流量标签透传consumer端的拦截器，支持dubbo2.7.x, 3.x版本
@@ -55,11 +55,15 @@ public class ApacheDubboConsumerInterceptor extends AbstractClientInterceptor<Rp
      */
     @Override
     protected void injectTrafficTag2Carrier(RpcInvocation invocation) {
-        for (Map.Entry<String, List<String>> entry : TrafficUtils.getTrafficTag().getTag().entrySet()) {
-            if (entry.getKey() == null || CollectionUtils.isEmpty(entry.getValue())) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
                 continue;
             }
-            invocation.setAttachment(entry.getKey(), entry.getValue().get(0));
+            List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
+            if (CollectionUtils.isEmpty(values)) {
+                continue;
+            }
+            invocation.setAttachment(key, values.get(0));
         }
     }
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/dubbo/ApacheDubboProviderInterceptor.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.dubbo;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
 import com.huaweicloud.sermant.tag.transmission.utils.DubboUtils;
 
@@ -28,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * dubbo流量标签透传的provider端拦截器，支持dubbo2.7.x, 3.x
@@ -104,7 +106,11 @@ public class ApacheDubboProviderInterceptor extends AbstractServerInterceptor<Rp
                 .map(obj -> (Map<String, Object>) obj)
                 .orElse(new HashMap<>());
 
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        Set<String> keySet = attachments.keySet();
+        for (String key : keySet) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             Object value = attachments.get(key);
             if (value instanceof String) {
                 tag.put(key, Collections.singletonList((String) value));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptor.java
@@ -61,6 +61,8 @@ public class ClientCallImplInterceptor extends AbstractClientInterceptor<Metadat
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                // grpc 会对null校验，此处传递"null" 字符串
+                header.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), "null");
                 continue;
             }
             header.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), values.get(0));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import io.grpc.Metadata;
@@ -54,7 +55,10 @@ public class ClientCallImplInterceptor extends AbstractClientInterceptor<Metadat
 
     @Override
     protected void injectTrafficTag2Carrier(Metadata header) {
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
 import com.huaweicloud.sermant.tag.transmission.config.TagTransmissionConfig;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
@@ -30,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * grpc内部的server interceptor，从grpc的header中提取流量标签
@@ -65,7 +67,11 @@ public class ServerHeaderInterceptor implements ServerInterceptor {
 
     private void extractTrafficTagFromCarrier(Metadata requestHeaders) {
         Map<String, List<String>> tag = new HashMap<>();
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        Set<String> keySet = requestHeaders.keys();
+        for (String key : keySet) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             String value = requestHeaders.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
 
             // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptor.java
@@ -75,7 +75,7 @@ public class ServerHeaderInterceptor implements ServerInterceptor {
             String value = requestHeaders.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));
 
             // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
-            if (value == null) {
+            if (value == null || "null".equals(value)) {
                 tag.put(key, null);
                 continue;
             }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcConsumerInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.servicecomb;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import org.apache.servicecomb.core.Invocation;
@@ -57,7 +58,10 @@ public class ServiceCombRpcConsumerInterceptor extends AbstractClientInterceptor
      */
     @Override
     protected void injectTrafficTag2Carrier(Invocation invocation) {
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcConsumerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcConsumerInterceptor.java
@@ -64,6 +64,7 @@ public class ServiceCombRpcConsumerInterceptor extends AbstractClientInterceptor
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                invocation.getContext().put(key, null);
                 continue;
             }
             invocation.getContext().put(key, values.get(0));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcProviderInterceptor.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.servicecomb;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
 
 import org.apache.servicecomb.core.Invocation;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * servicecombRPC provider端interceptor，支持servicecomb2.x版本
@@ -68,7 +70,11 @@ public class ServiceCombRpcProviderInterceptor extends AbstractServerInterceptor
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(Invocation invocation) {
         Map<String, List<String>> tag = new HashMap<>();
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        Set<String> keySet = invocation.getContext().keySet();
+        for (String key : keySet) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             String value = invocation.getContext().get(key);
             if (value != null) {
                 // consumer端使用servicecombrpc方式调用provider端

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/servicecomb/ServiceCombRpcProviderInterceptor.java
@@ -24,6 +24,7 @@ import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInter
 import org.apache.servicecomb.core.Invocation;
 
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,15 @@ public class ServiceCombRpcProviderInterceptor extends AbstractServerInterceptor
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(Invocation invocation) {
         Map<String, List<String>> tag = new HashMap<>();
+        extractFromContext(invocation, tag);
+        extractFromRequestEx(invocation, tag);
+        return tag;
+    }
+
+    private void extractFromContext(Invocation invocation, Map<String, List<String>> tag) {
+        if (invocation.getContext() == null) {
+            return;
+        }
         Set<String> keySet = invocation.getContext().keySet();
         for (String key : keySet) {
             if (!TagKeyMatcher.isMatch(key)) {
@@ -82,16 +92,32 @@ public class ServiceCombRpcProviderInterceptor extends AbstractServerInterceptor
                 continue;
             }
 
+            // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
+            tag.put(key, null);
+        }
+    }
+
+    private void extractFromRequestEx(Invocation invocation, Map<String, List<String>> tag) {
+        if (invocation.getRequestEx() == null) {
+            return;
+        }
+        Enumeration<String> headerNames = invocation.getRequestEx().getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String key = headerNames.nextElement();
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
+
             // consumer端使用非servicecombrpc方式调用provider端，比如httpclient，okhttp等
-            value = invocation.getRequestEx().getHeader(key);
-            if (value != null) {
-                tag.put(key, Collections.singletonList(value));
+            Enumeration<String> valuesEnumeration = invocation.getRequestEx().getHeaders(key);
+            if (valuesEnumeration != null && valuesEnumeration.hasMoreElements()) {
+                List<String> values = Collections.list(valuesEnumeration);
+                tag.put(key, values);
                 continue;
             }
 
             // 流量标签的value为null时，也需存入本地变量，覆盖原来的value，以防误用旧流量标签
             tag.put(key, null);
         }
-        return tag;
     }
 }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptor.java
@@ -64,6 +64,8 @@ public class SofaRpcClientInterceptor extends AbstractClientInterceptor<SofaRequ
             }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
+                // sofa 无法添加value为null的键值对
+                sofaRequest.addRequestProp(key, "null");
                 continue;
             }
             sofaRequest.addRequestProp(key, values.get(0));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcClientInterceptor.java
@@ -19,6 +19,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.CollectionUtils;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractClientInterceptor;
 
 import com.alipay.sofa.rpc.core.request.SofaRequest;
@@ -57,7 +58,10 @@ public class SofaRpcClientInterceptor extends AbstractClientInterceptor<SofaRequ
      */
     @Override
     protected void injectTrafficTag2Carrier(SofaRequest sofaRequest) {
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        for (String key : TrafficUtils.getTrafficTag().getTag().keySet()) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             List<String> values = TrafficUtils.getTrafficTag().getTag().get(key);
             if (CollectionUtils.isEmpty(values)) {
                 continue;

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptor.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.sofarpc;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.config.strategy.TagKeyMatcher;
 import com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor;
 
 import com.alipay.sofa.rpc.core.request.SofaRequest;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * sofarpc server端interceptor，支持5.0+版本
@@ -68,7 +70,11 @@ public class SofaRpcServerInterceptor extends AbstractServerInterceptor<SofaRequ
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(SofaRequest sofaRequest) {
         Map<String, List<String>> tag = new HashMap<>();
-        for (String key : tagTransmissionConfig.getTagKeys()) {
+        Set<String> keySet = sofaRequest.getRequestProps().keySet();
+        for (String key : keySet) {
+            if (!TagKeyMatcher.isMatch(key)) {
+                continue;
+            }
             Object value = sofaRequest.getRequestProp(key);
             if (value instanceof String) {
                 tag.put(key, Collections.singletonList((String) value));

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/main/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/sofarpc/SofaRpcServerInterceptor.java
@@ -70,13 +70,16 @@ public class SofaRpcServerInterceptor extends AbstractServerInterceptor<SofaRequ
     @Override
     protected Map<String, List<String>> extractTrafficTagFromCarrier(SofaRequest sofaRequest) {
         Map<String, List<String>> tag = new HashMap<>();
+        if (sofaRequest.getRequestProps() == null) {
+            return tag;
+        }
         Set<String> keySet = sofaRequest.getRequestProps().keySet();
         for (String key : keySet) {
             if (!TagKeyMatcher.isMatch(key)) {
                 continue;
             }
             Object value = sofaRequest.getRequestProp(key);
-            if (value instanceof String) {
+            if (value instanceof String && !"null".equals(value)) {
                 tag.put(key, Collections.singletonList((String) value));
                 continue;
             }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/BaseInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/BaseInterceptorTest.java
@@ -26,7 +26,9 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 流量标签透传UT基础测试类
@@ -51,7 +53,9 @@ public class BaseInterceptorTest {
         List<String> tagKeys = new ArrayList<>();
         tagKeys.add("id");
         tagKeys.add("name");
-        tagTransmissionConfig.setTagKeys(tagKeys);
+        Map<String, List<String>> matchRule = new HashMap<>();
+        matchRule.put("equals", tagKeys);
+        tagTransmissionConfig.setMatchRule(matchRule);
         TrafficUtils.removeTrafficTag();
     }
 

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/BaseInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/BaseInterceptorTest.java
@@ -54,7 +54,7 @@ public class BaseInterceptorTest {
         tagKeys.add("id");
         tagKeys.add("name");
         Map<String, List<String>> matchRule = new HashMap<>();
-        matchRule.put("equals", tagKeys);
+        matchRule.put("exact", tagKeys);
         tagTransmissionConfig.setMatchRule(matchRule);
         TrafficUtils.removeTrafficTag();
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-service/src/main/java/com/huaweicloud/sermant/tag/transmission/listener/TagConfigListener.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-service/src/main/java/com/huaweicloud/sermant/tag/transmission/listener/TagConfigListener.java
@@ -72,7 +72,7 @@ public class TagConfigListener implements DynamicConfigListener {
             return;
         }
         tagTransmissionConfig.setEnabled(dynamicConfig.isEnabled());
-        tagTransmissionConfig.setTagKeys(dynamicConfig.getTagKeys());
+        tagTransmissionConfig.setMatchRule(dynamicConfig.getMatchRule());
         LOGGER.info(String.format(Locale.ROOT, "Update tagTransmissionConfig, %s",
                 tagTransmissionConfig.toString()));
     }


### PR DESCRIPTION
【修复issue】#1244

【修改内容】
（1）增加了流量标签键的匹配策略，当前支持：精确、前缀、后缀匹配
（2）在服务端会判断客户端请求携带的 header、attachment 等的键是否符合透传规则，如果符合，则放置在线程变量
（3）在客户端取出线程变量时，会判断线程变量中的键是否符合透传规则，如果符合，则在请求中携带

【用例描述】在config.yaml中配置分别配置等于、前缀、后缀匹配 规则，判断是否能够正常透传流量标签

【自测情况】1、本地静态检查通过；2、UT 测试通过

【影响范围】无