### PR TITLE
Update versions of opensource components. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <http.client.version>4.5.13</http.client.version>
         <http.core.version>4.4.13</http.core.version>
         <Java-WebSocket.version>1.5.1</Java-WebSocket.version>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.94.Final</netty.version>
         <protobuf.version>3.17.3</protobuf.version>
         <fastjson.version>1.2.83</fastjson.version>
         <xml.apis.version>1.4.01</xml.apis.version>

--- a/sermant-agentcore/sermant-agentcore-implement/pom.xml
+++ b/sermant-agentcore/sermant-agentcore-implement/pom.xml
@@ -29,6 +29,7 @@
         <javadoc.plugin.version>3.3.2</javadoc.plugin.version>
         <nexus.staging.plugin.version>1.6.7</nexus.staging.plugin.version>
         <nacos.version>2.1.0</nacos.version>
+        <jackson-databind.version>2.13.4.1</jackson-databind.version>
     </properties>
 
     <dependencies>
@@ -52,6 +53,17 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>${fastjson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
【Fix issue】#1318

[Modification content] The versions of netty and jackson-databind have been modified. The netty version has been updated to 4.1.94.Final, and the jackson-databind version has been updated to 2.13.4.1.

[Use case description] Not required

[Self-test situation] 1. Local static check passed

[Scope of influence] None