### PR TITLE
agentcore集成测试：测试插件（类匹配、方法匹配、增强能力、系统类）

### DIFF
--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/pom.xml
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>agentcore-test</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>agentcore-test-plugin</artifactId>
+
+    <properties>
+        <package.plugin.name>${project.artifactId}</package.plugin.name>
+        <package.plugin.version>${project.version}</package.plugin.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <package.plugin.type>plugin</package.plugin.type>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Sermant-Plugin-Name>${package.plugin.name}</Sermant-Plugin-Name>
+                            <Sermant-Plugin-Version>${package.plugin.version}</Sermant-Plugin-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/bootstrap/TestBootstrapDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/bootstrap/TestBootstrapDeclarer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.bootstrap;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap.ActiveCountInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap.GetAllStackTracesInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap.NoParamsConstructorInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap.SetNameInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试系统类的增强能力
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestBootstrapDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals("java.lang.Thread");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                // 测试静态方法
+                InterceptDeclarer.build(MethodMatcher.nameEquals("getAllStackTraces"),
+                        new GetAllStackTracesInterceptor()),
+                // 测试无参构造方法
+                InterceptDeclarer.build(MethodMatcher.isConstructor().and(MethodMatcher.paramCountEquals(0)),
+                        new NoParamsConstructorInterceptor()),
+                // 测试实例方法
+                InterceptDeclarer.build(MethodMatcher.nameEquals("setName"), new SetNameInterceptor()),
+                // 测试静态方法skip
+                InterceptDeclarer.build(MethodMatcher.nameEquals("activeCount"), new ActiveCountInterceptor()),
+        };
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestAnnotationDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestAnnotationDeclarer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.classmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试通过单个注解匹配类
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestAnnotationDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isAnnotatedWith("com.huaweicloud.agentcore.test.application.common.TestAnnotationA");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestAnnotationsDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestAnnotationsDeclarer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.classmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试注解匹配类
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestAnnotationsDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isAnnotatedWith("com.huaweicloud.agentcore.test.application.common.TestAnnotationA",
+                "com.huaweicloud.agentcore.test.application.common.TestAnnotationB");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestInfixDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestInfixDeclarer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.classmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试通过中缀匹配类
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestInfixDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameInfixedWith("Infix");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestPrefixDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestPrefixDeclarer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.classmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试通过前缀匹配类
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestPrefixDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.namePrefixedWith("com.huaweicloud.agentcore.test.application.tests.classmatch.Prefix");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestSuffixDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestSuffixDeclarer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.classmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试通过后缀匹配类
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestSuffixDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameSuffixedWith("Suffix");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestSuperTypeDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestSuperTypeDeclarer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.classmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试通过单个父类匹配类
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestSuperTypeDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isExtendedFrom("com.huaweicloud.agentcore.test.application.common.TestSuperTypeA");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestSuperTypesDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/classmatch/TestSuperTypesDeclarer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.classmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试超类匹配类
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestSuperTypesDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.isExtendedFrom("com.huaweicloud.agentcore.test.application.common.TestSuperTypeA",
+                "com.huaweicloud.agentcore.test.application.common.TestSuperTypeB");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/enhancement/TestExecuteContextDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/enhancement/TestExecuteContextDeclarer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.enhancement;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试ExecuteContext增强能力
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestExecuteContextDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals("com.huaweicloud.agentcore.test.application.tests.enhancement.EnhancementTest");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals("testSkipFunction"), new Interceptor() {
+                    @Override
+                    public ExecuteContext before(ExecuteContext context) {
+                        context.skip(true);
+                        return context;
+                    }
+
+                    @Override
+                    public ExecuteContext after(ExecuteContext context) {
+                        return context;
+                    }
+
+                    @Override
+                    public ExecuteContext onThrow(ExecuteContext context) {
+                        return context;
+                    }
+                }),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("testSetFiledFunction"), new Interceptor() {
+                    @Override
+                    public ExecuteContext before(ExecuteContext context) {
+                        context.setStaticFieldValue("staticField", "staticFieldSetBySermant");
+                        context.setMemberFieldValue("memberField", "memberFieldSetBySermant");
+                        return context;
+                    }
+
+                    @Override
+                    public ExecuteContext after(ExecuteContext context) {
+                        return context;
+                    }
+
+                    @Override
+                    public ExecuteContext onThrow(ExecuteContext context) {
+                        return context;
+                    }
+                }),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("testSetArguments"), new Interceptor() {
+                    @Override
+                    public ExecuteContext before(ExecuteContext context) {
+                        context.getArguments()[0] = "argSetBySermant";
+                        return context;
+                    }
+
+                    @Override
+                    public ExecuteContext after(ExecuteContext context) {
+                        return context;
+                    }
+
+                    @Override
+                    public ExecuteContext onThrow(ExecuteContext context) {
+                        return context;
+                    }
+                })
+        };
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/methodmatch/TestMethodMatcherDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/methodmatch/TestMethodMatcherDeclarer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.methodmatch;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.SetEnhanceFlagInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试方法匹配
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class TestMethodMatcherDeclarer extends AbstractPluginDeclarer {
+    /**
+     * 测试方法参数为3时的方法匹配
+     */
+    private static final int TEST_METHOD_PARAMS_COUNT = 3;
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(
+                "com.huaweicloud.agentcore.test.application.tests.methodmatch.MethodMatchersTest");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.isConstructor(), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.isStaticMethod(), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("exactNameMethod"), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("exactNameMethod"), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.namePrefixedWith("prefix"), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameInfixedWith("Infix"), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameSuffixedWith("Suffix"), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.resultTypeEquals(boolean.class), new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.paramCountEquals(TEST_METHOD_PARAMS_COUNT),
+                        new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.paramTypesEqual(boolean.class, boolean.class),
+                        new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(
+                        MethodMatcher.isAnnotatedWith(
+                                "com.huaweicloud.agentcore.test.application.common.TestAnnotationA"),
+                        new SetEnhanceFlagInterceptor()),
+                InterceptDeclarer.build(
+                        MethodMatcher.isAnnotatedWith(
+                                "com.huaweicloud.agentcore.test.application.common.TestAnnotationA",
+                                "com.huaweicloud.agentcore.test.application.common.TestAnnotationB"),
+                        new SetEnhanceFlagInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/SetEnhanceFlagInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/SetEnhanceFlagInterceptor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+
+/**
+ * 告知应用被成功增强
+ *
+ * @author luanwenfei
+ * @since 2023-09-07
+ */
+public class SetEnhanceFlagInterceptor extends AbstractInterceptor {
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        context.getArguments()[0] = true;
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/ActiveCountInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/ActiveCountInterceptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+
+/**
+ * 测试静态方法的skip
+ *
+ * @author tangle
+ * @since 2023-09-07
+ */
+public class ActiveCountInterceptor extends AbstractInterceptor {
+    private static final int SKIP_COUNT = 999;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        return context.skip(SKIP_COUNT);
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/GetAllStackTracesInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/GetAllStackTracesInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+
+import java.lang.reflect.Method;
+
+/**
+ * 测试静态方法的拦截
+ *
+ * @author tangle
+ * @since 2023-09-07
+ */
+public class GetAllStackTracesInterceptor extends AbstractInterceptor {
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        Class<?> targetClass = Class.forName("com.huaweicloud.agentcore.test.application.tests.bootstrap"
+                + ".BootstrapTest");
+        Method targetMethod = targetClass.getMethod("setStaticFlag", boolean.class);
+        targetMethod.invoke(null, true);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/NoParamsConstructorInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/NoParamsConstructorInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+
+import java.lang.reflect.Method;
+
+/**
+ * 测试无参构造函数的拦截
+ *
+ * @author tangle
+ * @since 2023-09-07
+ */
+public class NoParamsConstructorInterceptor extends AbstractInterceptor {
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        Class<?> targetClass = Class.forName("com.huaweicloud.agentcore.test.application.tests.bootstrap"
+                + ".BootstrapTest");
+        Method targetMethod = targetClass.getMethod("setConstructorFlag", boolean.class);
+        targetMethod.invoke(null, true);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/SetNameInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/bootstrap/SetNameInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.bootstrap;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+
+/**
+ * 测试实例方法的拦截
+ *
+ * @author tangle
+ * @since 2023-09-07
+ */
+public class SetNameInterceptor extends AbstractInterceptor {
+    /**
+     * 修改Thread.setName()的入参为“modifyName”
+     */
+    private static final String NAME = "modifyName";
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        context.getArguments()[0] = NAME;
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,10 @@
+com.huaweicloud.agentcore.tests.plugin.declarer.enhancement.TestExecuteContextDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.classmatch.TestAnnotationDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.classmatch.TestAnnotationsDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.classmatch.TestSuperTypeDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.classmatch.TestSuperTypesDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.classmatch.TestInfixDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.classmatch.TestPrefixDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.classmatch.TestSuffixDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.methodmatch.TestMethodMatcherDeclarer
+com.huaweicloud.agentcore.tests.plugin.declarer.bootstrap.TestBootstrapDeclarer

--- a/sermant-integration-tests/agentcore-test/pom.xml
+++ b/sermant-integration-tests/agentcore-test/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+        <relativePath/>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>agentcore-test</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>agentcore-test-plugin</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+
+        <sermant.basedir>${pom.basedir}/../../..</sermant.basedir>
+        <package.plugin.name>${project.artifactId}</package.plugin.name>
+        <package.plugin.version>${project.version}</package.plugin.version>
+        <package.plugin.dir>${package.agent.dir}/pluginPackage</package.plugin.dir>
+        <package.plugin.type>undefined</package.plugin.type>
+        <package.output.dir>${package.plugin.dir}/${package.plugin.name}/${package.plugin.type}</package.output.dir>
+        <package.server.output.dir>${package.server.dir}/${package.plugin.name}</package.server.output.dir>
+
+        <config.skip.flag>true</config.skip.flag>
+        <config.file.name>config.yaml</config.file.name>
+        <config.source.dir>../config</config.source.dir>
+        <config.output.dir>${package.plugin.dir}/${package.plugin.name}/config</config.output.dir>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>test</id>
+            <modules>
+                <module>agentcore-test-plugin</module>
+            </modules>
+        </profile>
+    </profiles>
+
+    <build>
+        <finalName>${project.artifactId}-${package.plugin.version}</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Sermant-Plugin-Name>${package.plugin.name}</Sermant-Plugin-Name>
+                                <Sermant-Plugin-Version>${package.plugin.version}</Sermant-Plugin-Version>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>copy-resources</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${config.skip.flag}</skip>
+                                <outputDirectory>${config.output.dir}</outputDirectory>
+                                <overwrite>true</overwrite>
+                                <resources>
+                                    <resource>
+                                        <directory>${config.source.dir}</directory>
+                                        <includes>
+                                            <include>${config.file.name}</include>
+                                        </includes>
+                                    </resource>
+                                </resources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <configuration>
+                        <outputFile>${package.output.dir}/${project.artifactId}-${project.version}.jar</outputFile>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/sermant-integration-tests/pom.xml
+++ b/sermant-integration-tests/pom.xml
@@ -29,6 +29,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>agentcore-test</module>
         <module>dubbo-test</module>
         <module>spring-test</module>
     </modules>


### PR DESCRIPTION
【修复issue】#1298

【修改内容】
1. 增加了agentcore的测试插件结构，方便挂载在测试应用上进行agentcore的功能测试
2. 测试插件增加功能：类匹配测试、方法匹配测试、增强能力测试、部分系统类测试

【用例描述】是，待后续代码补充

【自测情况】本地静态检查通过，集成测试通过，测试代码后续补充

【影响范围】无