### PR TITLE
Traffic label transparent transmission plugin integration test demo: dubbo demo, rpc-api demo, public httpserver demo

### DIFF
--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <artifactId>tag-transmission-test</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>alibaba-dubbo-consumer-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <zkclient.version>0.10</zkclient.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-x-discovery</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${alibaba.dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+            <version>${zkclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>rpc-api-demo</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/consumer/AlibabaDubboConsumerApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/consumer/AlibabaDubboConsumerApplication.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.alibabadubbo.consumer;
+
+import com.alibaba.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@EnableDubbo
+@SpringBootApplication
+public class AlibabaDubboConsumerApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(AlibabaDubboConsumerApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/consumer/controller/AlibabaDubboController.java
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/consumer/controller/AlibabaDubboController.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.alibabadubbo.consumer.controller;
+
+import com.huaweicloud.demo.tagtransmission.rpc.api.alibabadubbo.AlibabaTagTransmissionService;
+
+import com.alibaba.dubbo.config.annotation.Reference;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * alibaba dubbo消费端
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@RestController
+@RequestMapping("alibabaDubbo")
+public class AlibabaDubboController {
+    @Reference(loadbalance = "random")
+    private AlibabaTagTransmissionService tagTransmissionService;
+
+    /**
+     * 验证alibaba dubbo透传流量标签
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "testAlibabaDubbo", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    @ResponseBody
+    public String testAlibabaDubbo() {
+        return tagTransmissionService.transmitTag();
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/src/main/resources/application.yaml
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-consumer-demo/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+# Spring Boot应用程序配置
+spring:
+  application:
+    name: alibaba-dubbo-consumer
+  main:
+    allow-bean-definition-overriding: true
+server:
+  port: 9041
+
+# Dubbo配置
+dubbo:
+  application:
+    name: alibaba-dubbo-consumer
+    qos-port: 33335
+  registry:
+    address: zookeeper://127.0.0.1:2181
+  protocol:
+    name: dubbo
+    port: -1

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <artifactId>tag-transmission-test</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>alibaba-dubbo-provider-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <tag-transmission.version>1.0.0</tag-transmission.version>
+        <zkclient.version>0.10</zkclient.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-x-discovery</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${alibaba.dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+            <version>${zkclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>rpc-api-demo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>tag-transmission-util-demo</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/provider/AlibabaDubboProviderApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/provider/AlibabaDubboProviderApplication.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.alibabadubbo.provider;
+
+import com.alibaba.dubbo.config.spring.context.annotation.EnableDubbo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+@EnableDubbo
+public class AlibabaDubboProviderApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(AlibabaDubboProviderApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/provider/serviceimpl/AlibabaTagTransmissionServiceImpl.java
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/alibabadubbo/provider/serviceimpl/AlibabaTagTransmissionServiceImpl.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.alibabadubbo.provider.serviceimpl;
+
+import com.huaweicloud.demo.tagtransmission.rpc.api.alibabadubbo.AlibabaTagTransmissionService;
+import com.huaweicloud.demo.tagtransmission.util.HttpClientUtils;
+
+import com.alibaba.dubbo.config.annotation.Service;
+
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * alibaba dubbo服务实现类
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@Service
+public class AlibabaTagTransmissionServiceImpl implements AlibabaTagTransmissionService {
+    @Value("${common.server.url}")
+    private String commonServerUrl;
+
+    @Override
+    public String transmitTag() {
+        return HttpClientUtils.doHttpUrlConnectionGet(commonServerUrl);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+common.server.url=http://127.0.0.1:9040/common/httpServer

--- a/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/resources/application.yaml
+++ b/sermant-integration-tests/tag-transmission-test/alibaba-dubbo-provider-demo/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+# Spring Boot应用程序配置
+spring:
+  application:
+    name: alibaba-dubbo-provider
+  main:
+    allow-bean-definition-overriding: true
+server:
+  port: 9042
+
+# Dubbo配置
+dubbo:
+  application:
+    name: alibaba-dubbo-provider
+    qos-port: 33336
+  registry:
+    address: zookeeper://127.0.0.1:2181
+  protocol:
+    name: dubbo
+    port: -1

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <artifactId>tag-transmission-test</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apache-dubbo-consumer-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-spring-boot-starter</artifactId>
+            <version>${apache.dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-x-discovery</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>rpc-api-demo</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/consumer/ApacheDubboConsumerApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/consumer/ApacheDubboConsumerApplication.java
@@ -1,0 +1,40 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.apachedubbo.consumer;
+
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-10-13
+ **/
+@EnableDubbo
+@SpringBootApplication
+public class ApacheDubboConsumerApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(ApacheDubboConsumerApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/consumer/controller/ApacheDubboController.java
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/consumer/controller/ApacheDubboController.java
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.apachedubbo.consumer.controller;
+
+import com.huaweicloud.demo.tagtransmission.rpc.api.apachedubbo.ApacheTagTransmissionService;
+
+import org.apache.dubbo.config.annotation.Reference;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * apache dubbo消费端
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@RestController
+@RequestMapping("apacheDubbo")
+public class ApacheDubboController {
+    @Lazy
+    @Reference(loadbalance = "random")
+    private ApacheTagTransmissionService tagTransmissionService;
+
+    /**
+     * 验证apache dubbo透传流量标签
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "testApacheDubbo", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    @ResponseBody
+    public String testApacheDubbo() {
+        return tagTransmissionService.transmitTag();
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/src/main/resources/application.yaml
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-consumer-demo/src/main/resources/application.yaml
@@ -1,0 +1,18 @@
+# Spring Boot应用程序配置
+spring:
+  application:
+    name: apache-dubbo-consumer
+  main:
+    allow-bean-definition-overriding: true
+# Dubbo配置
+dubbo:
+  application:
+    name: apache-dubbo-consumer
+    qos-port: 33333
+  registry:
+    address: zookeeper://127.0.0.1:2181
+  protocol:
+    name: dubbo
+    port: -1
+server:
+  port: 9043

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <artifactId>tag-transmission-test</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apache-dubbo-provider-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-spring-boot-starter</artifactId>
+            <version>${apache.dubbo.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-x-discovery</artifactId>
+            <version>${curator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>rpc-api-demo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>tag-transmission-util-demo</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/provider/ApacheDubboProviderApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/provider/ApacheDubboProviderApplication.java
@@ -1,0 +1,40 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.apachedubbo.provider;
+
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+@EnableDubbo
+public class ApacheDubboProviderApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(ApacheDubboProviderApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/provider/serviceimpl/ApacheTagTransmissionServiceImpl.java
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/java/com/huaweicloud/demo/tagtransmission/apachedubbo/provider/serviceimpl/ApacheTagTransmissionServiceImpl.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.apachedubbo.provider.serviceimpl;
+
+import com.huaweicloud.demo.tagtransmission.rpc.api.apachedubbo.ApacheTagTransmissionService;
+import com.huaweicloud.demo.tagtransmission.util.HttpClientUtils;
+
+import org.apache.dubbo.config.annotation.Service;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * dubbo服务实现类
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@Service
+public class ApacheTagTransmissionServiceImpl implements ApacheTagTransmissionService {
+    @Value("${common.server.url}")
+    private String commonServerUrl;
+
+    @Override
+    public String transmitTag() {
+        return HttpClientUtils.doHttpUrlConnectionGet(commonServerUrl);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+common.server.url=http://127.0.0.1:9040/common/httpServer

--- a/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/resources/application.yaml
+++ b/sermant-integration-tests/tag-transmission-test/apache-dubbo-provider-demo/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+# Spring Boot应用程序配置
+spring:
+  application:
+    name: apache-dubbo-provider
+  main:
+    allow-bean-definition-overriding: true
+
+# Dubbo配置
+dubbo:
+  application:
+    name: apache-dubbo-provider
+    qos-port: 33334
+  registry:
+    address: zookeeper://127.0.0.1:2181
+  protocol:
+    name: dubbo
+    port: -1
+server:
+  port: 9044

--- a/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <artifactId>tag-transmission-test</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>httpserver-common-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/HttpCommonServerApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/HttpCommonServerApplication.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.commonserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+public class HttpCommonServerApplication {
+    /**
+     * springboot应用启动类
+     *
+     * @param args
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(HttpCommonServerApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/config/TagKeyConfig.java
+++ b/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/config/TagKeyConfig.java
@@ -1,0 +1,36 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.commonserver.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 获取流量标签的key
+ *
+ * @author daizhenyu
+ * @since 2023-10-12
+ **/
+@Configuration
+public class TagKeyConfig {
+    @Value("${traffic.tag.key}")
+    private String[] trafficTagKey;
+
+    public String[] getTrafficTagKey() {
+        return trafficTagKey;
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/controller/ServerController.java
+++ b/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/controller/ServerController.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.commonserver.controller;
+
+import com.huaweicloud.demo.tagtransmission.commonserver.utils.TagConversionUtils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 公共的httpserver，用于验证各组件服务端可以将流量标签透传至下游服务
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@RestController
+@RequestMapping("common")
+public class ServerController {
+    @Value("${traffic.tag.key}")
+    private String[] trafficTagKey;
+
+    /**
+     * 公用的http server端，返回http的header，用于验证是否成功透传标签
+     *
+     * @param request http请求request
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "httpServer", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testHttpServer(HttpServletRequest request) {
+        return TagConversionUtils.convertHeader2String(request, trafficTagKey);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/utils/TagConversionUtils.java
+++ b/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/commonserver/utils/TagConversionUtils.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.commonserver.utils;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * 转换流量标签的工具类
+ *
+ * @author daizhenyu
+ * @since 2023-09-11
+ **/
+public class TagConversionUtils {
+    private static final int BOUND_LENGTH = 2;
+
+    private static final String DOUBLE_QUOTATION_MARKS = "\"";
+
+    private TagConversionUtils() {
+    }
+
+    /**
+     * 将http header中的tag表示为json字符串形式
+     *
+     * @param request
+     * @param tagKeys
+     * @return string
+     */
+    public static String convertHeader2String(HttpServletRequest request, String[] tagKeys) {
+        return buildString(request, tagKeys);
+    }
+
+    private static String buildString(HttpServletRequest request, String[] tagKeys) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        for (String key : tagKeys) {
+            if (request.getHeader(key) == null) {
+                continue;
+            }
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(key);
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(":");
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(request.getHeader(key));
+            builder.append(DOUBLE_QUOTATION_MARKS);
+            builder.append(",");
+        }
+        if (builder.length() >= BOUND_LENGTH) {
+            builder.deleteCharAt(builder.length() - 1);
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/httpserver-common-demo/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9040
+traffic.tag.key=id,dynamic,x-sermant-test,tag-sermant

--- a/sermant-integration-tests/tag-transmission-test/rpc-api-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/rpc-api-demo/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <artifactId>tag-transmission-test</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rpc-api-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/alibabadubbo/AlibabaTagTransmissionService.java
+++ b/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/alibabadubbo/AlibabaTagTransmissionService.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.rpc.api.alibabadubbo;
+
+/**
+ * alibaba dubbo 接口服务
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+public interface AlibabaTagTransmissionService {
+    /**
+     * 接口服务方法
+     *
+     * @return 流量标签
+     */
+    String transmitTag();
+}

--- a/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/apachedubbo/ApacheTagTransmissionService.java
+++ b/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/apachedubbo/ApacheTagTransmissionService.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.rpc.api.apachedubbo;
+
+/**
+ * apache dubbo 的接口服务
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+public interface ApacheTagTransmissionService {
+    /**
+     * 接口服务方法
+     *
+     * @return 流量标签
+     */
+    String transmitTag();
+}

--- a/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/servicecomb/ServiceCombTagTransmissionService.java
+++ b/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/servicecomb/ServiceCombTagTransmissionService.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.rpc.api.servicecomb;
+
+/**
+ * servicecomb的接口服务
+ *
+ * @author daizhenyu
+ * @since 2023-09-28
+ **/
+public interface ServiceCombTagTransmissionService {
+    /**
+     * 接口方法
+     *
+     * @return 流量标签
+     */
+    String transmitTag();
+}

--- a/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/sofarpc/SofaRpcTagTransmissionService.java
+++ b/sermant-integration-tests/tag-transmission-test/rpc-api-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rpc/api/sofarpc/SofaRpcTagTransmissionService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.rpc.api.sofarpc;
+
+/**
+ * Quick Start demo interface
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ */
+public interface SofaRpcTagTransmissionService {
+    /**
+     * 接口方法
+     *
+     * @return 流量标签
+     */
+    String transmitTag();
+}


### PR DESCRIPTION
【Fix issue】#1333

[Modification] Added a demo of the integration test part of the traffic label transparent transmission plug-in, including:
1.alibaba-dubbo-provider-demo
2.alibaba-dubbo-consumer-demo
3.rpc-api-demo
4.apache-dubbo-provider-demo
5.apache-dubbo-consumer-demo
6.httpserver-common-demo
[Use case description] Not required

[Self-test situation] 1. Local static check passed