### PR TITLE
Put the configuration item description into the configuration file and fix the bug where the heartbeat still reports plugin information after the plugin is uninstalled.

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/bootstrap.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/bootstrap.properties
@@ -1,4 +1,8 @@
+# 指定当前Sermant制品的制品名，用于在多Sermant场景中标识不同的Sermant制品，基于artifact隔离不同Sermant的配置及服务治理能力
 artifact=default
-#appName=default
-#appType=default
-#serviceName=default
+# 指定Sermant当前接入实例所归属实例的应用名
+appName=default
+# 指定Sermant当前接入实例所归属实例的应用类型
+appType=default
+# 指定Sermant当前接入实例所归属实例的服务名
+serviceName=default

--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -1,61 +1,96 @@
-# agent config
+#=============================字节码增强配置==============================
+# 字节码增强重转换开关, 开启则可以支持对已加载的类通过重转换进行字节码增强, 默认值为true
 agent.config.isReTransformEnable=true
+# 字节码增强日志输出开关, 开启则会将字节码增强相关日志输出到日志文件, 默认值为false
 agent.config.isShowEnhanceLog=false
+# 被增强类字节码输出开关, 开启则会将增强后的字节码以文件的形式进行输出, 默认值为false
 agent.config.isOutputEnhancedClasses=false
+# 被增强类字节码输出位置配置, 配置后会将增强后的字节码以文件的形式输出到该配置指定目录, 不配置则默认为agent/enhancedClasses
 agent.config.enhancedClassesOutputPath=
+# 拦截器执行时使用线程上下文类加载器辅助加载宿主服务类的开关, 开启则会在拦截器执行中通过线程上下文类加载器辅助加载宿主类, 用于服务治理逻辑使用, 默认值为true
 agent.config.useContextLoader=true
+# 字节码增强时对类进行查找时需忽略的类的前缀列表, 如果某些类不希望被字节码增强, 则可以通过该配置项进行配置
 agent.config.ignoredPrefixes=com.huawei.sermant,com.huaweicloud.sermant
+# 字节码增强时对类进行查找时需要忽略的接口的列表, 如果某些接口的全部实现类都不希望被字节码增强, 则可以通过该配置项进行配置
 agent.config.ignoredInterfaces=org.springframework.cglib.proxy.Factory
+# 指定插件服务中允许被字节码增强的类（插件服务中的类默认不允许被字节码增强）
 agent.config.serviceInjectList=com.huawei.discovery.service.lb.filter.NopInstanceFilter,com.huawei.discovery.service.lb.DiscoveryManager,com.huawei.discovery.service.util.ApplyUtil,com.huawei.discovery.service.lb.cache.InstanceCacheManager
-
-# agent service config
+#============================= 核心服务配置 =============================#
+# 心跳服务开关
 agent.service.heartbeat.enable=false
+# 统一网关服务开关
 agent.service.gateway.enable=false
+# 链路标记服务开关
 agent.service.tracing.enable=false
+# Spring注入服务开关
 agent.service.inject.enable=true
+# 动态配置服务开关
 agent.service.dynamic.config.enable=true
-
-# event config
+#============================= 事件系统配置 =============================#
+# 事件系统开关
 event.enable=false
+# Warn级别日志事件上报开关
 event.offerWarnLog=false
+# Error级别日志事件上报开关
 event.offerErrorLog=false
+# 事件发送间隔时间, 指定事件向Sermant Backend发送的间隔时间（ms）
 event.sendInterval=30000
+# 指定相同事件记录时间间隔, 在一定时间内重复事件压缩（ms）
 event.offerInterval=300000
-
-# notification config
+# 内部事件通知开关
 notification.enable=false
-
-# dynamic config
+#=============================动态配置服务配置=============================#
+# 指定配置读取超时时间（ms）
 dynamic.config.timeoutValue=30000
+# 指定配置的默认组
 dynamic.config.defaultGroup=sermant
+# 指定配置中心的服务端地址
 dynamic.config.serverAddress=127.0.0.1:2181
