### PR TITLE
Supports repeated installation of plug-ins, using '#' to separate plugin copies, plugin services and configured Key information to carry class loaders

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/PluginManager.java
@@ -168,7 +168,8 @@ public class PluginManager {
                 continue;
             }
             try {
-                final String pluginPath = pluginPackage + File.separatorChar + pluginName;
+                // 去除插件名副本标记，获取实际所需要用到的资源目录
+                final String pluginPath = pluginPackage + File.separatorChar + getRealPluginName(pluginName);
                 if (!new File(pluginPath).exists()) {
                     LOGGER.log(Level.WARNING, "Plugin directory {0} does not exist, so skip initializing {1}. ",
                             new String[]{pluginPath, pluginName});
@@ -284,7 +285,8 @@ public class PluginManager {
         JarFile jarFile = null;
         try {
             jarFile = new JarFile(jar);
-            if (ifCheckSchema && !PluginSchemaValidator.checkSchema(pluginName, jarFile)) {
+            if (ifCheckSchema && !PluginSchemaValidator.checkSchema(pluginName, getRealPluginName(pluginName),
+                    jarFile)) {
                 throw new SchemaException(SchemaException.UNEXPECTED_EXT_JAR, jar.getPath());
             }
             if (consumer != null) {
@@ -303,6 +305,16 @@ public class PluginManager {
                 }
             }
         }
+    }
+
+    /**
+     * 形如 plugin-name#1 plugin-name#2 方式标记插件副本，共用资源文件，通过分隔插件名获取实际的插件名，对应插件目录名及Manifest中的插件标识
+     *
+     * @param pluginName 插件名
+     * @return 实际插件名
+     */
+    private static String getRealPluginName(String pluginName) {
+        return pluginName.split("#")[0];
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/common/PluginSchemaValidator.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/common/PluginSchemaValidator.java
@@ -73,28 +73,29 @@ public class PluginSchemaValidator {
     /**
      * 检查名称和版本
      *
-     * @param name 插件名称
+     * @param pluginName 插件名称
+     * @param realPluginName 实际插件名，插件名去除副本标记后的所使用的插件
      * @param jarFile 插件包
      * @return 为真时经过名称和版本校验，为插件包或插件服务包，为假时表示第三方jar包
      * @throws IOException 获取manifest文件异常
      * @throws SchemaException 传入插件名和从资源文件中检索到的不一致
      */
-    public static boolean checkSchema(String name, JarFile jarFile) throws IOException {
+    public static boolean checkSchema(String pluginName, String realPluginName, JarFile jarFile) throws IOException {
         final Object nameAttr = JarFileUtils.getManifestAttr(jarFile, PluginConstant.PLUGIN_NAME_KEY);
         if (nameAttr == null) {
             return false;
         }
-        if (!nameAttr.toString().equals(name)) {
-            throw new SchemaException(SchemaException.UNEXPECTED_NAME, nameAttr.toString(), name);
+        if (!nameAttr.toString().equals(realPluginName)) {
+            throw new SchemaException(SchemaException.UNEXPECTED_NAME, nameAttr.toString(), pluginName);
         }
         final Object versionAttr = JarFileUtils.getManifestAttr(jarFile, PluginConstant.PLUGIN_VERSION_KEY);
         final String givingVersion =
                 versionAttr == null ? PluginConstant.PLUGIN_DEFAULT_VERSION : versionAttr.toString();
-        final String expectingVersion = PLUGIN_VERSION_MAP.get(name);
+        final String expectingVersion = PLUGIN_VERSION_MAP.get(pluginName);
         if (expectingVersion == null) {
-            PLUGIN_VERSION_MAP.put(name, givingVersion);
+            PLUGIN_VERSION_MAP.put(pluginName, givingVersion);
         } else if (!expectingVersion.equals(givingVersion)) {
-            throw new SchemaException(SchemaException.UNEXPECTED_VERSION, name, givingVersion, expectingVersion);
+            throw new SchemaException(SchemaException.UNEXPECTED_VERSION, pluginName, givingVersion, expectingVersion);
         }
         return true;
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/service/PluginServiceManager.java
@@ -20,6 +20,7 @@ import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.event.collector.FrameworkEventCollector;
 import com.huaweicloud.sermant.core.plugin.Plugin;
 import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.utils.KeyGenerateUtils;
 
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -50,9 +51,9 @@ public class PluginServiceManager extends ServiceManager {
         for (PluginService service : ServiceLoader.load(PluginService.class, classLoader)) {
             if (loadService(service, service.getClass(), PluginService.class)) {
                 try {
-                    String serviceName = service.getClass().getName();
+                    String pluginServiceKey = KeyGenerateUtils.generateClassKeyWithClassLoader(service.getClass());
                     service.start();
-                    plugin.getServices().add(serviceName);
+                    plugin.getServices().add(pluginServiceKey);
                 } catch (Exception ex) {
                     LOGGER.log(Level.SEVERE, "Error occurs while starting plugin service: " + service.getClass(), ex);
                 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/KeyGenerateUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/KeyGenerateUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.utils;
+
+/**
+ * 生成各类键
+ *
+ * @author luanwenfei
+ * @since 2023-10-19
+ */
+public class KeyGenerateUtils {
+    private KeyGenerateUtils() {
+    }
+
+    /**
+     * 通过Class生成携带类加载器信息的键
+     *
+     * @param cls 类
+     * @return 键
+     */
+    public static String generateClassKeyWithClassLoader(Class<?> cls) {
+        return cls.getName() + "@" + System.identityHashCode(cls.getClassLoader());
+    }
+}

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/NacosRegistryFactoryTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/NacosRegistryFactoryTest.java
@@ -30,6 +30,7 @@ import com.huawei.dubbo.registry.alibaba.NacosRegistryFactory;
 import com.huawei.dubbo.registry.service.nacos.NacosRegistryService;
 import com.huaweicloud.sermant.core.service.BaseService;
 import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.utils.KeyGenerateUtils;
 
 /**
  * 测试NacosRegistryFactory
@@ -45,7 +46,8 @@ public class NacosRegistryFactoryTest {
         Field field = ServiceManager.class.getDeclaredField("SERVICES");
         field.setAccessible(true);
         Map<String, BaseService> map = (Map<String, BaseService>) field.get(null);
-        map.put(NacosRegistryService.class.getCanonicalName(), new NacosRegistryService() {
+        map.put(KeyGenerateUtils.generateClassKeyWithClassLoader(NacosRegistryService.class),
+                new NacosRegistryService() {
 
             @Override
             public void doRegister(Object url) {

--- a/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/RegistryFactoryTest.java
+++ b/sermant-plugins/sermant-service-registry/dubbo-registry-plugin/src/test/java/com/huawei/dubbo/registry/RegistryFactoryTest.java
@@ -22,6 +22,7 @@ import com.huawei.dubbo.registry.service.RegistryService;
 
 import com.huaweicloud.sermant.core.service.BaseService;
 import com.huaweicloud.sermant.core.service.ServiceManager;
+import com.huaweicloud.sermant.core.utils.KeyGenerateUtils;
 
 import com.alibaba.dubbo.common.URL;
 
@@ -47,7 +48,7 @@ public class RegistryFactoryTest {
         Field field = ServiceManager.class.getDeclaredField("SERVICES");
         field.setAccessible(true);
         Map<String, BaseService> map = (Map<String, BaseService>) field.get(null);
-        map.put(RegistryService.class.getCanonicalName(), new RegistryService() {
+        map.put(KeyGenerateUtils.generateClassKeyWithClassLoader(RegistryService.class), new RegistryService() {
             @Override
             public void startRegistration() {
             }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/test/java/com/huawei/registry/service/client/BaseTest.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/test/java/com/huawei/registry/service/client/BaseTest.java
@@ -17,10 +17,11 @@
 package com.huawei.registry.service.client;
 
 import com.huawei.registry.config.RegisterConfig;
-
 import com.huawei.registry.config.RegisterServiceCommonConfig;
+
 import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.config.common.BaseConfig;
+import com.huaweicloud.sermant.core.config.utils.ConfigKeyUtil;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 
 import org.junit.BeforeClass;
@@ -49,15 +50,18 @@ public class BaseTest {
         removeFinalModify(configMap);
 
         configManagerMap = (Map<String, BaseConfig>) configMap.get(null);
-        configManagerMap.put("servicecomb.service", new RegisterConfig());
-        configManagerMap.put("register.service", new RegisterServiceCommonConfig());
+        configManagerMap.put(ConfigKeyUtil.getCLTypeKey("servicecomb.service", RegisterConfig.class.getClassLoader()),
+                new RegisterConfig());
+        configManagerMap.put(
+                ConfigKeyUtil.getCLTypeKey("register.service", RegisterServiceCommonConfig.class.getClassLoader()),
+                new RegisterServiceCommonConfig());
     }
 
     /**
      * 移除final修饰符
      *
      * @param field 字段
-     * @throws NoSuchFieldException   无该字段抛出
+     * @throws NoSuchFieldException 无该字段抛出
      * @throws IllegalAccessException 无法拿到该字段抛出
      */
     protected static void removeFinalModify(Field field) throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
【Fix issue】#1332

[Modified content] 1. Modified the way the plug-in manager obtains the plug-in directory when installing plug-ins, and truncated the plug-in name through the copy separator 2. Modified the method of plug-in service manager to identify plug-in services, adding a new class loader to the identification content 3 , Modified the method of plug-in configuration manager to identify plug-in configuration, and added a new class loader to the identification content.

[Use case description] New use case 1. Static installation of multi-copy plug-ins 2. Dynamic installation of multi-copy plug-ins 3. Install copy plug-ins to test plug-in service differentiation 4. Install copy plug-ins to test plug-in configuration differentiation 5. Install copy plug-ins to test bytecode capabilities Take effect

[Self-test situation] 1. The local static check has passed; 2. Baseline use case integration test, new use cases are manually covered

[Scope of impact] 1. Is there any impact on users' use (such as API modifications and startup parameter modifications)? 2. Is it necessary to update some documents (such as user manuals)