### PR TITLE
Traffic label transparent transmission plugin: grpc module UT

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ClientCallImplInterceptorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+/**
+ * ClientCallImplInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-31
+ **/
+public class ClientCallImplInterceptorTest extends AbstractRpcInterceptorTest {
+    private final ClientCallImplInterceptor interceptor = new ClientCallImplInterceptor();
+
+    public ClientCallImplInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+        TrafficUtils.setTrafficTag(trafficTag);
+    }
+
+    @Test
+    public void testGrpcConsumer() {
+        Object[] arguments;
+        ExecuteContext context;
+        ExecuteContext returnContext;
+        Metadata metadata;
+        Key<String> name = Key.of("name", Metadata.ASCII_STRING_MARSHALLER);
+        Key<String> id = Key.of("id", Metadata.ASCII_STRING_MARSHALLER);
+        Key<String> key = Key.of("key", Metadata.ASCII_STRING_MARSHALLER);
+
+        // Metadata 为null
+        arguments = new Object[]{null, null};
+        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+        returnContext = interceptor.before(context);
+        Assert.assertNull(returnContext.getArguments()[1]);
+
+        // 流量标签关闭
+        tagTransmissionConfig.setEnabled(false);
+        metadata = new Metadata();
+        arguments = new Object[]{null, metadata};
+        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+        returnContext = interceptor.before(context);
+        Assert.assertNull(((Metadata) returnContext.getArguments()[1]).get(name));
+        Assert.assertNull(((Metadata) returnContext.getArguments()[1]).get(id));
+        tagTransmissionConfig.setEnabled(true);
+
+        // Metadata不为null, TrafficTag都是匹配的流量标签
+        metadata = new Metadata();
+        arguments = new Object[]{null, metadata};
+        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+        interceptor.before(context);
+        Assert.assertEquals("001", metadata.get(id));
+        Assert.assertEquals("test001", metadata.get(name));
+
+        // Metadata不为null, TrafficTag含有不匹配的流量标签
+        TrafficUtils.getTrafficTag().getTag().put("key", Collections.singletonList("value"));
+        metadata = new Metadata();
+        arguments = new Object[]{null, metadata};
+        context = ExecuteContext.forMemberMethod(new Object(), null, arguments, null, null);
+        interceptor.before(context);
+        Assert.assertEquals("001", metadata.get(id));
+        Assert.assertEquals("test001", metadata.get(name));
+        Assert.assertNull(metadata.get(key));
+    }
+}

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-plugin/src/test/java/com/huaweicloud/sermant/tag/transmission/interceptors/rpc/grpc/ServerHeaderInterceptorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.tag.transmission.interceptors.rpc.grpc;
+
+import com.huaweicloud.sermant.core.utils.tag.TrafficTag;
+import com.huaweicloud.sermant.core.utils.tag.TrafficUtils;
+import com.huaweicloud.sermant.tag.transmission.interceptors.rpc.AbstractRpcInterceptorTest;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ServerMetadataInterceptor类的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-08-31
+ **/
+public class ServerHeaderInterceptorTest extends AbstractRpcInterceptorTest {
+    private final ServerHeaderInterceptor interceptor = new ServerHeaderInterceptor();
+
+    public ServerHeaderInterceptorTest() {
+    }
+
+    @Override
+    public void doBefore(TrafficTag trafficTag) {
+    }
+
+    @Test
+    public void testInterceptCall() {
+        // 配置grpc拦截器所需参数
+        ServerCall call = Mockito.mock(ServerCall.class);
+        ServerCallHandler handler = Mockito.mock(ServerCallHandler.class);
+        Metadata metadata;
+        Map<String, List<String>> expectTag;
+        Key<String> name = Key.of("name", Metadata.ASCII_STRING_MARSHALLER);
+        Key<String> id = Key.of("id", Metadata.ASCII_STRING_MARSHALLER);
+
+        // metadata为null
+        interceptor.interceptCall(call, null, handler);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+
+        // metadata含有均符合匹配规则的流量标签，且value不为null
+        metadata = new Metadata();
+        metadata.put(id, "001");
+        metadata.put(name, "test001");
+        expectTag = new HashMap<>();
+        expectTag.put("id", Collections.singletonList("001"));
+        expectTag.put("name", Collections.singletonList("test001"));
+        interceptor.interceptCall(call, metadata, handler);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+
+        // metadata含有为null部分的流量标签
+        metadata = new Metadata();
+        metadata.put(name, "null");
+        metadata.put(id, "001");
+        expectTag = new HashMap<>();
+        expectTag.put("id", Collections.singletonList("001"));
+        expectTag.put("name", null);
+        interceptor.interceptCall(call, metadata, handler);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+    }
+
+    @After
+    public void afterTest() {
+        Mockito.clearAllCaches();
+    }
+}


### PR DESCRIPTION
【Fix issue】#1244

[Modification] Add traffic label transparent transmission plug-in grpc module UT

[Use case description] Do you need to modify the use case? reason? / Reason for not adding use cases?

[Self-test situation] 1. Local static check passed; 2. grpc partial UT coverage rate is 70%

[Scope of influence] None