+# 指定动态配置中心类型, 取值范围为NOP(无实现)、ZOOKEEPER、KIE、NACOS
 dynamic.config.dynamicConfigType=ZOOKEEPER
+# 指定在启动Sermant时的配置中心的重连次数
 dynamic.config.connectRetryTimes=5
+# 指定在启动Sermant时连接配置中心的超时时间（ms）
 dynamic.config.connectTimeout=1000
-dynamic.config.userName=
-dynamic.config.password=
-dynamic.config.privateKey=
+# 指定是否开启配置中心授权, 开启后需验证用户名密码
 dynamic.config.enableAuth=false
+# 指定连接动态配置中心时的用户名
+dynamic.config.userName=
+# 指定连接动态配置中心时的密码
+dynamic.config.password=
+# 指定为用户名和密码进行加解密的密钥
+dynamic.config.privateKey=
+# 指定获取配置的请求超时时间（ms）
 dynamic.config.requestTimeout=3000
-
-# heartbeat config
+#=============================心跳服务配置===============================#
+# 指定心跳时间间隔（ms）
 heartbeat.interval=30000
-
-# inject config
+#=============================Spring注入服务配置=========================#
+# Spring注入服务所需依赖的包
 inject.essentialPackage=com.huawei.sermant,com.huaweicloud.sermant,com.huawei.dynamic.config,com.huawei.flowcontrol,com.huaweicloud.loadbalancer,com.huawei.monitor,com.huawei.dubbo.registry,com.huawei.registry,com.huaweicloud.visibility,com.huawei.discovery
-
-# gateway config
+#=============================统一网关配置===============================#
+# 指定统一网关对接的Netty服务端IP
 gateway.nettyIp=127.0.0.1
+# 指定统一网关对接的Netty服务端端口
 gateway.nettyPort=6888
+# 指定统一网关对接的Netty服务端连接超时时间（ms）
 gateway.nettyConnectTimeout=5000
+# 指定统一网关对接的Netty客户端读写等待时间（ms）
 gateway.nettyWriteAndReadWaitTime=60000
+# 指定统一网关数据向服务端发送的间隔时间（s）
 gateway.sendInternalTime=10
+# 指定统一网关重连退避算法初始连接间隔（s）
 gateway.initReconnectInternalTime=5
+# 指定统一网关重连退避算法最大连接间隔（s）
 gateway.maxReconnectInternalTime=180
-
-# service meta config
+#=============================元数据配置================================#
+# 指定应用名称, 用于服务注册等服务治理场景
 service.meta.application=default
+# 指定服务版本, 用于服务注册、标签路由等服务治理场景
 service.meta.version=1.0.0
+# 指定服务命名空间, 用于服务注册等服务治理场景
 service.meta.project=default
+# 指定服务所在环境, 用于服务注册等服务治理场景
 service.meta.environment=
+# 指定服务所在az（可用区）, 用于服务注册、标签路由等服务治理场景
 service.meta.zone=

--- a/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
@@ -1,4 +1,10 @@
-# premain启动时生效，配置支持静态安装的插件，不允许卸载
+# premain启动会加载plugins下配置的插件目录, agentmain启动会加载dynamicPlugins下的active插件目录
+# 插件的加载顺序如下：
+#   1. 首先按照`plugins`中配置的插件顺序来加载默认插件。
+#   2. 然后再按照`profile`配置的场景顺序来加载场景插件列表, 各场景的插件加载顺序也和配置文件中的顺序一致。
+#   3. 如果`profiles`中的配置的插件已经在之前加载过, 则不再重复加载。
+#   4. 不同插件的相同拦截点的字节码增强的生效顺序与插件加载顺序是一致的。
+# plugins用于配置静态插件, premain启动时生效, 配置支持静态安装的插件, 不允许卸载
 plugins:
   - flowcontrol
   - service-router
@@ -11,12 +17,15 @@ plugins:
   - service-removal
   - service-visibility
   - tag-transmission
