### PR TITLE
Modify zookeeper connection failure logs. 

### DIFF
--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperBufferedClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperBufferedClient.java
@@ -148,7 +148,7 @@ public class ZooKeeperBufferedClient implements Closeable {
         waitConnect();
         if (zkClient.getState() != ZooKeeper.States.CONNECTED
                 && zkClient.getState() != ZooKeeper.States.CONNECTEDREADONLY) {
-            throw new ZooKeeperInitException();
+            throw new ZooKeeperInitException("Unable to connect to the zookeeper server.");
         }
     }
 
@@ -181,7 +181,7 @@ public class ZooKeeperBufferedClient implements Closeable {
         try {
             return new ZooKeeper(connectString, sessionTimeout, watcher);
         } catch (IOException ignored) {
-            throw new ZooKeeperInitException(connectString);
+            throw new ZooKeeperInitException("Connect to " + connectString + "failed. ");
         }
     }
 
@@ -189,14 +189,14 @@ public class ZooKeeperBufferedClient implements Closeable {
      * 获取zk客户端，若客户端断开，则抛出异常
      *
      * @return zk客户端
-     * @throws ZooKeeperInitException zk初始化异常
+     * @throws ZooKeeperConnectionException zk连接异常
      */
     private ZooKeeper getZkClient() {
         final ZooKeeper.States state = zkClient.getState();
         if (state == ZooKeeper.States.CONNECTED || state == ZooKeeper.States.CONNECTEDREADONLY) {
             return zkClient;
         }
-        throw new ZooKeeperInitException();
+        throw new ZooKeeperConnectionException("Unable to connect to the zookeeper server, connection timeout.");
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperConnectionException.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperConnectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,20 @@
 package com.huaweicloud.sermant.implement.service.dynamicconfig.zookeeper;
 
 /**
- * zookeeper客户端初始化异常
+ * zookeeper连接异常
  *
- * @author HapThorin
- * @version 1.0.0
- * @since 2021-12-15
+ * @author zhp
+ * @since 2023-09-12
  */
-public class ZooKeeperInitException extends RuntimeException {
+public class ZooKeeperConnectionException extends RuntimeException {
     private static final long serialVersionUID = 5111014183835362572L;
 
     /**
-     * zookeeper连接失败
+     * zookeeper连接异常
      *
      * @param exceptionMessage 异常信息
      */
-    public ZooKeeperInitException(String exceptionMessage) {
+    public ZooKeeperConnectionException(String exceptionMessage) {
         super(exceptionMessage);
     }
 }


### PR DESCRIPTION
【Fix issue】#1295

[Modification content] Modify the exception information of zookeeper connection failure

[Use case description] The function has no impact, but exception information should be

[Self-test situation] 1. The local static check passed and the local test passed.

[Scope of influence] 1. No impact on users’ use