### PR TITLE
Agentcore integration test: supplementary test plugin, automated test pipeline

### DIFF
--- a/.github/actions/common/agentcore/action.yml
+++ b/.github/actions/common/agentcore/action.yml
@@ -1,0 +1,59 @@
+name: "Common operations"
+description: "do something common for all test"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK ${{ env.javaVersion }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.javaVersion }}
+        distribution: 'adopt'
+        cache: maven
+    - name: download zookeeper
+      uses: actions/cache@v3
+      with:
+        path: apache-zookeeper-3.6.3-bin.tar.gz
+        key: ${{ runner.os }}-apache-zookeeper-3.6.3
+    - name: start zookeeper
+      shell: bash
+      run: |
+        tar -zxf apache-zookeeper-3.6.3-bin.tar.gz
+        bash apache-zookeeper-3.6.3-bin/bin/zkServer.sh start apache-zookeeper-3.6.3-bin/conf/zoo_sample.cfg
+    - name: download local cse
+      uses: actions/cache@v3
+      with:
+        path: Local-CSE-2.1.3-linux-amd64.zip
+        key: ${{ runner.os }}-local-cse
+        restore-keys: |
+          ${{ runner.os }}-local-cse
+    - name: start cse
+      shell: bash
+      run: |
+        export ROOT_PATH=$(pwd)
+        bash ./sermant-integration-tests/scripts/startCse.sh
+    - name: download nacos server
+      uses: actions/cache@v3
+      with:
+        path: nacos-server-2.1.0.tar.gz
+        key: ${{ runner.os }}-nacos-server-2.1.0
+        restore-keys: |
+          ${{ runner.os }}-nacos-server-2.1.0
+    - name: start nacos server
+      shell: bash
+      run: |
+        tar -zxf nacos-server-2.1.0.tar.gz
+        bash nacos/bin/startup.sh -m standalone
+    - name: cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: download agent
+      uses: actions/cache@v3
+      with:
+        path: sermant-agent-*/
+        key: ${{ runner.os }}-agent-${{ github.run_id }}
+    - name: plugin change check
+      uses: ./.github/actions/common/plugin-change-check

