### PR TITLE
动态配置核心服务支持nacos：UT

### DIFF
--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigService.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigService.java
@@ -330,11 +330,6 @@ public class NacosDynamicConfigService extends DynamicConfigService {
      * @return nacos监听器
      */
     private Listener instantiateListener(String key, String validGroup, DynamicConfigListener listener) {
-        // 初始获取一次config
-        String config = nacosClient.getConfig(key, validGroup);
-        if (!StringUtils.isEmpty(config)) {
-            listener.process(DynamicConfigEvent.initEvent(key, validGroup, config));
-        }
         return new Listener() {
             private final Executor defaultExecutor = Executors.newSingleThreadExecutor();
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribeTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribeTest.java
@@ -1,0 +1,94 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+/**
+ * Nacos动态配置订阅功能测试
+ *
+ * @author tangle
+ * @since 2023-09-08
+ */
+public class DynamicConfigSubscribeTest extends NacosBaseTest {
+    /**
+     * 订阅器
+     */
+    DynamicConfigSubscribe dynamicConfigSubscribe;
+
+    public DynamicConfigSubscribeTest() {
+    }
+
+    @Test
+    public void test() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
+        try {
+            // 测试订阅
+            TestListener testListener = new TestListener();
+            dynamicConfigSubscribe = new DynamicConfigSubscribe("testServiceName", testListener, "testPluginName",
+                    "testSubscribeKey");
+            Assert.assertTrue(dynamicConfigSubscribe.subscribe());
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment",
+                            "content:1"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment_service:testServiceName",
+                            "content:2"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "testCustomLabel:testCustomLabelValue",
+                            "content:3"));
+            Thread.sleep(1000);
+            Assert.assertTrue(testListener.isChange());
+            Field fieldListener = nacosDynamicConfigService.getClass().getDeclaredField("listeners");
+            fieldListener.setAccessible(true);
+            Assert.assertEquals(3,
+                    ((List<NacosListener>) fieldListener.get(nacosDynamicConfigService)).size());
+
+            // 测试删除订阅
+            Assert.assertTrue(dynamicConfigSubscribe.unSubscribe());
+            Assert.assertEquals(0,
+                    ((List<NacosListener>) fieldListener.get(nacosDynamicConfigService)).size());
+            testListener.setChange(false);
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment",
+                            "content:11"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment_service:testServiceName",
+                            "content:22"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "testCustomLabel:testCustomLabelValue",
+                            "content:33"));
+            Thread.sleep(1000);
+            Assert.assertFalse(testListener.isChange());
+        } finally {
+            nacosDynamicConfigService.doRemoveConfig("testSubscribeKey",
+                    "app:testApplication_environment:testEnvironment");
+            nacosDynamicConfigService.doRemoveConfig("testSubscribeKey",
+                    "app:testApplication_environment:testEnvironment_service:testServiceName");
+            nacosDynamicConfigService.doRemoveConfig("testSubscribeKey", "testCustomLabel:testCustomLabelValue");
+        }
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosBaseTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosBaseTest.java
@@ -1,0 +1,113 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+import com.huaweicloud.sermant.core.service.dynamicconfig.config.DynamicConfig;
+import com.huaweicloud.sermant.core.utils.AesUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+/**
+ * Nacos动态配置基础测试
+ *
+ * @author tangle
+ * @since 2023-09-08
+ */
+public class NacosBaseTest {
+    /**
+     * Nacos动态配置服务
+     */
+    public NacosDynamicConfigService nacosDynamicConfigService;
+
+    /**
+     * 配置类
+     */
+    public final DynamicConfig dynamicConfig = new DynamicConfig();
+
+    public final ServiceMeta serviceMeta = new ServiceMeta();
+
+    public MockedStatic<ConfigManager> dynamicConfigMockedStatic;
+
+    public MockedStatic<ServiceManager> serviceManagerMockedStatic;
+
+    /**
+     * 测试监听器子类
+     */
+    public class TestListener implements DynamicConfigListener {
+        private boolean isChange = false;
+
+        @Override
+        public void process(DynamicConfigEvent event) {
+            setChange(true);
+        }
+
+        public boolean isChange() {
+            return isChange;
+        }
+
+        public void setChange(boolean change) {
+            isChange = change;
+        }
+    }
+
+    /**
+     * 初始配置设置
+     */
+    @Before
+    public void initConfig() {
+        dynamicConfig.setEnableAuth(true);
+        dynamicConfig.setServerAddress("127.0.0.1:8848");
+        dynamicConfig.setTimeoutValue(30000);
+        Optional<String> optional = AesUtil.generateKey();
+        dynamicConfig.setPrivateKey(optional.orElse(""));
+        dynamicConfig.setUserName(AesUtil.encrypt(optional.get(), "nacos").orElse(""));
+        dynamicConfig.setPassword(AesUtil.encrypt(optional.get(), "nacos").orElse(""));
+        serviceMeta.setProject("testProject2");
+        serviceMeta.setApplication("testApplication");
+        serviceMeta.setEnvironment("testEnvironment");
+        serviceMeta.setCustomLabel("testCustomLabel");
+        serviceMeta.setCustomLabelValue("testCustomLabelValue");
+        dynamicConfigMockedStatic = Mockito.mockStatic(ConfigManager.class);
+        dynamicConfigMockedStatic.when(() -> ConfigManager.getConfig(DynamicConfig.class))
+                .thenReturn(dynamicConfig);
+        dynamicConfigMockedStatic.when(() -> ConfigManager.getConfig(ServiceMeta.class))
+                .thenReturn(serviceMeta);
+
+        nacosDynamicConfigService = new NacosDynamicConfigService();
+        nacosDynamicConfigService.start();
+
+        serviceManagerMockedStatic = Mockito.mockStatic(ServiceManager.class);
+        serviceManagerMockedStatic.when(() -> ServiceManager.getService(NacosDynamicConfigService.class))
+                .thenReturn(nacosDynamicConfigService);
+    }
+
+    @After
+    public void closeMock() {
+        dynamicConfigMockedStatic.close();
+        serviceManagerMockedStatic.close();
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigServiceTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Nacos动态配置服务功能测试
+ *
+ * @author tangle
+ * @since 2023-09-08
+ */
+public class NacosDynamicConfigServiceTest extends NacosBaseTest {
+    @Test
+    public void test() throws Exception {
+        try {
+            // 测试发布和获取配置：合法group名称
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testTrueSingleConfigKey",
+                            "test.True&Single:Config-Group",
+                            "testTrueSingleConfigContent"));
+            Thread.sleep(1000);
+            Assert.assertEquals("testTrueSingleConfigContent",
+                    nacosDynamicConfigService.doGetConfig("testTrueSingleConfigKey",
+                            "test.True_Single:Config-Group").orElse(""));
+
+            // 测试发布和获取配置：不合法group名称
+            Assert.assertFalse(
+                    nacosDynamicConfigService.doPublishConfig("testErrorSingleConfigKey", "test+++Error&Single"
+                            + ":Config-Group", "testErrorSingleConfigContent"));
+            Assert.assertEquals(Optional.empty(), nacosDynamicConfigService.doGetConfig("testErrorSingleConfigKey",
+                    "test+++.Error_Single:Config-Group"));
+
+            // 测试移除配置
+            Assert.assertTrue(nacosDynamicConfigService.doRemoveConfig("testTrueSingleConfigKey", "test.True_Single"
+                    + ":Config-Group"));
+            Assert.assertEquals("",
+                    nacosDynamicConfigService.doGetConfig("testTrueSingleConfigKey",
+                            "test.True_Single:Config-Group").orElse(""));
+
+            // 测试监听器的添加
+            TestListener testListener = new TestListener();
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSingleListenerKey", "testSingleListenerGroup",
+                            "testSingleListenerContent"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doAddConfigListener("testSingleListenerKey", "testSingleListenerGroup",
+                            testListener));
+            Thread.sleep(1000);
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSingleListenerKey", "testSingleListenerGroup",
+                            "testSingleListenerContent-3"));
+            Thread.sleep(1000);
+            Assert.assertTrue(testListener.isChange());
+            testListener.setChange(false);
+
+            // 测试监听器的移除
+            Assert.assertTrue(nacosDynamicConfigService.doRemoveConfigListener("testSingleListenerKey",
+                    "testSingleListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSingleListenerKey", "testSingleListenerGroup",
+                            "testSingleListenerContent-3"));
+            Thread.sleep(1000);
+            Assert.assertFalse(testListener.isChange());
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testSingleListenerKey", "testSingleListenerGroup"));
+
+            // 测试组监听器的添加、获取组内所有key
+            TestListener testListenerGroup = new TestListener();
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-1", "testGroupListenerGroup",
+                            "testGroupListenerContent-1"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-2", "testGroupListenerGroup",
+                            "testGroupListenerContent-2"));
+            Assert.assertTrue(nacosDynamicConfigService.doAddGroupListener("testGroupListenerGroup",
+                    testListenerGroup));
+            Thread.sleep(1000);
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-2", "testGroupListenerGroup",
+                            "testGroupListenerContent-2-2"));
+            Assert.assertEquals(2, nacosDynamicConfigService.doListKeysFromGroup("testGroupListenerGroup").size());
+            Thread.sleep(1000);
+            Assert.assertTrue(testListenerGroup.isChange());
+
+            // 测试组监听器定时任务自动更新
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-3", "testGroupListenerGroup",
+                            "testGroupListenerContent-3"));
+            Thread.sleep(1000);
+            Whitebox.invokeMethod(nacosDynamicConfigService, "updateConfigListener");
+            Thread.sleep(1000);
+            Field fieldListener = nacosDynamicConfigService.getClass().getDeclaredField("listeners");
+            fieldListener.setAccessible(true);
+            Assert.assertEquals(3,
+                    ((List<NacosListener>) fieldListener.get(nacosDynamicConfigService)).get(0).getKeyListener()
+                            .size());
+            testListener.setChange(false);
+
+            // 测试组监听器的移除
+            Assert.assertTrue(nacosDynamicConfigService.doRemoveGroupListener("testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-4", "testGroupListenerGroup",
+                            "testGroupListenerKey-4"));
+            Thread.sleep(1000);
+            Assert.assertFalse(testListener.isChange());
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-1", "testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-2", "testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-3", "testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-4", "testGroupListenerGroup"));
+        } finally {
+            nacosDynamicConfigService.doRemoveConfig("testTrueSingleConfigKey", "test.True_Single"
+                    + ":Config-Group");
+            nacosDynamicConfigService.doRemoveConfigListener("testSingleListenerKey",
+                    "testSingleListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-1", "testGroupListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-2", "testGroupListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-3", "testGroupListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-4", "testGroupListenerGroup");
+        }
+    }
+}


### PR DESCRIPTION
【修复issue】#1289

【修改内容】
1. 增加了动态配置核心服务支持nacos的UT
2. 删除了没必要的监听前获取配置逻辑：DynamicConfigService类的addConfigListener方法中已经包含首次获取配置

【用例描述】增加了动态配置核心服务支持nacos的UT

【自测情况】本地静态检查通过，UT通过

【影响范围】无