### PR TITLE
Truncate hostname longer than 64 bits in Servicecomb registration

### DIFF
--- a/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/RegistryServiceImpl.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-service/src/main/java/com/huawei/dubbo/registry/service/RegistryServiceImpl.java
@@ -117,6 +117,8 @@ public class RegistryServiceImpl implements RegistryService {
 
     private static final int REGISTRATION_WAITE_TIME = 30;
 
+    private static final int MAX_HOST_NAME_LENGTH = 64;
+
     private static final List<Subscription> PENDING_SUBSCRIBE_EVENT = new CopyOnWriteArrayList<>();
 
     private static final AtomicBoolean SHUTDOWN = new AtomicBoolean();
@@ -394,7 +396,11 @@ public class RegistryServiceImpl implements RegistryService {
 
     private String getHost() {
         try {
-            return InetAddress.getLocalHost().getHostName();
+            String hostName = InetAddress.getLocalHost().getHostName();
+
+            // ServiceComb不支持64个字符以上的hostname注册, 此处参考spring-cloud-huawei进行截断处理
+            return hostName != null && hostName.length() > MAX_HOST_NAME_LENGTH ? hostName.substring(0,
+                    MAX_HOST_NAME_LENGTH) : hostName;
         } catch (UnknownHostException e) {
             LOGGER.warning("Cannot get the host.");
             return "";


### PR DESCRIPTION
【Fix issue】#1329

[Modification content] Truncate the hostname when registering Servicecomb and limit it to no more than 64 characters. Refer to spring-cloud-huawei's method https://github.com/huaweicloud/spring-cloud-huawei/pull/1072/files

[Use case description] Not involved

[Self-test situation] Local static check passed

[Scope of influence] No impact on users