-# agentmain启动时生效，配置支持动态安装插件，active类型插件将会主动启用, passive类型插件需通过指令或接口调用启用，允许卸载
+# dynamicPlugins用于配置支持动态安装的插件, agentmain启动时生效, 允许卸载:
+#  1. active类型插件将会主动启用
+#  2. passive类型插件需通过指令或接口调用启用
 dynamicPlugins:
   active:
 #    - active-plugin
   passive:
 #    - passive-plugin
+# profile用于按场景配置挂载的插件列表
 profiles:
   cse:
     - flowcontrol
@@ -26,4 +35,5 @@ profiles:
   apm:
     - flowcontrol
     - service-router
+# profile用于配置当前生效的场景
 profile: cse,apm

--- a/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
@@ -1,61 +1,96 @@
-# agent config
+#=============================字节码增强配置==============================
+# 字节码增强重转换开关, 开启则可以支持对已加载的类通过重转换进行字节码增强, 默认值为true
 agent.config.isReTransformEnable=true
+# 字节码增强日志输出开关, 开启则会将字节码增强相关日志输出到日志文件, 默认值为false
 agent.config.isShowEnhanceLog=false
+# 被增强类字节码输出开关, 开启则会将增强后的字节码以文件的形式进行输出, 默认值为false
 agent.config.isOutputEnhancedClasses=false
+# 被增强类字节码输出位置配置, 配置后会将增强后的字节码以文件的形式输出到该配置指定目录, 不配置则默认为agent/enhancedClasses
 agent.config.enhancedClassesOutputPath=
+# 拦截器执行时使用线程上下文类加载器辅助加载宿主服务类的开关, 开启则会在拦截器执行中通过线程上下文类加载器辅助加载宿主类, 用于服务治理逻辑使用, 默认值为true
 agent.config.useContextLoader=true
+# 字节码增强时对类进行查找时需忽略的类的前缀列表, 如果某些类不希望被字节码增强, 则可以通过该配置项进行配置
 agent.config.ignoredPrefixes=com.huawei.sermant,com.huaweicloud.sermant
+# 字节码增强时对类进行查找时需要忽略的接口的列表, 如果某些接口的全部实现类都不希望被字节码增强, 则可以通过该配置项进行配置
 agent.config.ignoredInterfaces=org.springframework.cglib.proxy.Factory
+# 指定插件服务中允许被字节码增强的类（插件服务中的类默认不允许被字节码增强）
 agent.config.serviceInjectList=com.huawei.discovery.service.lb.filter.NopInstanceFilter,com.huawei.discovery.service.lb.DiscoveryManager,com.huawei.discovery.service.util.ApplyUtil,com.huawei.discovery.service.lb.cache.InstanceCacheManager
-
-# agent service config
+#============================= 核心服务配置 =============================#
+# 心跳服务开关
 agent.service.heartbeat.enable=true
+# 统一网关服务开关
 agent.service.gateway.enable=true
+# 链路标记服务开关
 agent.service.tracing.enable=true
+# Spring注入服务开关
 agent.service.inject.enable=true
+# 动态配置服务开关
 agent.service.dynamic.config.enable=true
-
-# event config
+#============================= 事件系统配置 =============================#
+# 事件系统开关
 event.enable=false
+# Warn级别日志事件上报开关
 event.offerWarnLog=false
+# Error级别日志事件上报开关
 event.offerErrorLog=false
+# 事件发送间隔时间, 指定事件向Sermant Backend发送的间隔时间（ms）
 event.sendInterval=30000
+# 指定相同事件记录时间间隔, 在一定时间内重复事件压缩（ms）
 event.offerInterval=300000
-
-# notification config
+# 内部事件通知开关
 notification.enable=false
-
-# dynamic config
+#=============================动态配置服务配置=============================#
+# 指定配置读取超时时间（ms）
 dynamic.config.timeoutValue=30000
+# 指定配置的默认组
 dynamic.config.defaultGroup=sermant
+# 指定配置中心的服务端地址
 dynamic.config.serverAddress=127.0.0.1:2181
