### PR TITLE
Traffic label transparent transmission test part demo

### DIFF
--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/pom.xml
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huawei.spring.test</groupId>
+        <artifactId>tag-transmission-demo</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>alibaba-dubbo-consumer-demo</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <httpclient4x.version>4.3</httpclient4x.version>
+        <curator.version>5.0.0</curator.version>
+        <alibaba.dubbo.version>2.6.12</alibaba.dubbo.version>
+        <tag-transmission.version>1.0.0</tag-transmission.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient4x.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${alibaba.dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huawei.spring.test</groupId>
+            <artifactId>tag-transmission-common-lib</artifactId>
+            <version>${tag-transmission.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/consumer/AlibabaDubboApplication.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/consumer/AlibabaDubboApplication.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.alibabadubbo.consumer;
+
+import com.alibaba.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@EnableDubbo
+@SpringBootApplication
+public class AlibabaDubboApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(AlibabaDubboApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/consumer/controller/AlibabaDubboConsumer.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/consumer/controller/AlibabaDubboConsumer.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.alibabadubbo.consumer.controller;
+
+import com.huaweicloud.demo.lib.dubbo.service.AlibabaGreetingInnerService;
+import com.huaweicloud.demo.lib.dubbo.service.AlibabaGreetingOuterService;
+
+import com.alibaba.dubbo.config.annotation.Reference;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * apache dubbo消费端
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@Lazy
+@RestController
+@RequestMapping("alibabaDubbo")
+public class AlibabaDubboConsumer {
+    @Reference(loadbalance = "random")
+    private AlibabaGreetingInnerService greetingInnerService;
+
+    @Reference(loadbalance = "random")
+    private AlibabaGreetingOuterService greetingOuterService;
+
+    /**
+     * 验证同一进程的apache dubbo透传流量标签
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "inner", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    @ResponseBody
+    public String innerAlibabaDubbo() {
+        return greetingInnerService.sayHello();
+    }
+
+    /**
+     * 验证不同进程的apache dubbo透传流量标签
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "outer", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    @ResponseBody
+    public String outerAlibabaDubbo() {
+        return greetingOuterService.sayHello();
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/consumer/providerimpl/GreetingServiceAlibabaInnerDubboImpl.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/consumer/providerimpl/GreetingServiceAlibabaInnerDubboImpl.java
@@ -1,0 +1,41 @@
+/*
+ *  *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  *   Licensed under the Apache License, Version 2.0 (the "License");
+ *  *   you may not use this file except in compliance with the License.
+ *  *   You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *   Unless required by applicable law or agreed to in writing, software
+ *  *   distributed under the License is distributed on an "AS IS" BASIS,
+ *  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *   See the License for the specific language governing permissions and
+ *  *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.alibabadubbo.consumer.providerimpl;
+
+import com.huaweicloud.demo.lib.dubbo.service.AlibabaGreetingInnerService;
+import com.huaweicloud.demo.lib.utils.HttpClientUtils;
+
+import com.alibaba.dubbo.config.annotation.Service;
+
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * dubbo服务实现类
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@Service
+public class GreetingServiceAlibabaInnerDubboImpl implements AlibabaGreetingInnerService {
+    @Value("${sofaRpcUrl}")
+    private String sofaRpcUrl;
+
+    @Override
+    public String sayHello() {
+        return HttpClientUtils.doHttpClientV4Get(sofaRpcUrl);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+sofaRpcUrl=http://127.0.0.1:9041/inner/sofaRpc

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/resources/application.yaml
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-consumer-demo/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+# Spring Boot应用程序配置
+spring:
+  application:
+    name: alibaba-dubbo-consumer
+  main:
+    allow-bean-definition-overriding: true
+server:
+  port: 9044
+
+# Dubbo配置
+dubbo:
+  application:
+    name: alibaba-dubbo-consumer
+    qos-port: 33335
+  registry:
+    address: zookeeper://localhost:2181
+  protocol:
+    name: dubbo
+    port: -1

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/pom.xml
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huawei.spring.test</groupId>
+        <artifactId>tag-transmission-demo</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>alibaba-dubbo-provider-demo</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <httpclient4x.version>4.3</httpclient4x.version>
+        <curator.version>5.0.0</curator.version>
+        <alibaba.dubbo.version>2.6.12</alibaba.dubbo.version>
+        <tag-transmission.version>1.0.0</tag-transmission.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient4x.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${alibaba.dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huawei.spring.test</groupId>
+            <artifactId>tag-transmission-common-lib</artifactId>
+            <version>${tag-transmission.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/provider/AlibabaDubboServerApplication.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/provider/AlibabaDubboServerApplication.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.alibabadubbo.provider;
+
+import com.alibaba.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+@EnableDubbo
+public class AlibabaDubboServerApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(AlibabaDubboServerApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/provider/providerimpl/GreetingServiceApacheDubboImpl.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/alibabadubbo/provider/providerimpl/GreetingServiceApacheDubboImpl.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.alibabadubbo.provider.providerimpl;
+
+import com.huaweicloud.demo.lib.dubbo.service.AlibabaGreetingOuterService;
+import com.huaweicloud.demo.lib.utils.HttpClientUtils;
+
+import com.alibaba.dubbo.config.annotation.Service;
+
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * dubbo服务实现类
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@Service
+public class GreetingServiceApacheDubboImpl implements AlibabaGreetingOuterService {
+    @Value("${sofaRpcUrl}")
+    private String sofaRpcUrl;
+
+    @Override
+    public String sayHello() {
+        return HttpClientUtils.doHttpClientV4Get(sofaRpcUrl);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+sofaRpcUrl=http://127.0.0.1:9041/outer/sofaRpc

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/resources/application.yaml
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/alibaba-dubbo-provider-demo/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+# Spring Boot应用程序配置
+spring:
+  application:
+    name: alibaba-dubbo-server
+  main:
+    allow-bean-definition-overriding: true
+server:
+  port: 9045
+
+# Dubbo配置
+dubbo:
+  application:
+    name: alibaba-dubbo-server
+    qos-port: 33336
+  registry:
+    address: zookeeper://localhost:2181
+  protocol:
+    name: dubbo
+    port: -1

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/pom.xml
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huawei.spring.test</groupId>
+        <artifactId>tag-transmission-demo</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>httpserver-common-demo</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <httpclient4x.version>4.5.13</httpclient4x.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient4x.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/HttpCommonServerApplication.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/HttpCommonServerApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.commonserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+public class HttpCommonServerApplication {
+    /**
+     * springboot应用启动类
+     *
+     * @param args
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(HttpCommonServerApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/common/Constant.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/common/Constant.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.commonserver.common;
+
+/**
+ * 常量类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+public class Constant {
+    /**
+     * 流量标签的key值
+     */
+    public static final String[] TRAFFIC_TAG_KEY = {"id", "dynamic", "x-sermant-test", "tag-sermant"};
+
+    private Constant() {
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/controller/ServerController.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/controller/ServerController.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.commonserver.controller;
+
+import com.huaweicloud.demo.commonserver.utils.TagConversionUtils;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 公共的httpserver，用于验证各组件服务端可以将流量标签透传至下游服务
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@RestController
+@RequestMapping("common")
+public class ServerController {
+    /**
+     * 公用的http server端，返回http的header，用于验证是否成功透传标签
+     *
+     * @param request http请求request
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "httpserver", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testHttpServer(HttpServletRequest request) {
+        return TagConversionUtils.convertHeader2String(request);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/utils/TagConversionUtils.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/java/com/huaweicloud/demo/commonserver/utils/TagConversionUtils.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.commonserver.utils;
+
+import com.huaweicloud.demo.commonserver.common.Constant;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 转换流量标签的工具类
+ *
+ * @author daizhenyu
+ * @since 2023-09-11
+ **/
+public class TagConversionUtils {
+    private static final int BOUND_LENGTH = 2;
+
+    private static final String DOUBLE_QUOTATION_MARKS = "\"";
+
+    private TagConversionUtils() {
+    }
+
+    /**
+     * 将http header中的tag表示为json字符串形式
+     *
+     * @param request
+     * @return string
+     */
+    public static String convertHeader2String(HttpServletRequest request) {
+        return buildString(request);
+    }
+
+    private static String buildString(HttpServletRequest request) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        for (String key : Constant.TRAFFIC_TAG_KEY) {
+            if (request.getHeader(key) == null) {
+                continue;
+            }
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(key);
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(":");
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(request.getHeader(key));
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(",");
+        }
+        if (builder.length() >= BOUND_LENGTH) {
+            builder.deleteCharAt(builder.length() - 1);
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-common-demo/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=9040

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/pom.xml
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huawei.spring.test</groupId>
+        <artifactId>tag-transmission-demo</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>httpserver-jetty-demo</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <httpclient4x.version>4.5.13</httpclient4x.version>
+        <tag-transmission.version>1.0.0</tag-transmission.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huawei.spring.test</groupId>
+            <artifactId>tag-transmission-common-lib</artifactId>
+            <version>${tag-transmission.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient4x.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/src/main/java/com/huaweicloud/demo/jetty/HttpJettyApplication.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/src/main/java/com/huaweicloud/demo/jetty/HttpJettyApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.jetty;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+public class HttpJettyApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(HttpJettyApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/src/main/java/com/huaweicloud/demo/jetty/controller/ServerController.java
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/src/main/java/com/huaweicloud/demo/jetty/controller/ServerController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.jetty.controller;
+
+import com.huaweicloud.demo.lib.utils.HttpClientUtils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * http Server端，供http客户端调用
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@Controller
+@ResponseBody
+@RequestMapping(value = "jetty")
+public class ServerController {
+    @Value("${apacheDubboUrl}")
+    private String apacheDubboUrl;
+
+    /**
+     * 验证jetty服务端透传流量标签
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "httpserver", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testJetty() {
+        return HttpClientUtils.doHttpClientV4Get(apacheDubboUrl);
+    }
+}

--- a/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/spring-test/tag-transmission-demo/httpserver-jetty-demo/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9043
+apacheDubboUrl=http://127.0.0.1:9041/outer/dubbo


### PR DESCRIPTION
【Fix issue】#1244

[Modification content] Added some demo applications for traffic label transparent transmission, including alibaba dubbo demo, public httpserver demo and jetty server demo, used for traffic label transparent transmission plug-in integration testing

[Use case description] No

[Self-test situation] 1. Local static check passed

[Scope of influence] None