### PR TITLE
Add JSSE metrics collection.

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
@@ -14,6 +14,7 @@ plugins:
 # agentmain启动时生效，配置支持动态安装插件，active类型插件将会主动启用, passive类型插件需通过指令或接口调用启用，允许卸载
 dynamicPlugins:
   active:
+    - jsse
 #    - active-plugin
   passive:
 #    - passive-plugin

--- a/sermant-plugins/pom.xml
+++ b/sermant-plugins/pom.xml
@@ -42,6 +42,7 @@
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
                 <module>sermant-tag-transmission</module>
+                <module>sermant-jsse</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -74,6 +75,7 @@
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
                 <module>sermant-tag-transmission</module>
+                <module>sermant-jsse</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -106,6 +108,7 @@
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
                 <module>sermant-tag-transmission</module>
+                <module>sermant-jsse</module>
             </modules>
         </profile>
     </profiles>

--- a/sermant-plugins/sermant-jsse/config/config.yaml
+++ b/sermant-plugins/sermant-jsse/config/config.yaml
@@ -1,0 +1,6 @@
+jsse.config:
+  enable: false
+  delayTime: 1000
+  period: 1000
+  filePath: /tmp/java-data-
+  fileName: jsse-metric.txt

--- a/sermant-plugins/sermant-jsse/jsse-plugin/pom.xml
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <artifactId>sermant-jsse</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jsse-plugin</artifactId>
+
+    <name>jsse-plugin</name>
+    <description>The plugin module of jsse.</description>
+
+    <properties>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>plugin</package.plugin.type>
+        <alibaba.dubbo.version>2.5.7</alibaba.dubbo.version>
+        <apache.dubbo.version>2.7.3</apache.dubbo.version>
+        <servlet-api.version>4.0.1</servlet-api.version>
+    </properties>
+    <dependencies>
+        <!--Provider依赖-->
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${alibaba.dubbo.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+            <version>${apache.dubbo.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!--test依赖-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/common/Constants.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/common/Constants.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.common;
+
+/**
+ * 常量类
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class Constants {
+    /**
+     * 进程名连接符
+     */
+    public static final String PROCESS_NAME_LINK = "@";
+
+    /**
+     * 进程名连接符
+     */
+    public static final String FILE_PATH_LINK = "/";
+
+    /**
+     * L7客户端角色
+     */
+    public static final String CLIENT_ROLE = "client";
+
+    /**
+     * L7服务端角色
+     */
+    public static final String SERVER_ROLE = "server";
+
+    /**
+     * TCP协议
+     */
+    public static final String TCP_PROTOCOL = "tcp";
+
+    /**
+     * TCP协议
+     */
+    public static final String UDP_PROTOCOL = "udp";
+
+    /**
+     * 角色连接符
+     */
+    public static final String CONNECT = "_";
+
+    /**
+     * SSL开关的KEY
+     */
+    public static final String SSL_ENABLE = "sslEnabled";
+
+    /**
+     * 服务调用使用的CLIENT下表字段名
+     */
+    public static final String CLIENT_INDEX = "index";
+
+    /**
+     * CLIENT集合名称
+     */
+    public static final String CLIENTS_NAME = "clients";
+
+    /**
+     * DUBBO TCP协议集合
+     */
+    public static final String TCP_PROTOCOLS = "dubbo,rmi,http,https";
+
+    /**
+     * 连接信息头
+     */
+    public static final String LINK_HEAD = "sermant_l7_link";
+
+    /**
+     * 连接信息头
+     */
+    public static final String RPC_HEAD = "sermant_l7_rpc";
+
+    /**
+     * SSL开启标识
+     */
+    public static final String SSL_OPEN = "ssl";
+
+    /**
+     * SSL未开启标识
+     */
+    public static final String SSL_CLOSE = "no_ssl";
+
+    private Constants() {
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/config/JsseConfig.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/config/JsseConfig.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.config;
+
+import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfig;
+
+/**
+ * JSSE配置类
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+@ConfigTypeKey(value = "jsse.config")
+public class JsseConfig implements PluginConfig {
+    private boolean enable;
+
+    /**
+     * 首次采集延迟时间
+     */
+    private int delayTime;
+
+    /**
+     * 指标采集间隔时间
+     */
+    private int period;
+
+    /**
+     * 文件路径
+     */
+    private String filePath;
+
+    /**
+     * 文件名称
+     */
+    private String fileName;
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+
+    public int getDelayTime() {
+        return delayTime;
+    }
+
+    public void setDelayTime(int delayTime) {
+        this.delayTime = delayTime;
+    }
+
+    public int getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(int period) {
+        this.period = period;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/AbstractDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/AbstractDeclarer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer;
+
+import com.huawei.jsse.config.JsseConfig;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.SuperTypeDeclarer;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+
+/**
+ * 插件增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public abstract class AbstractDeclarer implements PluginDeclarer {
+    private static final JsseConfig JSSE_CONFIG = PluginConfigManager.getPluginConfig(JsseConfig.class);
+
+    @Override
+    public SuperTypeDeclarer[] getSuperTypeDeclarers() {
+        return new SuperTypeDeclarer[0];
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return JSSE_CONFIG.isEnable();
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/DecodeDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/DecodeDeclarer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.alibaba;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.alibaba.CodecInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo报文解码增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class DecodeDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS = "com.alibaba.dubbo.remoting.exchange.codec.ExchangeCodec";
+
+    private static final String METHODS_NAME = "decode";
+
+    private static final int PARAM_COUNT = 2;
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME)
+                .and(MethodMatcher.paramCountEquals(PARAM_COUNT)), new CodecInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/EncodeDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/EncodeDeclarer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.alibaba;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.alibaba.CodecInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo报文编码增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class EncodeDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS = "com.alibaba.dubbo.remoting.exchange.codec.ExchangeCodec";
+
+    private static final String METHODS_NAME = "encode";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME),
+                new CodecInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/HandlerDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/HandlerDeclarer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.alibaba;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.alibaba.HandlerInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo服务处理增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class HandlerDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS =
+            "com.alibaba.dubbo.remoting.exchange.support.header.HeaderExchangeHandler";
+
+    private static final String METHODS_NAME = "handleRequest";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME),
+                new HandlerInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/InvokeDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/alibaba/InvokeDeclarer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.alibaba;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.alibaba.InvokeInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo调用增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class InvokeDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS = "com.alibaba.dubbo.rpc.protocol.dubbo.DubboInvoker";
+
+    private static final String METHODS_NAME = "doInvoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME),
+                new InvokeInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/DecodeDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/DecodeDeclarer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.apache;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.apache.CodecInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo报文解码增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class DecodeDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS = "org.apache.dubbo.remoting.exchange.codec.ExchangeCodec";
+
+    private static final String METHODS_NAME = "decode";
+
+    private static final int PARAM_COUNT = 2;
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME)
+                        .and(MethodMatcher.paramCountEquals(PARAM_COUNT)), new CodecInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/EncodeDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/EncodeDeclarer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.apache;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.apache.CodecInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo报文编码增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class EncodeDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS = "org.apache.dubbo.remoting.exchange.codec.ExchangeCodec";
+
+    private static final String METHODS_NAME = "encode";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME),
+                new CodecInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/HandlerDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/HandlerDeclarer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.apache;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.apache.HandlerInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo服务处理增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class HandlerDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS =
+            "org.apache.dubbo.remoting.exchange.support.header.HeaderExchangeHandler";
+
+    private static final String METHODS_NAME = "handleRequest";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME),
+                new HandlerInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/InvokeDeclarer.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/declarer/apache/InvokeDeclarer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.declarer.apache;
+
+import com.huawei.jsse.declarer.AbstractDeclarer;
+import com.huawei.jsse.interceptor.apache.InvokeInterceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+
+/**
+ * dubbo调用增强声明
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class InvokeDeclarer extends AbstractDeclarer {
+    private static final String ENHANCE_CLASS = "org.apache.dubbo.rpc.protocol.dubbo.DubboInvoker";
+
+    private static final String METHODS_NAME = "doInvoke";
+
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return ClassMatcher.nameEquals(ENHANCE_CLASS);
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[]{InterceptDeclarer.build(MethodMatcher.nameEquals(METHODS_NAME),
+                new InvokeInterceptor())};
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/entity/JsseInfo.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/entity/JsseInfo.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.entity;
+
+/**
+ * jsse公共指标信息
+ *
+ * @author zhp
+ * @since 2023-10-18
+ */
+public class JsseInfo {
+    /**
+     * 进程Id
+     */
+    private String processId;
+
+    /**
+     * 客户端IP
+     */
+    private String clientIp;
+
+    /**
+     * 服务端IP
+     */
+    private String serverIp;
+
+    /**
+     * 服务端端口
+     */
+    private String serverPort;
+
+    /**
+     * L4角色信息
+     */
+    private String l4Role;
+
+    /**
+     * L7角色信息
+     */
+    private String l7Role;
+
+    /**
+     * 协议
+     */
+    private String protocol;
+
+    /**
+     * 容器Id
+     */
+    private String containerId;
+
+    /**
+     * 进程名称
+     */
+    private String comm;
+
+    /**
+     * K8S pod名称
+     */
+    private String podName;
+
+    /**
+     * K8S pod的IP
+     */
+    private String podIp;
+
+    /**
+     * 是否开启SSL
+     */
+    private boolean enableSsl;
+
+    /**
+     * 节点实例Id
+     */
+    private String machineId;
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public void setProcessId(String processId) {
+        this.processId = processId;
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public void setClientIp(String clientIp) {
+        this.clientIp = clientIp;
+    }
+
+    public String getServerIp() {
+        return serverIp;
+    }
+
+    public void setServerIp(String serverIp) {
+        this.serverIp = serverIp;
+    }
+
+    public String getServerPort() {
+        return serverPort;
+    }
+
+    public void setServerPort(String serverPort) {
+        this.serverPort = serverPort;
+    }
+
+    public String getL4Role() {
+        return l4Role;
+    }
+
+    public void setL4Role(String l4Role) {
+        this.l4Role = l4Role;
+    }
+
+    public String getL7Role() {
+        return l7Role;
+    }
+
+    public void setL7Role(String l7Role) {
+        this.l7Role = l7Role;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    public String getComm() {
+        return comm;
+    }
+
+    public void setComm(String comm) {
+        this.comm = comm;
+    }
+
+    public String getPodName() {
+        return podName;
+    }
+
+    public void setPodName(String podName) {
+        this.podName = podName;
+    }
+
+    public String getPodIp() {
+        return podIp;
+    }
+
+    public void setPodIp(String podIp) {
+        this.podIp = podIp;
+    }
+
+    public boolean isEnableSsl() {
+        return enableSsl;
+    }
+
+    public void setEnableSsl(boolean enableSsl) {
+        this.enableSsl = enableSsl;
+    }
+
+    public String getMachineId() {
+        return machineId;
+    }
+
+    public void setMachineId(String machineId) {
+        this.machineId = machineId;
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/entity/JsseLinkInfo.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/entity/JsseLinkInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.entity;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Jsse连接信息
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class JsseLinkInfo extends JsseInfo {
+    /**
+     * 发送的字节数
+     */
+    private AtomicInteger sentBytes = new AtomicInteger();
+
+    /**
+     * 接收的字节数
+     */
+    private AtomicInteger receiveBytes = new AtomicInteger();
+
+    /**
+     * 发送的报文数
+     */
+    private AtomicInteger sentMessages = new AtomicInteger();
+
+    /**
+     * 接收的报文数
+     */
+    private AtomicInteger receiveMessages = new AtomicInteger();
+
+    public AtomicInteger getSentBytes() {
+        return sentBytes;
+    }
+
+    public void setSentBytes(AtomicInteger sentBytes) {
+        this.sentBytes = sentBytes;
+    }
+
+    public AtomicInteger getReceiveBytes() {
+        return receiveBytes;
+    }
+
+    public void setReceiveBytes(AtomicInteger receiveBytes) {
+        this.receiveBytes = receiveBytes;
+    }
+
+    public AtomicInteger getSentMessages() {
+        return sentMessages;
+    }
+
+    public void setSentMessages(AtomicInteger sentMessages) {
+        this.sentMessages = sentMessages;
+    }
+
+    public AtomicInteger getReceiveMessages() {
+        return receiveMessages;
+    }
+
+    public void setReceiveMessages(AtomicInteger receiveMessages) {
+        this.receiveMessages = receiveMessages;
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/entity/JsseRpcInfo.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/entity/JsseRpcInfo.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.entity;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * JSSE RPC调用信息
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class JsseRpcInfo extends JsseInfo {
+    private AtomicInteger reqCount = new AtomicInteger();
+
+    private AtomicInteger responseCount = new AtomicInteger();
+
+    private AtomicLong sumLatency = new AtomicLong();
+
+    private AtomicInteger reqErrorCount = new AtomicInteger();
+
+    private List<Long> latencyList = new CopyOnWriteArrayList<>();
+
+    public AtomicInteger getReqCount() {
+        return reqCount;
+    }
+
+    public void setReqCount(AtomicInteger reqCount) {
+        this.reqCount = reqCount;
+    }
+
+    public AtomicInteger getResponseCount() {
+        return responseCount;
+    }
+
+    public void setResponseCount(AtomicInteger responseCount) {
+        this.responseCount = responseCount;
+    }
+
+    public AtomicLong getSumLatency() {
+        return sumLatency;
+    }
+
+    public void setSumLatency(AtomicLong sumLatency) {
+        this.sumLatency = sumLatency;
+    }
+
+    public AtomicInteger getReqErrorCount() {
+        return reqErrorCount;
+    }
+
+    public void setReqErrorCount(AtomicInteger reqErrorCount) {
+        this.reqErrorCount = reqErrorCount;
+    }
+
+    public List<Long> getLatencyList() {
+        return latencyList;
+    }
+
+    public void setLatencyList(List<Long> latencyList) {
+        this.latencyList = latencyList;
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/alibaba/CodecInterceptor.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/alibaba/CodecInterceptor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.interceptor.alibaba;
+
+import com.huawei.jsse.common.Constants;
+import com.huawei.jsse.entity.JsseLinkInfo;
+import com.huawei.jsse.manager.JsseManager;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.remoting.Channel;
+import com.alibaba.dubbo.remoting.buffer.ChannelBuffer;
+
+import java.net.InetSocketAddress;
+
+/**
+ * dubbo报文加解码拦截器
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class CodecInterceptor implements Interceptor {
+    private static final int PARAM_COUNT = 2;
+
+    private static final String TCP_PROTOCOL = "dubbo,rmi,http,https";
+
+    private static final String ENCODE_METHOD_NAME = "encode";
+
+    private int writeIndex;
+
+    private int readIndex;
+
+    private String key;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments == null || arguments.length < PARAM_COUNT
+                || !(arguments[0] instanceof Channel && arguments[1] instanceof ChannelBuffer)) {
+            return context;
+        }
+        Channel channel = (Channel) arguments[0];
+        ChannelBuffer buffer = (ChannelBuffer) arguments[1];
+        InetSocketAddress localAddress = channel.getLocalAddress();
+        InetSocketAddress remoteAddress = channel.getRemoteAddress();
+        key = localAddress.getHostName() + Constants.CONNECT + remoteAddress.getAddress();
+        JsseLinkInfo jsseLinkInfo = JsseManager.getJsseLink(key);
+        if (StringUtils.isEmpty(jsseLinkInfo.getClientIp())) {
+            initJsseLinkInfo(jsseLinkInfo, channel);
+        }
+        writeIndex = buffer.writerIndex();
+        readIndex = buffer.readerIndex();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments == null || arguments.length < PARAM_COUNT
+                || !(arguments[0] instanceof Channel && arguments[1] instanceof ChannelBuffer)) {
+            return context;
+        }
+        ChannelBuffer buffer = (ChannelBuffer) arguments[1];
+        JsseLinkInfo jsseLinkInfo = JsseManager.getJsseLink(key);
+        if (StringUtils.equals(context.getMethod().getName(), ENCODE_METHOD_NAME)) {
+            jsseLinkInfo.getSentBytes().addAndGet(buffer.writerIndex() - writeIndex);
+            jsseLinkInfo.getSentMessages().incrementAndGet();
+            return context;
+        }
+        if (buffer.readerIndex() - readIndex > 0) {
+            jsseLinkInfo.getReceiveBytes().addAndGet(buffer.readerIndex() - readIndex);
+            jsseLinkInfo.getReceiveMessages().incrementAndGet();
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        return context;
+    }
+
+    /**
+     * 初始化jsse连接信息
+     *
+     * @param jsseLinkInfo 连接信息
+     * @param channel 渠道信息
+     */
+    private void initJsseLinkInfo(JsseLinkInfo jsseLinkInfo, Channel channel) {
+        jsseLinkInfo.setClientIp(channel.getLocalAddress().getHostName());
+        jsseLinkInfo.setServerIp(channel.getRemoteAddress().getHostName());
+        jsseLinkInfo.setServerPort(StringUtils.getString(channel.getRemoteAddress().getPort()));
+        jsseLinkInfo.setProtocol(channel.getUrl().getProtocol());
+        if (isClientSide(channel)) {
+            jsseLinkInfo.setL7Role(Constants.CLIENT_ROLE);
+        } else {
+            jsseLinkInfo.setL7Role(Constants.SERVER_ROLE);
+        }
+        if (TCP_PROTOCOL.contains(jsseLinkInfo.getProtocol())) {
+            jsseLinkInfo.setL4Role(Constants.TCP_PROTOCOL + Constants.CONNECT + jsseLinkInfo.getL7Role());
+        } else {
+            jsseLinkInfo.setL4Role(Constants.UDP_PROTOCOL + Constants.CONNECT + jsseLinkInfo.getL7Role());
+        }
+        jsseLinkInfo.setEnableSsl(Boolean.parseBoolean(channel.getUrl().getParameter(Constants.SSL_ENABLE)));
+    }
+
+    /**
+     * 是否为客户端
+     *
+     * @param channel 渠道信息
+     * @return 是否为客户端的结果
+     */
+    private boolean isClientSide(Channel channel) {
+        String side = (String) channel.getAttribute(com.alibaba.dubbo.common.Constants.SIDE_KEY);
+        if (Constants.CLIENT_ROLE.equals(side)) {
+            return true;
+        }
+        if (Constants.SERVER_ROLE.equals(side)) {
+            return false;
+        }
+        InetSocketAddress address = channel.getRemoteAddress();
+        URL url = channel.getUrl();
+        return url.getPort() == address.getPort() && NetUtils.filterLocalHost(url.getIp())
+                .equals(NetUtils.filterLocalHost(address.getAddress().getHostAddress()));
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/alibaba/HandlerInterceptor.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/alibaba/HandlerInterceptor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.interceptor.alibaba;
+
+import com.huawei.jsse.common.Constants;
+import com.huawei.jsse.entity.JsseRpcInfo;
+import com.huawei.jsse.manager.JsseManager;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.remoting.Channel;
+import com.alibaba.dubbo.remoting.exchange.ExchangeChannel;
+
+import java.net.InetSocketAddress;
+
+/**
+ * dubbo请求处理拦截器
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class HandlerInterceptor implements Interceptor {
+    private long startTime;
+
+    private String key;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        if (context.getArguments() == null || !(context.getArguments()[0] instanceof ExchangeChannel)) {
+            return context;
+        }
+        startTime = System.currentTimeMillis();
+        ExchangeChannel channel = (ExchangeChannel) context.getArguments()[0];
+        JsseRpcInfo jsseRpcInfo = initJsseRpcInfo(channel);
+        jsseRpcInfo.getReqCount().incrementAndGet();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getResponseCount().incrementAndGet();
+        long latency = System.currentTimeMillis() - startTime;
+        jsseRpcInfo.getSumLatency().addAndGet(latency);
+        jsseRpcInfo.getLatencyList().add(latency);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getReqErrorCount().incrementAndGet();
+        return context;
+    }
+
+    /**
+     * 初始化jsse调用信息
+     *
+     * @param channel 渠道信息
+     * @return 调用信息
+     */
+    private JsseRpcInfo initJsseRpcInfo(Channel channel) {
+        InetSocketAddress localAddress = channel.getLocalAddress();
+        InetSocketAddress remoteAddress = channel.getRemoteAddress();
+        key = localAddress.getHostName() + Constants.CONNECT + remoteAddress.getAddress();
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        if (StringUtils.isEmpty(jsseRpcInfo.getClientIp())) {
+            jsseRpcInfo.setClientIp(channel.getLocalAddress().getHostName());
+            jsseRpcInfo.setServerIp(channel.getRemoteAddress().getHostName());
+            jsseRpcInfo.setServerPort(StringUtils.getString(channel.getRemoteAddress().getPort()));
+            jsseRpcInfo.setProtocol(channel.getUrl().getProtocol());
+            if (isClientSide(channel)) {
+                jsseRpcInfo.setL7Role(Constants.CLIENT_ROLE);
+            } else {
+                jsseRpcInfo.setL7Role(Constants.SERVER_ROLE);
+            }
+            if (Constants.TCP_PROTOCOLS.contains(jsseRpcInfo.getProtocol())) {
+                jsseRpcInfo.setL4Role(Constants.TCP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+            } else {
+                jsseRpcInfo.setL4Role(Constants.UDP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+            }
+            jsseRpcInfo.setEnableSsl(Boolean.parseBoolean(channel.getUrl().getParameter(Constants.SSL_ENABLE)));
+        }
+        return jsseRpcInfo;
+    }
+
+    /**
+     * 是否为客户端
+     *
+     * @param channel 渠道信息
+     * @return 是否为客户端的结果
+     */
+    private boolean isClientSide(Channel channel) {
+        String side = (String) channel.getAttribute(com.alibaba.dubbo.common.Constants.SIDE_KEY);
+        if (Constants.CLIENT_ROLE.equals(side)) {
+            return true;
+        } else if (Constants.SERVER_ROLE.equals(side)) {
+            return false;
+        } else {
+            InetSocketAddress address = channel.getRemoteAddress();
+            URL url = channel.getUrl();
+            return url.getPort() == address.getPort() && NetUtils.filterLocalHost(url.getIp())
+                    .equals(NetUtils.filterLocalHost(address.getAddress().getHostAddress()));
+        }
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/alibaba/InvokeInterceptor.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/alibaba/InvokeInterceptor.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.interceptor.alibaba;
+
+import com.huawei.jsse.common.Constants;
+import com.huawei.jsse.entity.JsseRpcInfo;
+import com.huawei.jsse.manager.JsseManager;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import com.alibaba.dubbo.common.URL;
+import com.alibaba.dubbo.common.utils.AtomicPositiveInteger;
+import com.alibaba.dubbo.common.utils.NetUtils;
+import com.alibaba.dubbo.remoting.Channel;
+import com.alibaba.dubbo.remoting.exchange.ExchangeClient;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+/**
+ * dubbo服务调用拦截器
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class InvokeInterceptor implements Interceptor {
+    private long startTime;
+
+    private String key;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        Optional<Object> indexOptional = ReflectUtils.getFieldValue(context.getObject(), Constants.CLIENT_INDEX);
+        Optional<Object> clientOptional = ReflectUtils.getFieldValue(context.getObject(), Constants.CLIENTS_NAME);
+        if (!indexOptional.isPresent() || !clientOptional.isPresent()
+                || !(indexOptional.get() instanceof AtomicPositiveInteger)
+                || !(clientOptional.get() instanceof ExchangeClient[])) {
+            return context;
+        }
+        AtomicPositiveInteger index = (AtomicPositiveInteger) indexOptional.get();
+        ExchangeClient[] clients = (ExchangeClient[]) clientOptional.get();
+        ExchangeClient client = clients[index.get() % clients.length];
+        startTime = System.currentTimeMillis();
+        JsseRpcInfo jsseRpcInfo = initJsseRpcInfo(client);
+        jsseRpcInfo.getReqCount().incrementAndGet();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getResponseCount().incrementAndGet();
+        long latency = System.currentTimeMillis() - startTime;
+        jsseRpcInfo.getSumLatency().addAndGet(latency);
+        jsseRpcInfo.getLatencyList().add(latency);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getReqErrorCount().incrementAndGet();
+        return context;
+    }
+
+    /**
+     * 初始化jsse调用信息
+     *
+     * @param channel 渠道信息
+     * @return 调用信息
+     */
+    private JsseRpcInfo initJsseRpcInfo(Channel channel) {
+        InetSocketAddress localAddress = channel.getLocalAddress();
+        InetSocketAddress remoteAddress = channel.getRemoteAddress();
+        key = localAddress.getHostName() + Constants.CONNECT + remoteAddress.getAddress();
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        if (!StringUtils.isEmpty(jsseRpcInfo.getClientIp())) {
+            return jsseRpcInfo;
+        }
+        jsseRpcInfo.setClientIp(channel.getLocalAddress().getHostName());
+        jsseRpcInfo.setServerIp(channel.getRemoteAddress().getHostName());
+        jsseRpcInfo.setServerPort(StringUtils.getString(channel.getRemoteAddress().getPort()));
+        jsseRpcInfo.setProtocol(channel.getUrl().getProtocol());
+        if (isClientSide(channel)) {
+            jsseRpcInfo.setL7Role(Constants.CLIENT_ROLE);
+        } else {
+            jsseRpcInfo.setL7Role(Constants.SERVER_ROLE);
+        }
+        if (Constants.TCP_PROTOCOLS.contains(jsseRpcInfo.getProtocol())) {
+            jsseRpcInfo.setL4Role(Constants.TCP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+        } else {
+            jsseRpcInfo.setL4Role(Constants.UDP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+        }
+        jsseRpcInfo.setEnableSsl(Boolean.parseBoolean(channel.getUrl().getParameter(Constants.SSL_ENABLE)));
+        return jsseRpcInfo;
+    }
+
+    /**
+     * 是否为客户端
+     *
+     * @param channel 渠道信息
+     * @return 是否为客户端的结果
+     */
+    private boolean isClientSide(Channel channel) {
+        String side = (String) channel.getAttribute(com.alibaba.dubbo.common.Constants.SIDE_KEY);
+        if (Constants.CLIENT_ROLE.equals(side)) {
+            return true;
+        } else if (Constants.SERVER_ROLE.equals(side)) {
+            return false;
+        } else {
+            InetSocketAddress address = channel.getRemoteAddress();
+            URL url = channel.getUrl();
+            return url.getPort() == address.getPort() && NetUtils.filterLocalHost(url.getIp())
+                    .equals(NetUtils.filterLocalHost(address.getAddress().getHostAddress()));
+        }
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/apache/CodecInterceptor.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/apache/CodecInterceptor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.interceptor.apache;
+
+import com.huawei.jsse.common.Constants;
+import com.huawei.jsse.entity.JsseLinkInfo;
+import com.huawei.jsse.manager.JsseManager;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.remoting.Channel;
+import org.apache.dubbo.remoting.buffer.ChannelBuffer;
+
+import java.net.InetSocketAddress;
+
+/**
+ * dubbo报文加解码拦截器
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class CodecInterceptor implements Interceptor {
+    private static final int PARAM_COUNT = 2;
+
+    private static final String ENCODE_METHOD_NAME = "encode";
+
+    private int writeIndex;
+
+    private int readIndex;
+
+    private String key;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments == null || arguments.length < PARAM_COUNT
+                || !(arguments[0] instanceof Channel
+                && arguments[1] instanceof ChannelBuffer)) {
+            return context;
+        }
+        Channel channel = (Channel) arguments[0];
+        ChannelBuffer buffer = (ChannelBuffer) arguments[1];
+        InetSocketAddress localAddress = channel.getLocalAddress();
+        InetSocketAddress remoteAddress = channel.getRemoteAddress();
+        key = localAddress.getHostName() + Constants.CONNECT + remoteAddress.getAddress();
+        JsseLinkInfo jsseLinkInfo = JsseManager.getJsseLink(key);
+        if (StringUtils.isEmpty(jsseLinkInfo.getClientIp())) {
+            initJsseLinkInfo(jsseLinkInfo, channel);
+        }
+        writeIndex = buffer.writerIndex();
+        readIndex = buffer.readerIndex();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        Object[] arguments = context.getArguments();
+        if (arguments == null || arguments.length < PARAM_COUNT
+                || !(arguments[0] instanceof Channel
+                && arguments[1] instanceof ChannelBuffer)) {
+            return context;
+        }
+        ChannelBuffer buffer = (ChannelBuffer) arguments[1];
+        JsseLinkInfo jsseLinkInfo = JsseManager.getJsseLink(key);
+        if (StringUtils.equals(context.getMethod().getName(), ENCODE_METHOD_NAME)) {
+            jsseLinkInfo.getSentBytes().addAndGet(buffer.writerIndex() - writeIndex);
+            jsseLinkInfo.getSentMessages().incrementAndGet();
+            return context;
+        }
+        if (buffer.readerIndex() - readIndex > 0) {
+            jsseLinkInfo.getReceiveBytes().addAndGet(buffer.readerIndex() - readIndex);
+            jsseLinkInfo.getReceiveMessages().incrementAndGet();
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        return context;
+    }
+
+    /**
+     * 初始化jsse连接信息
+     *
+     * @param jsseLinkInfo 连接信息
+     * @param channel 渠道信息
+     */
+    private void initJsseLinkInfo(JsseLinkInfo jsseLinkInfo, Channel channel) {
+        jsseLinkInfo.setClientIp(channel.getLocalAddress().getHostName());
+        jsseLinkInfo.setServerIp(channel.getRemoteAddress().getHostName());
+        jsseLinkInfo.setServerPort(StringUtils.getString(channel.getRemoteAddress().getPort()));
+        jsseLinkInfo.setProtocol(channel.getUrl().getProtocol());
+        if (isClientSide(channel)) {
+            jsseLinkInfo.setL7Role(Constants.CLIENT_ROLE);
+        } else {
+            jsseLinkInfo.setL7Role(Constants.SERVER_ROLE);
+        }
+        if (Constants.TCP_PROTOCOLS.contains(jsseLinkInfo.getProtocol())) {
+            jsseLinkInfo.setL4Role(Constants.TCP_PROTOCOL + Constants.CONNECT + jsseLinkInfo.getL7Role());
+        } else {
+            jsseLinkInfo.setL4Role(Constants.UDP_PROTOCOL + Constants.CONNECT + jsseLinkInfo.getL7Role());
+        }
+        jsseLinkInfo.setEnableSsl(Boolean.parseBoolean(channel.getUrl().getParameter(Constants.SSL_ENABLE)));
+    }
+
+    /**
+     * 是否为客户端
+     *
+     * @param channel 渠道信息
+     * @return 是否为客户端的结果
+     */
+    private boolean isClientSide(Channel channel) {
+        String side = (String) channel.getAttribute(CommonConstants.SIDE_KEY);
+        if (Constants.CLIENT_ROLE.equals(side)) {
+            return true;
+        }
+        if (Constants.SERVER_ROLE.equals(side)) {
+            return false;
+        }
+        InetSocketAddress address = channel.getRemoteAddress();
+        URL url = channel.getUrl();
+        return url.getPort() == address.getPort() && NetUtils.filterLocalHost(url.getIp())
+                .equals(NetUtils.filterLocalHost(address.getAddress().getHostAddress()));
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/apache/HandlerInterceptor.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/apache/HandlerInterceptor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.interceptor.apache;
+
+import com.huawei.jsse.common.Constants;
+import com.huawei.jsse.entity.JsseRpcInfo;
+import com.huawei.jsse.manager.JsseManager;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.remoting.Channel;
+import org.apache.dubbo.remoting.exchange.ExchangeChannel;
+
+import java.net.InetSocketAddress;
+
+/**
+ * dubbo请求处理拦截器
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class HandlerInterceptor implements Interceptor {
+    private long startTime;
+
+    private String key;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        if (context.getArguments() == null || !(context.getArguments()[0] instanceof ExchangeChannel)) {
+            return context;
+        }
+        startTime = System.currentTimeMillis();
+        ExchangeChannel channel = (ExchangeChannel) context.getArguments()[0];
+        JsseRpcInfo jsseRpcInfo = initJsseRpcInfo(channel);
+        jsseRpcInfo.getReqCount().incrementAndGet();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getResponseCount().incrementAndGet();
+        long latency = System.currentTimeMillis() - startTime;
+        jsseRpcInfo.getSumLatency().addAndGet(latency);
+        jsseRpcInfo.getLatencyList().add(latency);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getReqErrorCount().incrementAndGet();
+        return context;
+    }
+
+    /**
+     * 初始化jsse调用信息
+     *
+     * @param channel 渠道信息
+     * @return 调用信息
+     */
+    private JsseRpcInfo initJsseRpcInfo(Channel channel) {
+        InetSocketAddress localAddress = channel.getLocalAddress();
+        InetSocketAddress remoteAddress = channel.getRemoteAddress();
+        key = localAddress.getHostName() + Constants.CONNECT + remoteAddress.getAddress();
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        if (StringUtils.isEmpty(jsseRpcInfo.getClientIp())) {
+            jsseRpcInfo.setClientIp(channel.getLocalAddress().getHostName());
+            jsseRpcInfo.setServerIp(channel.getRemoteAddress().getHostName());
+            jsseRpcInfo.setServerPort(StringUtils.getString(channel.getRemoteAddress().getPort()));
+            jsseRpcInfo.setProtocol(channel.getUrl().getProtocol());
+            if (isClientSide(channel)) {
+                jsseRpcInfo.setL7Role(Constants.CLIENT_ROLE);
+            } else {
+                jsseRpcInfo.setL7Role(Constants.SERVER_ROLE);
+            }
+            if (Constants.TCP_PROTOCOLS.contains(jsseRpcInfo.getProtocol())) {
+                jsseRpcInfo.setL4Role(Constants.TCP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+            } else {
+                jsseRpcInfo.setL4Role(Constants.UDP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+            }
+            jsseRpcInfo.setEnableSsl(Boolean.parseBoolean(channel.getUrl().getParameter(Constants.SSL_ENABLE)));
+        }
+        return jsseRpcInfo;
+    }
+
+    /**
+     * 是否为客户端
+     *
+     * @param channel 渠道信息
+     * @return 是否为客户端的结果
+     */
+    private boolean isClientSide(Channel channel) {
+        String side = (String) channel.getAttribute(com.alibaba.dubbo.common.Constants.SIDE_KEY);
+        if (Constants.CLIENT_ROLE.equals(side)) {
+            return true;
+        } else if (Constants.SERVER_ROLE.equals(side)) {
+            return false;
+        } else {
+            InetSocketAddress address = channel.getRemoteAddress();
+            URL url = channel.getUrl();
+            return url.getPort() == address.getPort() && NetUtils.filterLocalHost(url.getIp())
+                    .equals(NetUtils.filterLocalHost(address.getAddress().getHostAddress()));
+        }
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/apache/InvokeInterceptor.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/interceptor/apache/InvokeInterceptor.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.interceptor.apache;
+
+import com.huawei.jsse.common.Constants;
+import com.huawei.jsse.entity.JsseRpcInfo;
+import com.huawei.jsse.manager.JsseManager;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.Interceptor;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.common.utils.AtomicPositiveInteger;
+import org.apache.dubbo.common.utils.NetUtils;
+import org.apache.dubbo.remoting.Channel;
+import org.apache.dubbo.remoting.exchange.ExchangeClient;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+/**
+ * dubbo服务调用拦截器
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class InvokeInterceptor implements Interceptor {
+    private long startTime;
+
+    private String key;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        Optional<Object> indexOptional = ReflectUtils.getFieldValue(context.getObject(), Constants.CLIENT_INDEX);
+        Optional<Object> clientOptional = ReflectUtils.getFieldValue(context.getObject(), Constants.CLIENTS_NAME);
+        if (!indexOptional.isPresent() || !clientOptional.isPresent()
+                || !(indexOptional.get() instanceof AtomicPositiveInteger)
+                || !(clientOptional.get() instanceof ExchangeClient[])) {
+            return context;
+        }
+        AtomicPositiveInteger index = (AtomicPositiveInteger) indexOptional.get();
+        ExchangeClient[] clients = (ExchangeClient[]) clientOptional.get();
+        ExchangeClient client = clients[index.get() % clients.length];
+        startTime = System.currentTimeMillis();
+        JsseRpcInfo jsseRpcInfo = initJsseRpcInfo(client);
+        jsseRpcInfo.getReqCount().incrementAndGet();
+        return context;
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getResponseCount().incrementAndGet();
+        long latency = System.currentTimeMillis() - startTime;
+        jsseRpcInfo.getSumLatency().addAndGet(latency);
+        jsseRpcInfo.getLatencyList().add(latency);
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) {
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        jsseRpcInfo.getReqErrorCount().incrementAndGet();
+        return context;
+    }
+
+    /**
+     * 初始化jsse调用信息
+     *
+     * @param channel 渠道信息
+     * @return 调用信息
+     */
+    private JsseRpcInfo initJsseRpcInfo(Channel channel) {
+        InetSocketAddress localAddress = channel.getLocalAddress();
+        InetSocketAddress remoteAddress = channel.getRemoteAddress();
+        key = localAddress.getHostName() + Constants.CONNECT + remoteAddress.getAddress();
+        JsseRpcInfo jsseRpcInfo = JsseManager.getJsseRpc(key);
+        if (!StringUtils.isEmpty(jsseRpcInfo.getClientIp())) {
+            return jsseRpcInfo;
+        }
+        jsseRpcInfo.setClientIp(channel.getLocalAddress().getHostName());
+        jsseRpcInfo.setServerIp(channel.getRemoteAddress().getHostName());
+        jsseRpcInfo.setServerPort(StringUtils.getString(channel.getRemoteAddress().getPort()));
+        jsseRpcInfo.setProtocol(channel.getUrl().getProtocol());
+        if (isClientSide(channel)) {
+            jsseRpcInfo.setL7Role(Constants.CLIENT_ROLE);
+        } else {
+            jsseRpcInfo.setL7Role(Constants.SERVER_ROLE);
+        }
+        if (Constants.TCP_PROTOCOLS.contains(jsseRpcInfo.getProtocol())) {
+            jsseRpcInfo.setL4Role(Constants.TCP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+        } else {
+            jsseRpcInfo.setL4Role(Constants.UDP_PROTOCOL + Constants.CONNECT + jsseRpcInfo.getL7Role());
+        }
+        jsseRpcInfo.setEnableSsl(Boolean.parseBoolean(channel.getUrl().getParameter(Constants.SSL_ENABLE)));
+        return jsseRpcInfo;
+    }
+
+    /**
+     * 是否为客户端
+     *
+     * @param channel 渠道信息
+     * @return 是否为客户端的结果
+     */
+    private boolean isClientSide(Channel channel) {
+        String side = (String) channel.getAttribute(com.alibaba.dubbo.common.Constants.SIDE_KEY);
+        if (Constants.CLIENT_ROLE.equals(side)) {
+            return true;
+        } else if (Constants.SERVER_ROLE.equals(side)) {
+            return false;
+        } else {
+            InetSocketAddress address = channel.getRemoteAddress();
+            URL url = channel.getUrl();
+            return url.getPort() == address.getPort() && NetUtils.filterLocalHost(url.getIp())
+                    .equals(NetUtils.filterLocalHost(address.getAddress().getHostAddress()));
+        }
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/manager/JsseManager.java
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/java/com/huawei/jsse/manager/JsseManager.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.manager;
+
+import com.huawei.jsse.entity.JsseLinkInfo;
+import com.huawei.jsse.entity.JsseRpcInfo;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * JSSE管理类
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class JsseManager {
+    private static final Map<String, JsseLinkInfo> JSSE_LINK_INFO_MAP = new ConcurrentHashMap<>();
+
+    private static final Map<String, JsseRpcInfo> JSSE_RPC_INFO_MAP = new ConcurrentHashMap<>();
+
+    private JsseManager() {
+    }
+
+    /**
+     * 获取JSSE连接信息
+     *
+     * @return JSSE连接信息
+     */
+    public static Map<String, JsseLinkInfo> getJsseLinkMap() {
+        return JSSE_LINK_INFO_MAP;
+    }
+
+    /**
+     * 获取JSSE连接信息
+     *
+     * @return JSSE连接信息
+     */
+    public static Map<String, JsseRpcInfo> getJsseRpcMap() {
+        return JSSE_RPC_INFO_MAP;
+    }
+
+    /**
+     * 获取JSSE连接信息
+     *
+     * @param key JSSE MAP的密钥信息
+     * @return Jsse信息
+     */
+    public static JsseLinkInfo getJsseLink(String key) {
+        return JSSE_LINK_INFO_MAP.computeIfAbsent(key, s -> new JsseLinkInfo());
+    }
+
+    /**
+     * 获取JSSE RPC信息
+     *
+     * @param key JSSE MAP的密钥信息
+     * @return Jsse RPC信息
+     */
+    public static JsseRpcInfo getJsseRpc(String key) {
+        return JSSE_RPC_INFO_MAP.computeIfAbsent(key, s -> new JsseRpcInfo());
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+com.huawei.jsse.declarer.alibaba.DecodeDeclarer
+com.huawei.jsse.declarer.alibaba.EncodeDeclarer
+com.huawei.jsse.declarer.alibaba.HandlerDeclarer
+com.huawei.jsse.declarer.alibaba.InvokeDeclarer
+com.huawei.jsse.declarer.apache.DecodeDeclarer
+com.huawei.jsse.declarer.apache.EncodeDeclarer
+com.huawei.jsse.declarer.apache.HandlerDeclarer
+com.huawei.jsse.declarer.apache.InvokeDeclarer

--- a/sermant-plugins/sermant-jsse/jsse-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
+++ b/sermant-plugins/sermant-jsse/jsse-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.config.PluginConfig
@@ -1,0 +1,1 @@
+com.huawei.jsse.config.JsseConfig

--- a/sermant-plugins/sermant-jsse/jsse-service/pom.xml
+++ b/sermant-plugins/sermant-jsse/jsse-service/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-jsse</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jsse-service</artifactId>
+
+    <properties>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>service</package.plugin.type>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>jsse-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.83</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-plugins/sermant-jsse/jsse-service/src/main/java/com/huawei/jsse/service/JsseService.java
+++ b/sermant-plugins/sermant-jsse/jsse-service/src/main/java/com/huawei/jsse/service/JsseService.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.jsse.service;
+
+import com.huawei.jsse.common.Constants;
+import com.huawei.jsse.config.JsseConfig;
+import com.huawei.jsse.entity.JsseLinkInfo;
+import com.huawei.jsse.entity.JsseRpcInfo;
+import com.huawei.jsse.manager.JsseManager;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.core.plugin.service.PluginService;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import com.alibaba.fastjson.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.RandomAccessFile;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.InetAddress;
+import java.nio.channels.FileLock;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * JSSE服务类，上报指标数据
+ *
+ * @author zhp
+ * @since 2023-10-17
+ */
+public class JsseService implements PluginService {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static final JsseConfig JSSE_CONFIG = PluginConfigManager.getPluginConfig(JsseConfig.class);
+
+    private static final int CONTAINER_NAME_INDEX = 2;
+
+    private static final int ENABLE_NUM = 2;
+
+    /**
+     * 换行符。Gopher解析时需要用到
+     * System.lineSeparator()在UNIX返回"\n" 在Windows 返回"\r\n". 因此不能修改为System.lineSeparator();
+     */
+    private static final String LINE_BREAK = "|\r\n";
+
+    private static final BigDecimal MULTIPLYING_POWER = new BigDecimal(1000);
+
+    private static final int[] RANGE = {0, 3, 10, 50, 100, 500, 1000, 10000};
+
+    /**
+     * 进程Id
+     */
+    private String pid;
+
+    /**
+     * 进程名称
+     */
+    private String processName;
+
+    /**
+     * 机器Id
+     */
+    private String machineId;
+
+    /**
+     * 容器ID
+     */
+    private String containerId;
+
+    /**
+     * 容器名称
+     */
+    private String containerName;
+
+    /**
+     * 容器IP
+     */
+    private String containerIp;
+
+    /**
+     * 文件名称
+     */
+    private String jsseFileName;
+
+    private ScheduledExecutorService executorService;
+
+    @Override
+    public void start() {
+        if (!JSSE_CONFIG.isEnable()) {
+            return;
+        }
+        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+        String name = runtimeMxBean.getName();
+        int index = name.indexOf(Constants.PROCESS_NAME_LINK);
+        if (index != -1) {
+            pid = name.substring(0, index);
+            processName = name.substring(index + 1);
+        } else {
+            pid = "-1";
+            processName = StringUtils.EMPTY;
+        }
+        initMachineId();
+        initContainerInfo();
+        String filePath = JSSE_CONFIG.getFilePath() + pid;
+        jsseFileName = filePath + Constants.FILE_PATH_LINK + JSSE_CONFIG.getFileName();
+        try {
+            createTmpFile(filePath, jsseFileName);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "create metric file failed", e);
+            return;
+        }
+        executorService = Executors.newScheduledThreadPool(1);
+        executorService.scheduleAtFixedRate(this::writeMetricData, JSSE_CONFIG.getDelayTime(), JSSE_CONFIG.getPeriod(),
+                TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void stop() {
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+    }
+
+    /**
+     * 把指标数据写进文件里
+     */
+    private void writeMetricData() {
+        if (JsseManager.getJsseLinkMap().isEmpty() && JsseManager.getJsseRpcMap().isEmpty()) {
+            return;
+        }
+        try (RandomAccessFile raf = new RandomAccessFile(jsseFileName, "rw");
+                FileLock lock = raf.getChannel().lock()) {
+            raf.seek(raf.length());
+            writeLinkData(raf);
+            writeRpcData(raf);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Exception writing indicator data to file.", e);
+        }
+    }
+
+    /**
+     * 写连接数据
+     *
+     * @param raf 文件连接
+     * @throws IOException 文件写入异常
+     */
+    private void writeLinkData(RandomAccessFile raf) throws IOException {
+        for (Entry<String, JsseLinkInfo> entry : JsseManager.getJsseLinkMap().entrySet()) {
+            JsseLinkInfo oldJsseInfo = entry.getValue();
+            if (oldJsseInfo.getSentMessages().get() == 0 && oldJsseInfo.getReceiveMessages().get() == 0) {
+                continue;
+            }
+            JsseLinkInfo jsseLinkInfo = JSONObject.parseObject(JSONObject.toJSONString(oldJsseInfo),
+                    JsseLinkInfo.class);
+            raf.write(String.format(Locale.ROOT, "|sermant_l7_link|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s",
+                    pid, jsseLinkInfo.getClientIp(), jsseLinkInfo.getServerIp(), jsseLinkInfo.getServerPort(),
+                    jsseLinkInfo.getL4Role(), jsseLinkInfo.getL7Role(), jsseLinkInfo.getProtocol(),
+                    jsseLinkInfo.isEnableSsl() ? Constants.SSL_OPEN : Constants.SSL_CLOSE,
+                    jsseLinkInfo.getSentBytes().get(), jsseLinkInfo.getSentMessages().get(),
+                    jsseLinkInfo.getReceiveBytes().get(), jsseLinkInfo.getReceiveMessages().get()
+            ).getBytes(Charset.defaultCharset()));
+            raf.write(LINE_BREAK.getBytes(Charset.defaultCharset()));
+            oldJsseInfo.getReceiveMessages().getAndAdd(-jsseLinkInfo.getReceiveMessages().get());
+            oldJsseInfo.getReceiveBytes().getAndAdd(-jsseLinkInfo.getReceiveBytes().get());
+            oldJsseInfo.getSentMessages().getAndAdd(-jsseLinkInfo.getSentMessages().get());
+            oldJsseInfo.getSentBytes().getAndAdd(-jsseLinkInfo.getSentBytes().get());
+        }
+    }
+
+    /**
+     * 写RPC数据
+     *
+     * @param raf 文件连接
+     * @throws IOException 文件写入异常
+     */
+    private void writeRpcData(RandomAccessFile raf) throws IOException {
+        for (Entry<String, JsseRpcInfo> entry : JsseManager.getJsseRpcMap().entrySet()) {
+            JsseRpcInfo oldJsseInfo = entry.getValue();
+            if (oldJsseInfo.getReqCount().get() == 0 && oldJsseInfo.getResponseCount().get() == 0) {
+                continue;
+            }
+            JsseRpcInfo jsseRpcInfo = JSONObject.parseObject(JSONObject.toJSONString(oldJsseInfo),
+                    JsseRpcInfo.class);
+            BigDecimal reqCount = new BigDecimal(jsseRpcInfo.getReqCount().get());
+            BigDecimal resCount = new BigDecimal(jsseRpcInfo.getResponseCount().get());
+            BigDecimal errorCount = new BigDecimal(jsseRpcInfo.getReqErrorCount().get());
+            BigDecimal errorRatio = errorCount.divide(reqCount, ENABLE_NUM, RoundingMode.HALF_UP);
+            BigDecimal sumLatency = new BigDecimal(jsseRpcInfo.getSumLatency().get());
+            BigDecimal avgLatency = sumLatency.divide(reqCount, ENABLE_NUM, RoundingMode.HALF_UP);
+            BigDecimal reqThroughout = reqCount.multiply(MULTIPLYING_POWER).divide(avgLatency, ENABLE_NUM,
+                    RoundingMode.HALF_UP);
+            BigDecimal resThroughout = resCount.multiply(MULTIPLYING_POWER).divide(avgLatency, ENABLE_NUM,
+                    RoundingMode.HALF_UP);
+            String latencyHistogram = getLatencyHistogram(jsseRpcInfo.getLatencyList());
+            raf.write(String.format(Locale.ROOT, "|sermant_l7_rpc|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s"
+                            + "|%s|%s|%s", pid, jsseRpcInfo.getClientIp(), jsseRpcInfo.getServerIp(),
+                    jsseRpcInfo.getServerPort(), jsseRpcInfo.getL4Role(), jsseRpcInfo.getL7Role(),
+                    jsseRpcInfo.getProtocol(), jsseRpcInfo.isEnableSsl() ? Constants.SSL_OPEN : Constants.SSL_CLOSE,
+                    reqThroughout, resThroughout, reqCount, resCount, avgLatency, latencyHistogram,
+                    sumLatency, errorRatio, errorCount).getBytes(Charset.defaultCharset()));
+            raf.write(LINE_BREAK.getBytes(Charset.defaultCharset()));
+            oldJsseInfo.getReqErrorCount().getAndAdd(-jsseRpcInfo.getReqErrorCount().get());
+            oldJsseInfo.getSumLatency().getAndAdd(-jsseRpcInfo.getSumLatency().get());
+            oldJsseInfo.getResponseCount().getAndAdd(-jsseRpcInfo.getResponseCount().get());
+            oldJsseInfo.getReqCount().getAndAdd(-jsseRpcInfo.getReqCount().get());
+            oldJsseInfo.getLatencyList().removeAll(jsseRpcInfo.getLatencyList());
+        }
+    }
+
+    /**
+     * 初始化机器Id
+     */
+    private void initMachineId() {
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder("/bin/sh", "-c", "dmidecode -s system-uuid");
+            Process process = processBuilder.start();
+            try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    if (StringUtils.isExist(line)) {
+                        machineId = line.trim();
+                        break;
+                    }
+                }
+            }
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                LOGGER.log(Level.WARNING, "Failed to execute command: dmidecode -s system-uuid.");
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Error executing command: dmidecode -s system-uuid.", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(Level.WARNING, "Command execution interrupted.", e);
+        }
+        machineId = StringUtils.EMPTY;
+    }
+
+    /**
+     * 初始化容器信息
+     */
+    private void initContainerInfo() {
+        try {
+            containerIp = InetAddress.getLocalHost().getHostAddress();
+            ProcessBuilder processBuilder = new ProcessBuilder("cat", "/proc/self/cgroup");
+            Process process = processBuilder.start();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains("docker") || line.contains("kubepods")) {
+                    String[] parts = line.split("/");
+                    containerId = parts[parts.length - 1];
+                    containerName = parts[parts.length - CONTAINER_NAME_INDEX];
+                    break;
+                }
+            }
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                LOGGER.log(Level.WARNING, "Failed to get container ID.");
+            }
+        } catch (IOException | InterruptedException e) {
+            LOGGER.log(Level.WARNING, "Failed to get container ID.", e);
+        }
+        containerId = StringUtils.EMPTY;
+    }
+
+    /**
+     * 创建文件
+     *
+     * @param filePath 文件路径
+     * @param fileName 文件名称
+     * @throws IOException 文件创建异常
+     */
+    private void createTmpFile(String filePath, String fileName) throws IOException {
+        File dir = new File(filePath);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        File file = new File(fileName);
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+    }
+
+    /**
+     * 生成时延直方图
+     *
+     * @param latencyList 时延信息
+     * @return 时延直方图
+     */
+    private String getLatencyHistogram(List<Long> latencyList) {
+        if (latencyList == null || latencyList.isEmpty()) {
+            return StringUtils.EMPTY;
+        }
+        StringBuilder latencyHistogram = new StringBuilder(String.valueOf(RANGE.length - 1));
+        for (int index = 0; index < RANGE.length - 1; index++) {
+            final int latencyIndex = index;
+            latencyHistogram.append(" ").append(RANGE[index + 1]).append(" ").append((int) latencyList.stream().filter(
+                    v -> v > RANGE[latencyIndex] && v < RANGE[latencyIndex + 1]).count());
+        }
+        return latencyHistogram.toString();
+    }
+}

--- a/sermant-plugins/sermant-jsse/jsse-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
+++ b/sermant-plugins/sermant-jsse/jsse-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.huawei.jsse.service.JsseService

--- a/sermant-plugins/sermant-jsse/pom.xml
+++ b/sermant-plugins/sermant-jsse/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-plugins</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <artifactId>sermant-jsse</artifactId>
+
+    <properties>
+        <sermant.basedir>${pom.basedir}/../../..</sermant.basedir>
+        <package.plugin.name>jsse</package.plugin.name>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>agent</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>jsse-plugin</module>
+                <module>jsse-service</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>test</id>
+            <modules>
+                <module>jsse-plugin</module>
+                <module>jsse-service</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>release</id>
+            <modules>
+                <module>jsse-plugin</module>
+                <module>jsse-service</module>
+            </modules>
+        </profile>
+    </profiles>
+
+</project>


### PR DESCRIPTION
【Fix issue】#1341

[Modification content] Added dubbo’s JSSE indicator collection

[Use case description] 1. Subsequent supplementary test cases

[Self-test status] 1. Local static inspection and cleaning status; 2. Self-test passed

[Scope of impact] 1. Is there any impact on users’ use? 2. Subsequent supplementary usage documentation