+# 指定动态配置中心类型, 取值范围为NOP(无实现)、ZOOKEEPER、KIE、NACOS
 dynamic.config.dynamicConfigType=ZOOKEEPER
+# 指定在启动Sermant时的配置中心的重连次数
 dynamic.config.connectRetryTimes=5
+# 指定在启动Sermant时连接配置中心的超时时间（ms）
 dynamic.config.connectTimeout=1000
-dynamic.config.userName=
-dynamic.config.password=
-dynamic.config.privateKey=
+# 指定是否开启配置中心授权, 开启后需验证用户名密码
 dynamic.config.enableAuth=false
+# 指定连接动态配置中心时的用户名
+dynamic.config.userName=
+# 指定连接动态配置中心时的密码
+dynamic.config.password=
+# 指定为用户名和密码进行加解密的密钥
+dynamic.config.privateKey=
+# 指定获取配置的请求超时时间（ms）
 dynamic.config.requestTimeout=3000
-
-# heartbeat config
+#=============================心跳服务配置===============================#
+# 指定心跳时间间隔（ms）
 heartbeat.interval=30000
-
-# inject config
+#=============================Spring注入服务配置=========================#
+# Spring注入服务所需依赖的包
 inject.essentialPackage=com.huawei.sermant,com.huaweicloud.sermant,com.huawei.dynamic.config,com.huawei.flowcontrol,com.huaweicloud.loadbalancer,com.huawei.monitor,com.huawei.dubbo.registry,com.huawei.registry,com.huaweicloud.visibility,com.huawei.discovery
-
-# gateway config
+#=============================统一网关配置===============================#
+# 指定统一网关对接的Netty服务端IP
 gateway.nettyIp=127.0.0.1
+# 指定统一网关对接的Netty服务端端口
 gateway.nettyPort=6888
+# 指定统一网关对接的Netty服务端连接超时时间（ms）
 gateway.nettyConnectTimeout=5000
+# 指定统一网关对接的Netty客户端读写等待时间（ms）
 gateway.nettyWriteAndReadWaitTime=60000
+# 指定统一网关数据向服务端发送的间隔时间（s）
 gateway.sendInternalTime=10
+# 指定统一网关重连退避算法初始连接间隔（s）
 gateway.initReconnectInternalTime=5
+# 指定统一网关重连退避算法最大连接间隔（s）
 gateway.maxReconnectInternalTime=180
-
-# service meta config
+#=============================元数据配置================================#
+# 指定应用名称, 用于服务注册等服务治理场景
 service.meta.application=default
+# 指定服务版本, 用于服务注册、标签路由等服务治理场景
 service.meta.version=1.0.0
+# 指定服务命名空间, 用于服务注册等服务治理场景
 service.meta.project=default
+# 指定服务所在环境, 用于服务注册等服务治理场景
 service.meta.environment=
+# 指定服务所在az（可用区）, 用于服务注册、标签路由等服务治理场景
 service.meta.zone=

--- a/sermant-agentcore/sermant-agentcore-config/config/test/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/plugins.yaml
@@ -1,4 +1,10 @@
-# premain启动时生效，配置支持静态安装的插件，不允许卸载
+# premain启动会加载plugins下配置的插件目录, agentmain启动会加载dynamicPlugins下的active插件目录
+# 插件的加载顺序如下：
+#   1. 首先按照`plugins`中配置的插件顺序来加载默认插件。
+#   2. 然后再按照`profile`配置的场景顺序来加载场景插件列表, 各场景的插件加载顺序也和配置文件中的顺序一致。
+#   3. 如果`profiles`中的配置的插件已经在之前加载过, 则不再重复加载。
+#   4. 不同插件的相同拦截点的字节码增强的生效顺序与插件加载顺序是一致的。
+# plugins用于配置静态插件, premain启动时生效, 配置支持静态安装的插件, 不允许卸载
 plugins:
   - flowcontrol
   - service-router
@@ -11,12 +17,15 @@ plugins:
   - service-removal
   - service-visibility
   - tag-transmission
