### PR TITLE
动态配置核心服务支持nacos：UT、bug修改

### DIFF
--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -41,6 +41,11 @@ jobs:
           curl -o apache-zookeeper-3.6.3-bin.tar.gz -L https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
           tar -zxf apache-zookeeper-3.6.3-bin.tar.gz
           bash apache-zookeeper-3.6.3-bin/bin/zkServer.sh start apache-zookeeper-3.6.3-bin/conf/zoo_sample.cfg
+      - name: download nacos
+        run: |
+          curl -o nacos-server-2.1.0.tar.gz -L  https://github.com/alibaba/nacos/releases/download/2.1.0/nacos-server-2.1.0.tar.gz
+          tar -zxf nacos-server-2.1.0.tar.gz
+          bash nacos/bin/startup.sh -m standalone
       - name: Build with Maven
         run: mvn test
       - name: Generate code coverage report

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigService.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigService.java
@@ -330,11 +330,6 @@ public class NacosDynamicConfigService extends DynamicConfigService {
      * @return nacos监听器
      */
     private Listener instantiateListener(String key, String validGroup, DynamicConfigListener listener) {
-        // 初始获取一次config
-        String config = nacosClient.getConfig(key, validGroup);
-        if (!StringUtils.isEmpty(config)) {
-            listener.process(DynamicConfigEvent.initEvent(key, validGroup, config));
-        }
         return new Listener() {
             private final Executor defaultExecutor = Executors.newSingleThreadExecutor();
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribeTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribeTest.java
@@ -1,0 +1,107 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Nacos动态配置订阅功能测试
+ *
+ * @author tangle
+ * @since 2023-09-08
+ */
+public class DynamicConfigSubscribeTest extends NacosBaseTest {
+    /**
+     * 订阅器
+     */
+    DynamicConfigSubscribe dynamicConfigSubscribe;
+
+    public DynamicConfigSubscribeTest() {
+    }
+
+    @Test
+    public void testDynamicConfigSubscribe() throws NoSuchFieldException, IllegalAccessException, InterruptedException {
+        try {
+            // 测试订阅
+            TestListener testListener = new TestListener();
+            dynamicConfigSubscribe = new DynamicConfigSubscribe("testServiceName", testListener, "testPluginName",
+                    "testSubscribeKey");
+            Assert.assertTrue(dynamicConfigSubscribe.subscribe());
+            Thread.sleep(SLEEP_TIME_MILLIS);
+
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment",
+                            "content:1"));
+            checkChangeTrue(testListener, "content:1");
+
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment_service:testServiceName",
+                            "content:2"));
+            checkChangeTrue(testListener, "content:2");
+
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "testCustomLabel:testCustomLabelValue",
+                            "content:3"));
+            checkChangeTrue(testListener, "content:3");
+
+            Optional<Object> listeners = ReflectUtils.getFieldValueByClazz(nacosDynamicConfigService.getClass(),
+                    nacosDynamicConfigService, "listeners");
+            Assert.assertTrue(listeners.orElse(Collections.emptyList()) instanceof List);
+            Assert.assertEquals(3,
+                    ((List<NacosListener>) listeners.orElse(Collections.emptyList())).size());
+
+            // 测试删除订阅
+            Assert.assertTrue(dynamicConfigSubscribe.unSubscribe());
+            Assert.assertEquals(0,
+                    ((List<NacosListener>) listeners.orElse(Collections.emptyList())).size());
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment",
+                            "content:11"));
+            checkChangeFalse(testListener);
+
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "app:testApplication_environment:testEnvironment_service:testServiceName",
+                            "content:22"));
+            checkChangeFalse(testListener);
+
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSubscribeKey",
+                            "testCustomLabel:testCustomLabelValue",
+                            "content:33"));
+            checkChangeFalse(testListener);
+        } finally {
+            nacosDynamicConfigService.doRemoveConfig("testSubscribeKey",
+                    "app:testApplication_environment:testEnvironment");
+            nacosDynamicConfigService.doRemoveConfig("testSubscribeKey",
+                    "app:testApplication_environment:testEnvironment_service:testServiceName");
+            nacosDynamicConfigService.doRemoveConfig("testSubscribeKey", "testCustomLabel:testCustomLabelValue");
+        }
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosBaseTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosBaseTest.java
@@ -1,0 +1,129 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+import com.huaweicloud.sermant.core.service.dynamicconfig.config.DynamicConfig;
+import com.huaweicloud.sermant.core.utils.AesUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+/**
+ * Nacos动态配置基础测试
+ *
+ * @author tangle
+ * @since 2023-09-08
+ */
+public class NacosBaseTest {
+    /**
+     * 请求间隔线程睡眠时间
+     */
+    public static final long SLEEP_TIME_MILLIS = 1000L;
+
+    /**
+     * Nacos动态配置服务
+     */
+    public NacosDynamicConfigService nacosDynamicConfigService;
+
+    /**
+     * 配置类
+     */
+    public final DynamicConfig dynamicConfig = new DynamicConfig();
+
+    public final ServiceMeta serviceMeta = new ServiceMeta();
+
+    public MockedStatic<ConfigManager> dynamicConfigMockedStatic;
+
+    public MockedStatic<ServiceManager> serviceManagerMockedStatic;
+
+    /**
+     * 初始配置设置
+     */
+    @Before
+    public void initConfig() {
+        dynamicConfig.setEnableAuth(true);
+        dynamicConfig.setServerAddress("127.0.0.1:8848");
+        dynamicConfig.setTimeoutValue(30000);
+        Optional<String> optional = AesUtil.generateKey();
+        dynamicConfig.setPrivateKey(optional.orElse(""));
+        dynamicConfig.setUserName(AesUtil.encrypt(optional.get(), "nacos").orElse(""));
+        dynamicConfig.setPassword(AesUtil.encrypt(optional.get(), "nacos").orElse(""));
+        serviceMeta.setProject("testProject2");
+        serviceMeta.setApplication("testApplication");
+        serviceMeta.setEnvironment("testEnvironment");
+        serviceMeta.setCustomLabel("testCustomLabel");
+        serviceMeta.setCustomLabelValue("testCustomLabelValue");
+        dynamicConfigMockedStatic = Mockito.mockStatic(ConfigManager.class);
+        dynamicConfigMockedStatic.when(() -> ConfigManager.getConfig(DynamicConfig.class))
+                .thenReturn(dynamicConfig);
+        dynamicConfigMockedStatic.when(() -> ConfigManager.getConfig(ServiceMeta.class))
+                .thenReturn(serviceMeta);
+
+        nacosDynamicConfigService = new NacosDynamicConfigService();
+        nacosDynamicConfigService.start();
+
+        serviceManagerMockedStatic = Mockito.mockStatic(ServiceManager.class);
+        serviceManagerMockedStatic.when(() -> ServiceManager.getService(NacosDynamicConfigService.class))
+                .thenReturn(nacosDynamicConfigService);
+    }
+
+    @After
+    public void closeMock() {
+        if (dynamicConfigMockedStatic != null) {
+            dynamicConfigMockedStatic.close();
+        }
+        if (serviceManagerMockedStatic != null) {
+            serviceManagerMockedStatic.close();
+        }
+    }
+
+    /**
+     * 核查监听标识是否置true
+     *
+     * @param testListener 测试监听器
+     * @param predictContent 预测监听到的配置内容
+     * @throws InterruptedException
+     */
+    public void checkChangeTrue(TestListener testListener, String predictContent) throws InterruptedException {
+        Thread.sleep(SLEEP_TIME_MILLIS);
+        Assert.assertTrue(testListener.isChange());
+        Assert.assertEquals(predictContent, testListener.getContent());
+        testListener.setChange(false);
+    }
+
+    /**
+     * 核查监听标识是否置false
+     *
+     * @param testListener 测试监听器
+     * @throws InterruptedException
+     */
+    public void checkChangeFalse(TestListener testListener) throws InterruptedException {
+        Thread.sleep(SLEEP_TIME_MILLIS);
+        Assert.assertFalse(testListener.isChange());
+        testListener.setChange(false);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigServiceTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Nacos动态配置服务功能测试
+ *
+ * @author tangle
+ * @since 2023-09-08
+ */
+public class NacosDynamicConfigServiceTest extends NacosBaseTest {
+    @Test
+    public void testNacosDynamicConfigService() throws Exception {
+        try {
+            // 测试发布和获取配置：合法group名称
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testTrueSingleConfigKey",
+                            "test.True&Single:Config-Group",
+                            "testTrueSingleConfigContent"));
+            Thread.sleep(SLEEP_TIME_MILLIS);
+            Assert.assertEquals("testTrueSingleConfigContent",
+                    nacosDynamicConfigService.doGetConfig("testTrueSingleConfigKey",
+                            "test.True_Single:Config-Group").orElse(""));
+
+            // 测试发布和获取配置：不合法group名称
+            Assert.assertFalse(
+                    nacosDynamicConfigService.doPublishConfig("testErrorSingleConfigKey", "test+++Error&Single"
+                            + ":Config-Group", "testErrorSingleConfigContent"));
+            Assert.assertEquals(Optional.empty(), nacosDynamicConfigService.doGetConfig("testErrorSingleConfigKey",
+                    "test+++.Error_Single:Config-Group"));
+
+            // 测试移除配置
+            Assert.assertTrue(nacosDynamicConfigService.doRemoveConfig("testTrueSingleConfigKey", "test.True_Single"
+                    + ":Config-Group"));
+            Assert.assertEquals("",
+                    nacosDynamicConfigService.doGetConfig("testTrueSingleConfigKey",
+                            "test.True_Single:Config-Group").orElse(""));
+
+            // 测试监听器的添加
+            TestListener testListener = new TestListener();
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSingleListenerKey", "testSingleListenerGroup",
+                            "testSingleListenerContent"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doAddConfigListener("testSingleListenerKey", "testSingleListenerGroup",
+                            testListener));
+            Thread.sleep(SLEEP_TIME_MILLIS);
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSingleListenerKey", "testSingleListenerGroup",
+                            "testSingleListenerContent-3"));
+            checkChangeTrue(testListener, "testSingleListenerContent-3");
+
+            // 测试监听器的移除
+            Assert.assertTrue(nacosDynamicConfigService.doRemoveConfigListener("testSingleListenerKey",
+                    "testSingleListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testSingleListenerKey", "testSingleListenerGroup",
+                            "testSingleListenerContent-3"));
+            checkChangeFalse(testListener);
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testSingleListenerKey", "testSingleListenerGroup"));
+
+            // 测试组监听器的添加、获取组内所有key
+            TestListener testListenerGroup = new TestListener();
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-1", "testGroupListenerGroup",
+                            "testGroupListenerContent-1"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-2", "testGroupListenerGroup",
+                            "testGroupListenerContent-2"));
+            Assert.assertTrue(nacosDynamicConfigService.doAddGroupListener("testGroupListenerGroup",
+                    testListenerGroup));
+            Thread.sleep(SLEEP_TIME_MILLIS);
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-2", "testGroupListenerGroup",
+                            "testGroupListenerContent-2-2"));
+            Assert.assertEquals(2, nacosDynamicConfigService.doListKeysFromGroup("testGroupListenerGroup").size());
+            checkChangeTrue(testListenerGroup, "testGroupListenerContent-2-2");
+
+            // 测试组监听器定时任务自动更新
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-3", "testGroupListenerGroup",
+                            "testGroupListenerContent-3"));
+            Thread.sleep(SLEEP_TIME_MILLIS);
+            Whitebox.invokeMethod(nacosDynamicConfigService, "updateConfigListener");
+            Thread.sleep(SLEEP_TIME_MILLIS);
+
+            Optional<Object> listeners = ReflectUtils.getFieldValueByClazz(nacosDynamicConfigService.getClass(),
+                    nacosDynamicConfigService, "listeners");
+            Assert.assertTrue(listeners.orElse(Collections.emptyList()) instanceof List);
+            Assert.assertEquals(3,
+                    ((List<NacosListener>) listeners.orElse(Collections.emptyList())).get(0).getKeyListener()
+                            .size());
+
+            // 测试组监听器的移除
+            testListenerGroup.setChange(false);
+            Assert.assertTrue(nacosDynamicConfigService.doRemoveGroupListener("testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doPublishConfig("testGroupListenerKey-4", "testGroupListenerGroup",
+                            "testGroupListenerKey-4"));
+            checkChangeFalse(testListenerGroup);
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-1", "testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-2", "testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-3", "testGroupListenerGroup"));
+            Assert.assertTrue(
+                    nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-4", "testGroupListenerGroup"));
+        } finally {
+            nacosDynamicConfigService.doRemoveConfig("testTrueSingleConfigKey", "test.True_Single"
+                    + ":Config-Group");
+            nacosDynamicConfigService.doRemoveConfigListener("testSingleListenerKey",
+                    "testSingleListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-1", "testGroupListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-2", "testGroupListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-3", "testGroupListenerGroup");
+            nacosDynamicConfigService.doRemoveConfig("testGroupListenerKey-4", "testGroupListenerGroup");
+        }
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/TestListener.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/TestListener.java
@@ -1,0 +1,60 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.service.dynamicconfig.nacos;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+
+/**
+ * 测试监听器子类
+ *
+ * @author tangle
+ * @since 2023-09-12
+ */
+public class TestListener implements DynamicConfigListener {
+    /**
+     * 监听成功标识
+     */
+    private boolean isChange = false;
+
+    /**
+     * 监听到的配置内容
+     */
+    private String content;
+
+    @Override
+    public void process(DynamicConfigEvent event) {
+        setContent(event.getContent());
+        setChange(true);
+    }
+
+    public boolean isChange() {
+        return isChange;
+    }
+
+    public void setChange(boolean change) {
+        isChange = change;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/sermant-integration-tests/scripts/tryDownloadMidware.sh
+++ b/sermant-integration-tests/scripts/tryDownloadMidware.sh
@@ -29,6 +29,8 @@ ZK_FILE_NAME=apache-zookeeper-3.6.3-bin.tar.gz
 NACOS_ADDRESS=https://github.com/alibaba/nacos/releases/download/1.4.2/nacos-server-1.4.2.tar.gz
 NACOS_FILE_NAME=nacos-server-1.4.2.tar.gz
 
+NACOS_ADDRESS_210=https://github.com/alibaba/nacos/releases/download/2.1.0/nacos-server-2.1.0.tar.gz
+NACOS_FILE_NAME_210=nacos-server-2.1.0.tar.gz
 #======================================Service Center配置======================================
 SERVICE_CENTER_ADDRESS=https://github.com/apache/servicecomb-service-center/releases/download/v2.1.0/apache-servicecomb-service-center-2.1.0-linux-amd64.tar.gz
 SERVICE_CENTER_FILE_NAME=apache-servicecomb-service-center-2.1.0-linux-amd64.tar.gz
@@ -69,6 +71,9 @@ if [ $midleware == "zk" ];then
 elif [ $midleware == "nacos" ]; then
   ADDRESS=$NACOS_ADDRESS
   FILE_NAME=$NACOS_FILE_NAME
+elif [ $midleware == "nacos210" ]; then
+  ADDRESS=$NACOS_ADDRESS_210
+  FILE_NAME=$NACOS_FILE_NAME_210
 elif [ $midleware == "sc" ]; then
   ADDRESS=$SERVICE_CENTER_ADDRESS
   FILE_NAME=$SERVICE_CENTER_FILE_NAME


### PR DESCRIPTION
【修复issue】#1289

【修改内容】
1. 增加了动态配置核心服务支持nacos的UT
2. 删除了没必要的监听前获取配置逻辑：DynamicConfigService类的addConfigListener方法中已经包含首次获取配置

【用例描述】增加了动态配置核心服务支持nacos的UT

【自测情况】本地静态检查通过，UT通过

【影响范围】无