### PR TITLE
Add command parsing executor for dynamic installation and uninstallation

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/AgentUnInstallCommandExecutor.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/AgentUnInstallCommandExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.command;
+
+import com.huaweicloud.sermant.core.AgentCoreEntrance;
+
+/**
+ * Agent卸载命令执行器
+ *
+ * @author zhp
+ * @since 2023-09-09
+ */
+public class AgentUnInstallCommandExecutor implements CommandExecutor {
+    @Override
+    public void execute(String args) {
+        AgentCoreEntrance.unInstall();
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/Command.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/Command.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.command;
+
+/**
+ * 动态安装卸载的指令枚举
+ *
+ * @author zhp
+ * @since 2023-09-09
+ */
+public enum Command {
+    /**
+     * 卸载agent指令
+     */
+    UNINSTALL_AGENT("UNINSTALL-AGENT"),
+    /**
+     * 安装插件指令
+     */
+    INSTALL_PLUGINS("INSTALL-PLUGINS"),
+    /**
+     * 卸载插件指令
+     */
+    UNINSTALL_PLUGINS("UNINSTALL-PLUGINS");
+    private final String value;
+
+    Command(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/CommandExecutor.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/CommandExecutor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.command;
+
+/**
+ * 指令执行器
+ *
+ * @author zhp
+ * @since 2023-09-09
+ */
+public interface CommandExecutor {
+
+    /**
+     * 执行指令
+     *
+     * @param args 指令参数
+     */
+    void execute(String args);
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/CommandProcessor.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/CommandProcessor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.command;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 命令处理器
+ *
+ * @author zhp
+ * @since 2023-09-09
+ */
+public class CommandProcessor {
+    /**
+     * 命令执行器Map
+     */
+    private static final Map<String, CommandExecutor> COMMAND_EXECUTOR_MAP = new HashMap<>();
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    static {
+        COMMAND_EXECUTOR_MAP.put(Command.INSTALL_PLUGINS.getValue(), new PluginsInstallCommandExecutor());
+        COMMAND_EXECUTOR_MAP.put(Command.UNINSTALL_AGENT.getValue(), new AgentUnInstallCommandExecutor());
+        COMMAND_EXECUTOR_MAP.put(Command.UNINSTALL_PLUGINS.getValue(), new PluginsUnInstallCommandExecutor());
+    }
+
+    /**
+     * 构造函数
+     */
+    private CommandProcessor() {
+    }
+
+    /**
+     * 处理指令
+     *
+     * @param command 指令
+     */
+    public static void process(String command) {
+        if (StringUtils.isEmpty(command)) {
+            LOGGER.warning("Command information is empty.");
+            return;
+        }
+        LOGGER.log(Level.INFO, "Command information is {0}.", command);
+        String[] commandInfo = command.trim().split(":");
+        if (commandInfo.length == 0) {
+            LOGGER.warning("Illegal command information.");
+            return;
+        }
+        CommandExecutor commandExecutor = COMMAND_EXECUTOR_MAP.get(commandInfo[0].toUpperCase(Locale.ROOT));
+        if (commandExecutor == null) {
+            LOGGER.warning("No corresponding command executor found.");
+            return;
+        }
+        String commandArgs = commandInfo.length > 1 ? commandInfo[1] : null;
+        commandExecutor.execute(commandArgs);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/PluginsInstallCommandExecutor.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/PluginsInstallCommandExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.command;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.PluginManager;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * 插件安装命令执行器
+ *
+ * @author zhp
+ * @since 2023-09-09
+ */
+public class PluginsInstallCommandExecutor implements CommandExecutor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    public void execute(String args) {
+        if (StringUtils.isEmpty(args)) {
+            LOGGER.log(Level.WARNING, "The argument of command[INSTALL-PLUGINS] is empty.");
+            return;
+        }
+        String[] pluginNames = args.split("\\|");
+        PluginManager.install(Arrays.stream(pluginNames).collect(Collectors.toSet()));
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/PluginsUnInstallCommandExecutor.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/command/PluginsUnInstallCommandExecutor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.command;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.PluginManager;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * 插件卸载命令执行器
+ *
+ * @author zhp
+ * @since 2023-09-09
+ */
+public class PluginsUnInstallCommandExecutor implements CommandExecutor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    public void execute(String args) {
+        if (StringUtils.isEmpty(args)) {
+            LOGGER.log(Level.WARNING, "The argument of command[UNINSTALL-PLUGINS] is empty.");
+            return;
+        }
+        String[] pluginNames = args.split("\\|");
+        PluginManager.unInstall(Arrays.stream(pluginNames).collect(Collectors.toSet()));
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huaweicloud/sermant/core/command/CommandExecutorTest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/test/java/com/huaweicloud/sermant/core/command/CommandExecutorTest.java
@@ -1,0 +1,40 @@
+package com.huaweicloud.sermant.core.command;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class CommandExecutorTest {
+    private CommandExecutor commandExecutor;
+
+    @BeforeEach
+    public void setUp() {
+        commandExecutor = Mockito.mock(CommandExecutor.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        commandExecutor = null;
+    }
+
+    @Test
+    public void testExecuteWhenArgsIsValidThenNoException() {
+        // Arrange
+        String validArgs = "validArgs";
+
+        // Act & Assert
+        assertDoesNotThrow(() -> commandExecutor.execute(validArgs));
+    }
+
+    @Test
+    public void testExecuteWhenArgsIsNullThenNoException() {
+        // Arrange
+        String nullArgs = null;
+
+        // Act & Assert
+        assertDoesNotThrow(() -> commandExecutor.execute(nullArgs));
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-premain/src/test/java/com/huaweicloud/sermant/premain/common/BootArgsBuilderTest.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/test/java/com/huaweicloud/sermant/premain/common/BootArgsBuilderTest.java
@@ -4,6 +4,7 @@ package com.huaweicloud.sermant.premain.common;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -104,5 +105,17 @@ public class BootArgsBuilderTest {
                 }
             }
         }
+    }
+
+    /**
+     * 测试参数解析
+     */
+    @Test
+    public void testParseArgs(){
+        String agentArgs = "appName=test,command=INSTALL_PLUGIN:monitor|flowcontrol,server.port=9000";
+        Map<String, Object> argsMap = BootArgsBuilder.build(agentArgs);
+        Assert.assertEquals("test", argsMap.get("appName"));
+        Assert.assertEquals("9000", argsMap.get("server.port"));
+        Assert.assertEquals("INSTALL_PLUGIN:monitor|flowcontrol", argsMap.get("command"));
     }
 }


### PR DESCRIPTION
【Fix issue】#1236

【Modified content】
1. Modify parameter parsing to support dynamic installation and uninstallation of commands in the format similar to INSTALL-PLUGINS:[monitor].
2. Add command parsing for dynamic installation and uninstallation
3. Add a command executor for plug-in installation, uninstallation, and agent uninstallation (currently there is no specific execution logic)

[Use case description] 1. Subsequent supplementary use cases

[Self-test situation] 1. The local static check passed. 2. Passed the function self-test

[Scope of Impact] 1. User manual will be added in the future