-# agentmain启动时生效，配置支持动态安装插件，active类型插件将会主动启用, passive类型插件需通过指令或接口调用启用，允许卸载
+# dynamicPlugins用于配置支持动态安装的插件, agentmain启动时生效, 允许卸载:
+#  1. active类型插件将会主动启用
+#  2. passive类型插件需通过指令或接口调用启用
 dynamicPlugins:
   active:
 #    - active-plugin
   passive:
 #    - passive-plugin
+# profile用于按场景配置挂载的插件列表
 profiles:
   cse:
     - flowcontrol
@@ -26,4 +35,5 @@ profiles:
   apm:
     - flowcontrol
     - service-router
+# profile用于配置当前生效的场景
 profile: cse,apm

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
@@ -129,6 +129,9 @@ public class PluginManager {
 
             // 从插件Map中清除该插件
             PLUGIN_MAP.remove(name);
+
+            // 清除插件信息缓存
+            PluginSchemaValidator.removePluginVersionCache(name);
         }
     }
 

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/common/PluginSchemaValidator.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/common/PluginSchemaValidator.java
@@ -53,21 +53,31 @@ public class PluginSchemaValidator {
     /**
      * 当插件的版本不存在时，使用默认的版本号
      *
-     * @param name 插件名称
+     * @param pluginName 插件名称
      */
-    public static void setDefaultVersion(String name) {
-        if (!PLUGIN_VERSION_MAP.containsKey(name)) {
-            PLUGIN_VERSION_MAP.put(name, PluginConstant.PLUGIN_DEFAULT_VERSION);
+    public static void setDefaultVersion(String pluginName) {
+        if (!PLUGIN_VERSION_MAP.containsKey(pluginName)) {
+            PLUGIN_VERSION_MAP.put(pluginName, PluginConstant.PLUGIN_DEFAULT_VERSION);
         }
+    }
+
+    /**
+     * 清理插件的版本缓存
+     *
+     * @param pluginName 插件名
+     */
+    public static void removePluginVersionCache(String pluginName) {
+        PLUGIN_VERSION_MAP.remove(pluginName);
     }
 
     /**
      * 检查名称和版本
      *
-     * @param name    插件名称
+     * @param name 插件名称
      * @param jarFile 插件包
      * @return 为真时经过名称和版本校验，为插件包或插件服务包，为假时表示第三方jar包
      * @throws IOException 获取manifest文件异常
+     * @throws SchemaException 传入插件名和从资源文件中检索到的不一致
      */
     public static boolean checkSchema(String name, JarFile jarFile) throws IOException {
         final Object nameAttr = JarFileUtils.getManifestAttr(jarFile, PluginConstant.PLUGIN_NAME_KEY);

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/heartbeat/HeartbeatServiceImpl.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/heartbeat/HeartbeatServiceImpl.java
@@ -102,6 +102,9 @@ public class HeartbeatServiceImpl implements HeartbeatService {
     private void execute() {
         // 获取插件名和版本集合
         final Map<String, String> pluginVersionMap = PluginSchemaValidator.getPluginVersionMap();
+
+        // 清空插件信息缓存
+        heartbeatMessage.getPluginInfoMap().clear();
         for (Map.Entry<String, String> entry : pluginVersionMap.entrySet()) {
             heartbeatMessage.getPluginInfoMap().putIfAbsent(entry.getKey(),
                     new PluginInfo(entry.getKey(), entry.getValue()));


### PR DESCRIPTION
【Fix issue】#1323
[Modification content] 1. Add configuration description to the configuration file 2. Fix the bug where the heartbeat still reports plug-in information after the plug-in is uninstalled
[Use case description] Not involved
[Self-test situation] 1. The static check has been cleared. 2. The self-verification has passed. After the plug-in is uninstalled, it will be cleared in the Sermant Backend plug-in display area.
[Scope of Impact] 1. The configuration description has been deleted from the official document. The configuration file shall be subject to the configuration in the project file.