--- a/.github/actions/scenarios/agentcore/action.yml
+++ b/.github/actions/scenarios/agentcore/action.yml
@@ -1,0 +1,41 @@
+name: "Agent-core Common Test"
+description: "Auto test for spring common, include nacos dynamic config"
+runs:
+  using: "composite"
+  steps:
+    - name: entry
+      uses: ./.github/actions/common/entry
+      with:
+        log-dir: ./logs/agentcore-test
+    - name: start applications
+      shell: bash
+      env:
+        dynamic.config.serverAddress: 127.0.0.1:8848
+        dynamic.config.dynamicConfigType: NACOS
+        service.meta.project: TestAgentCore
+      run: |
+        nohup java -javaagent:sermant-agent-${{ env.sermantVersion }}/agent/sermant-agent.jar -jar \
+        sermant-agent-${{ env.sermantVersion }}/agent/agentcore-test-application-1.0.0-jar-with-dependencies.jar > ${{ env.logDir
+        }}/agentcore-test.log 2>&1 &
+    - name: waiting for agentcore services start
+      shell: bash
+      run: |
+        bash ./sermant-integration-tests/scripts/checkService.sh http://127.0.0.1:8915/ping 120
+    - name: agentcore test module start
+      shell: bash
+      run: mvn test --file sermant-integration-tests/agentcore-test/agentcore-integration-test/pom.xml
+    - name: exit
+      if: always()
+      uses: ./.github/actions/common/exit
+      with:
+        processor-keyword: agentcore
+    - name: if failure then upload error log
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() || cancelled() }}
+      with:
+        name: agentcore-test-logs
+        path: |
+          ./*.log
+          ./logs/**
+        if-no-files-found: warn
+        retention-days: 2

--- a/.github/workflows/agentcore_integration_test.yml
+++ b/.github/workflows/agentcore_integration_test.yml
@@ -1,0 +1,99 @@
+name: Agent-core Integration Test
+env:
+  sermantVersion: 1.0.0
+on:
+  push:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'sermant-agentcore/**'
+      - 'sermant-integration-tests/agentcore-test/**'
+      - '.github/workflows/agentcore*.yml'
+      - '.github/actions/common/agentcore/action.yml'
+      - '.github/actions/scenarios/agentcore/action.yml'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
+jobs:
+  download-midwares-and-cache:
+    name: download midwares and cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: cache local cse
+        uses: actions/cache@v3
+        with:
+          path: Local-CSE-2.1.3-linux-amd64.zip
+          key: ${{ runner.os }}-local-cse
+          restore-keys: |
+            ${{ runner.os }}-local-cse
+      - name: download cse
+        run: |
+          export ROOT_PATH=$(pwd)
+          bash ./sermant-integration-tests/scripts/tryDownloadMidware.sh cse
+      - name: cache zookeeper
+        uses: actions/cache@v3
+        with:
+          path: apache-zookeeper-3.6.3-bin.tar.gz
+          key: ${{ runner.os }}-apache-zookeeper-3.6.3
+          restore-keys: |
+            ${{ runner.os }}-apache-zookeeper-3.6.3
+      - name: download zookeeper
+        run: |
+          export ROOT_PATH=$(pwd)
+          bash ./sermant-integration-tests/scripts/tryDownloadMidware.sh zk
+      - name: cache nacos server
+        uses: actions/cache@v3
+        with:
+          path: nacos-server-2.1.0.tar.gz
+          key: ${{ runner.os }}-nacos-server-2.1.0
+          restore-keys: |
+            ${{ runner.os }}-nacos-server-2.1.0
+      - name: download nacos
+        run: |
+          export ROOT_PATH=$(pwd)
+          bash ./sermant-integration-tests/scripts/tryDownloadMidware.sh nacos210
+  build-agent-and-cache:
+    name: build agent and cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: maven
+      - name: cache agent
+        uses: actions/cache@v3
+        with:
+          path: sermant-agent-*/
+          key: ${{ runner.os }}-agent-${{ github.run_id }}
+      - name: package agent
+        run: |
+          sed -i '/sermant-injector/d' pom.xml
+          mvn package -DskipTests -Ptest --file pom.xml
+      - name: move test plugin
+        run: |
+          mkdir -p sermant-agent-${{ env.sermantVersion }}/agent/pluginPackage/agentcore-test-plugin/plugin
+          cp ./sermant-integration-tests/agentcore-test/agentcore-test-plugin/target/agentcore-test-plugin-1.0.0.jar sermant-agent-${{ env.sermantVersion }}/agent/pluginPackage/agentcore-test-plugin/plugin/
+          cp ./sermant-integration-tests/agentcore-test/agentcore-test-application/target/agentcore-test-application-1.0.0-jar-with-dependencies.jar sermant-agent-${{ env.sermantVersion }}/agent/
+          sed -i '/plugins:/a \  - agentcore-test-plugin' sermant-agent-${{ env.sermantVersion }}/agent/config/plugins.yaml
+  test-for-agentcore:
+    name: Test for agentcore
+    runs-on: ubuntu-latest
+    needs: [ build-agent-and-cache, download-midwares-and-cache ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
+      - name: set java version to environment
+        run: |
+          echo "javaVersion=8" >> $GITHUB_ENV
+      - name: common operations
+        uses: ./.github/actions/common/agentcore
+      - name: start agentcore test
+        uses: ./.github/actions/scenarios/agentcore
+
+

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/constants/TestConstants.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/constants/TestConstants.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.constants;
+
+/**
+ * 测试静态类
+ *
+ * @author tangle
+ * @since 2023-09-18
+ */
+public class TestConstants {
+    /**
+     * 参数下标；0，因测试插件，不进行具体定义
+     */
+    public static final int PARAM_INDEX_0 = 0;
+
+    /**
+     * 参数下标；1，因测试插件，不进行具体定义
+     */
+    public static final int PARAM_INDEX_1 = 1;
+
+    /**
+     * 参数下标；2，因测试插件，不进行具体定义
+     */
+    public static final int PARAM_INDEX_2 = 2;
+
+    /**
+     * 参数下标；3，因测试插件，不进行具体定义
+     */
+    public static final int PARAM_INDEX_3 = 3;
+
+    private TestConstants() {
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/dynamicconfig/TestDynamicConfigDeclarer.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/declarer/dynamicconfig/TestDynamicConfigDeclarer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.declarer.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig.AddConfigListenerInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig.AddGroupConfigListenerInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig.GetConfigInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig.PublishConfigInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig.RemoveConfigInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig.RemoveConfigListenerInterceptor;
+import com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig.RemoveGroupConfigListenerInterceptor;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * 测试动态配置核心
+ *
+ * @author tangle
+ * @since 2023-09-07
+ */
+public class TestDynamicConfigDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(
+                "com.huaweicloud.agentcore.test.application.tests.dynamicconfig.DynamicConfigTest");
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(MethodMatcher.nameEquals("publishConfig"), new PublishConfigInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("getConfig"), new GetConfigInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("removeConfig"), new RemoveConfigInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("addConfigListener"),
+                        new AddConfigListenerInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("removeConfigListener"),
+                        new RemoveConfigListenerInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("addGroupConfigListener"),
+                        new AddGroupConfigListenerInterceptor()),
+                InterceptDeclarer.build(MethodMatcher.nameEquals("removeGroupConfigListener"),
+                        new RemoveGroupConfigListenerInterceptor())};
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/AddConfigListenerInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/AddConfigListenerInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.constants.TestConstants;
+import com.huaweicloud.agentcore.tests.plugin.listener.TestListener;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 添加单一配置监听拦截器
+ *
+ * @author tangle
+ * @since 2023-08-30
+ */
+public class AddConfigListenerInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    DynamicConfigService dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        String key = (String) context.getArguments()[TestConstants.PARAM_INDEX_1];
+        String group = (String) context.getArguments()[TestConstants.PARAM_INDEX_2];
+        context.getArguments()[TestConstants.PARAM_INDEX_0] = dynamicConfigService.doAddConfigListener(key, group,
+                new TestListener());
+        LOGGER.log(Level.INFO, "Test agentcore add config listener, key:{0}, group:{1}, result:{2}",
+                new String[]{key, group, String.valueOf(context.getArguments()[TestConstants.PARAM_INDEX_0])});
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/AddGroupConfigListenerInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/AddGroupConfigListenerInterceptor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.constants.TestConstants;
+import com.huaweicloud.agentcore.tests.plugin.listener.TestListener;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 添加组配置监听拦截器
+ *
+ * @author tangle
+ * @since 2023-08-30
+ */
+public class AddGroupConfigListenerInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    DynamicConfigService dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        String group = (String) context.getArguments()[TestConstants.PARAM_INDEX_1];
+        context.getArguments()[TestConstants.PARAM_INDEX_0] = dynamicConfigService.doAddGroupListener(group,
+                new TestListener());
+        LOGGER.log(Level.INFO, "Test add group config listener, group:{0}, result:{1}",
+                new String[]{group, String.valueOf(context.getArguments()[TestConstants.PARAM_INDEX_0])});
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/GetConfigInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/GetConfigInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.constants.TestConstants;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 配置获取拦截器
+ *
+ * @author tangle
+ * @since 2023-08-30
+ */
+public class GetConfigInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    DynamicConfigService dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        String key = (String) context.getArguments()[TestConstants.PARAM_INDEX_1];
+        String group = (String) context.getArguments()[TestConstants.PARAM_INDEX_2];
+        String predictContent = (String) context.getArguments()[TestConstants.PARAM_INDEX_3];
+        String content = dynamicConfigService.doGetConfig(key, group).orElse("");
+        context.getArguments()[TestConstants.PARAM_INDEX_0] = predictContent.equals(content);
+        LOGGER.log(Level.INFO, "Test get config, key:{0}, group:{1}, config:{2}, result:{3}",
+                new String[]{key, group, content, String.valueOf(context.getArguments()[TestConstants.PARAM_INDEX_0])});
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/PublishConfigInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/PublishConfigInterceptor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.constants.TestConstants;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 配置发布拦截器
+ *
+ * @author tangle
+ * @since 2023-08-30
+ */
+public class PublishConfigInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    DynamicConfigService dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        String key = (String) context.getArguments()[TestConstants.PARAM_INDEX_1];
+        String group = (String) context.getArguments()[TestConstants.PARAM_INDEX_2];
+        String content = (String) context.getArguments()[TestConstants.PARAM_INDEX_3];
+        context.getArguments()[TestConstants.PARAM_INDEX_0] = dynamicConfigService.doPublishConfig(key, group, content);
+        LOGGER.log(Level.INFO, "Test publish config, key:{0}, group:{1}, config:{2}, result:{3}",
+                new String[]{key, group, content, String.valueOf(context.getArguments()[TestConstants.PARAM_INDEX_0])});
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/RemoveConfigInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/RemoveConfigInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.constants.TestConstants;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 配置移除拦截器
+ *
+ * @author tangle
+ * @since 2023-08-30
+ */
+public class RemoveConfigInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    DynamicConfigService dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        String key = (String) context.getArguments()[TestConstants.PARAM_INDEX_1];
+        String group = (String) context.getArguments()[TestConstants.PARAM_INDEX_2];
+        context.getArguments()[TestConstants.PARAM_INDEX_0] = dynamicConfigService.removeConfig(key, group);
+        LOGGER.log(Level.INFO, "Test remove config, key:{0}, group:{1}, result:{2}",
+                new String[]{key, group, String.valueOf(context.getArguments()[TestConstants.PARAM_INDEX_0])});
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/RemoveConfigListenerInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/RemoveConfigListenerInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.constants.TestConstants;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 移除单一配置监听拦截器
+ *
+ * @author tangle
+ * @since 2023-08-30
+ */
+public class RemoveConfigListenerInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    DynamicConfigService dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        String key = (String) context.getArguments()[TestConstants.PARAM_INDEX_1];
+        String group = (String) context.getArguments()[TestConstants.PARAM_INDEX_2];
+        context.getArguments()[TestConstants.PARAM_INDEX_0] = dynamicConfigService.doRemoveConfigListener(key, group);
+        LOGGER.log(Level.INFO, "Test remove config listener, key:{0}, group:{1}, result:{2}",
+                new String[]{key, group, String.valueOf(context.getArguments()[TestConstants.PARAM_INDEX_0])});
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/RemoveGroupConfigListenerInterceptor.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/interceptor/dynamicconfig/RemoveGroupConfigListenerInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.interceptor.dynamicconfig;
+
+import com.huaweicloud.agentcore.tests.plugin.constants.TestConstants;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 移除组配置监听拦截器
+ *
+ * @author tangle
+ * @since 2023-08-30
+ */
+public class RemoveGroupConfigListenerInterceptor extends AbstractInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    DynamicConfigService dynamicConfigService = ServiceManager.getService(DynamicConfigService.class);
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        String group = (String) context.getArguments()[TestConstants.PARAM_INDEX_1];
+        context.getArguments()[TestConstants.PARAM_INDEX_0] = dynamicConfigService.doRemoveGroupListener(group);
+        LOGGER.log(Level.INFO, "Test remove group config listener, group:{0}, result:{1}",
+                new String[]{group, String.valueOf(context.getArguments()[TestConstants.PARAM_INDEX_0])});
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        return context;
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/listener/TestListener.java
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/java/com/huaweicloud/agentcore/tests/plugin/listener/TestListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.agentcore.tests.plugin.listener;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 测试监听器类
+ *
+ * @author tangle
+ * @since 2023-09-11
+ */
+public class TestListener implements DynamicConfigListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    public void process(DynamicConfigEvent event) {
+        // 监听成功回执
+        setListenerReceipt();
+    }
+
+    /**
+     * 反射调用测试应用的监听成功标识变量
+     */
+    private void setListenerReceipt() {
+        try {
+            Class<?> targetClass = Class.forName(
+                    "com.huaweicloud.agentcore.test.application.tests.dynamicconfig"
+                            + ".DynamicConfigTest");
+            Method targetMethod = targetClass.getMethod("setListenerSuccess", boolean.class);
+            targetMethod.invoke(null, true);
+        } catch (ClassNotFoundException | InvocationTargetException | NoSuchMethodException
+                 | IllegalAccessException exception) {
+            LOGGER.log(Level.SEVERE, "setListenerReceipt exception: {0}", exception.getMessage());
+        }
+    }
+}

--- a/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-integration-tests/agentcore-test/agentcore-test-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,1 @@
+com.huaweicloud.agentcore.tests.plugin.declarer.dynamicconfig.TestDynamicConfigDeclarer


### PR DESCRIPTION
【Fix issue】#1298, #1289

【Modified content】
1. Supplement the agentcore integration test structure: test plug-in part (mounted on the test host application for interception enhancement), automated test pipeline
2. Add dynamic configuration related tests to the integrated test structure (supplementary test plug-in part)

[Use case description] Contains nacos dynamic configuration test cases

[Self-test status] The local static check passed and the local automated test passed.

[Scope of influence] None