### PR TITLE
Traffic label transparent transmission plugin integration test demo: tomcat demo, jetty demo, jdkhttp demo, httpclientv3 demo...

### DIFF
--- a/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tag-transmission-test</artifactId>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>httpclientv3-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>${httpclient3x.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv3/HttpClientApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv3/HttpClientApplication.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.httpclientv3;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-10-13
+ **/
+@SpringBootApplication
+public class HttpClientApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(HttpClientApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv3/controller/HttpClientV3Controller.java
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv3/controller/HttpClientV3Controller.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.httpclientv3.controller;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+/**
+ * controller，使用httpclient4.x调用http 服务端
+ *
+ * @author daizhenyu
+ * @since 2023-10-14
+ **/
+@RestController
+@RequestMapping(value = "httpClientV3")
+public class HttpClientV3Controller {
+    @Value("${common.server.url}")
+    private String commonServerUrl;
+
+    /**
+     * 验证httpclient3.x透传流量标签
+     *
+     * @return 流量标签值
+     * @throws IOException
+     */
+    @RequestMapping(value = "testHttpClientV3", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testHttpClientV3() throws IOException {
+        return doHttpClientV3Get(commonServerUrl);
+    }
+
+    private String doHttpClientV3Get(String url) throws IOException {
+        // 创建 HttpClient 实例
+        HttpClient httpClient = new HttpClient();
+        GetMethod getMethod = new GetMethod(url);
+
+        // 执行 GET 请求
+        httpClient.executeMethod(getMethod);
+        String responseContext = getMethod.getResponseBodyAsString();
+        getMethod.releaseConnection();
+        return responseContext;
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv3-demo/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+common.server.url=http://127.0.0.1:9040/common/httpServer
+server.port=9048

--- a/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tag-transmission-test</artifactId>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>httpclientv4-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient4x.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv4/HttpClientApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv4/HttpClientApplication.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.httpclientv4;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+public class HttpClientApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(HttpClientApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv4/controller/HttpClientV4Controller.java
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/src/main/java/com/huaweicloud/demo/tagtransmission/httpclientv4/controller/HttpClientV4Controller.java
@@ -1,0 +1,67 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.httpclientv4.controller;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+/**
+ * controller，使用httpclient3.x调用http 服务端
+ *
+ * @author daizhenyu
+ * @since 2023-10-14
+ **/
+@RestController
+@RequestMapping(value = "httpClientV4")
+public class HttpClientV4Controller {
+    @Value("${common.server.url}")
+    private String commonServerUrl;
+
+    /**
+     * 验证httpclient4.x透传流量标签
+     *
+     * @return 流量标签值
+     * @throws IOException
+     */
+    @RequestMapping(value = "testHttpClientV4", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testHttpClientV4() throws IOException {
+        return doHttpClientV4Get(commonServerUrl);
+    }
+
+    private String doHttpClientV4Get(String url) throws IOException {
+        // 创建 CloseableHttpClient 实例
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        HttpGet httpGet = new HttpGet(url);
+
+        // 执行 GET 请求
+        CloseableHttpResponse response = httpClient.execute(httpGet);
+        String responseContext = EntityUtils.toString(response.getEntity());
+        response.close();
+        httpClient.close();
+        return responseContext;
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/httpclientv4-demo/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+common.server.url=http://127.0.0.1:9040/common/httpServer
+server.port=9049

--- a/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tag-transmission-test</artifactId>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jdkhttp-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>tag-transmission-util-demo</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jdkhttp/JdkHttpApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jdkhttp/JdkHttpApplication.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.jdkhttp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+public class JdkHttpApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(JdkHttpApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jdkhttp/controller/JdkHttpController.java
+++ b/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jdkhttp/controller/JdkHttpController.java
@@ -1,0 +1,65 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.jdkhttp.controller;
+
+import com.huaweicloud.demo.tagtransmission.util.HttpClientUtils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+/**
+ * controller，使用JdkHttp调用http 服务端
+ *
+ * @author daizhenyu
+ * @since 2023-10-14
+ **/
+@RestController
+@RequestMapping(value = "jdkHttp")
+public class JdkHttpController {
+    @Value("${jetty.server.url}")
+    private String jettyServerUrl;
+
+    @Value("${tomcat.server.url}")
+    private String tomcatServerUrl;
+
+    /**
+     * 验证JdkHttp透传流量标签, 调用jetty服务端
+     *
+     * @return 流量标签值
+     * @throws IOException
+     */
+    @RequestMapping(value = "testJdkHttpAndJetty", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testJdkHttpAndJetty() {
+        return HttpClientUtils.doHttpUrlConnectionGet(jettyServerUrl);
+    }
+
+    /**
+     * 验证JdkHttp透传流量标签，调用tomcat服务端
+     *
+     * @return 流量标签值
+     * @throws IOException
+     */
+    @RequestMapping(value = "testJdkHttpAndTomcat", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testJdkHttpAndTomcat() {
+        return HttpClientUtils.doHttpUrlConnectionGet(tomcatServerUrl);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/jdkhttp-demo/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+jetty.server.url=http://127.0.0.1:9051/jetty/testJetty
+tomcat.server.url=http://127.0.0.1:9052/tomcat/testTomcat
+server.port=9050

--- a/sermant-integration-tests/tag-transmission-test/jetty-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/jetty-demo/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <artifactId>tag-transmission-test</artifactId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jetty-demo</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>tag-transmission-util-demo</artifactId>
+            <version>${tag-transmission.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sermant-integration-tests/tag-transmission-test/jetty-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jettyserver/HttpJettyApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/jetty-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jettyserver/HttpJettyApplication.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.jettyserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@SpringBootApplication
+public class HttpJettyApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(HttpJettyApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/jetty-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jettyserver/controller/ServerController.java
+++ b/sermant-integration-tests/tag-transmission-test/jetty-demo/src/main/java/com/huaweicloud/demo/tagtransmission/jettyserver/controller/ServerController.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.jettyserver.controller;
+
+import com.huaweicloud.demo.tagtransmission.util.HttpClientUtils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * http Server端，使用jetty作为容器
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@RestController
+@RequestMapping(value = "jetty")
+public class ServerController {
+    @Value("${common.server.url}")
+    private String commonServerUrl;
+
+    /**
+     * 验证jetty服务端透传流量标签
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "testJetty", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testJetty() {
+        return HttpClientUtils.doHttpUrlConnectionGet(commonServerUrl);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/jetty-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/jetty-demo/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9051
+common.server.url=http://127.0.0.1:9040/common/httpServer

--- a/sermant-integration-tests/tag-transmission-test/midware-common-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/midware-common-demo/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tag-transmission-test</artifactId>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>midware-common-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/midware-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/midware/common/MessageConstant.java
+++ b/sermant-integration-tests/tag-transmission-test/midware-common-demo/src/main/java/com/huaweicloud/demo/tagtransmission/midware/common/MessageConstant.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.midware.common;
+
+/**
+ * 消息中间件的公共常量
+ *
+ * @author daizhenyu
+ * @since 2023-09-28
+ **/
+public class MessageConstant {
+    /**
+     * 消息中间件的topic
+     */
+    public static final String TOPIC = "traffic_tag_test";
+
+    /**
+     * 时间格式
+     */
+    public static final String TIME_FORMAT = "yyyy/MM/dd HH:mm:ss";
+
+    /**
+     * rocketmq消息的tag
+     */
+    public static final String TAG = "";
+
+    /**
+     * rocketmq消费者消费消息的标签范围
+     */
+    public static final String TAG_SCOPE = "*";
+
+    /**
+     * rocketmq生产者组
+     */
+    public static final String ROCKETMQ_PRODUCE_GROUP = "producer_group";
+
+    /**
+     * rocketmq消费者组
+     */
+    public static final String CONSUME_GROUP = "consume_group";
+
+    /**
+     * rocketmq消息体
+     */
+    public static final String MESSAGE_BODY_ROCKET = "hello inner rocketmq:";
+
+    /**
+     * kafka发送消息的key
+     */
+    public static final String KAFKA_KEY = "trafficTag";
+
+    /**
+     * kafka消息体
+     */
+    public static final String MESSAGE_BODY_KAFKA = "hello inner kafka:";
+
+    /**
+     * kafka拉去消息的timeout
+     */
+    public static final int KAFKA_CONSUMER_TIMEOUT = 100;
+
+    private MessageConstant() {
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tag-transmission-test</artifactId>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rocketmq-consumer-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>midware-common-demo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>tag-transmission-util-demo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-client</artifactId>
+            <version>${rocketmq-client.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rocketmq/consumer/RocketMqConsumer.java
+++ b/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rocketmq/consumer/RocketMqConsumer.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.rocketmq.consumer;
+
+import com.huaweicloud.demo.tagtransmission.midware.common.MessageConstant;
+import com.huaweicloud.demo.tagtransmission.util.HttpClientUtils;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * kafka消费者
+ *
+ * @author daizhenyu
+ * @since 2023-09-08
+ **/
+@Component
+public class RocketMqConsumer implements CommandLineRunner {
+    /**
+     * 存储消费者调用http服务端返回的流量标签
+     */
+    public static final Map<String, String> ROCKETMQ_TAG_MAP = new HashMap<>();
+
+    @Value("${common.server.url}")
+    private String commonServerUrl;
+
+    @Value("${rocketmq.address}")
+    private String rocketMqAddress;
+
+    @Override
+    public void run(String[] args) throws MQClientException {
+        consumeData();
+    }
+
+    private void consumeData() throws MQClientException {
+        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer(MessageConstant.CONSUME_GROUP);
+        consumer.setNamesrvAddr(rocketMqAddress);
+        consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+        consumer.subscribe(MessageConstant.TOPIC, MessageConstant.TAG_SCOPE);
+        consumer.registerMessageListener(new MessageListenerOrderly() {
+            @Override
+            public ConsumeOrderlyStatus consumeMessage(List<MessageExt> messageExts,
+                    ConsumeOrderlyContext context) {
+                if (messageExts != null) {
+                    for (MessageExt ext : messageExts) {
+                        ext.getBody();
+                        ROCKETMQ_TAG_MAP.put("rocketmqTag", HttpClientUtils.doHttpUrlConnectionGet(commonServerUrl));
+                    }
+                }
+                return ConsumeOrderlyStatus.SUCCESS;
+            }
+        });
+        consumer.start();
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rocketmq/consumer/RocketMqConsumerApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rocketmq/consumer/RocketMqConsumerApplication.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.rocketmq.consumer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-10-13
+ **/
+@SpringBootApplication
+public class RocketMqConsumerApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(RocketMqConsumerApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rocketmq/consumer/controller/RocketMqConsumerController.java
+++ b/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/java/com/huaweicloud/demo/tagtransmission/rocketmq/consumer/controller/RocketMqConsumerController.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.rocketmq.consumer.controller;
+
+import com.huaweicloud.demo.tagtransmission.rocketmq.consumer.RocketMqConsumer;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 消息中间件消费者controller
+ *
+ * @author daizhenyu
+ * @since 2023-09-28
+ **/
+@RestController
+@RequestMapping(value = "rocketMqConsumer")
+public class RocketMqConsumerController {
+    /**
+     * 查询rocketmq消费者消费消息后返回的流量标签透传
+     *
+     * @return string
+     */
+    @RequestMapping(value = "queryRocketMqTag", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String queryRocketmqTag() {
+        String trafficTag = RocketMqConsumer.ROCKETMQ_TAG_MAP.get("rocketmqTag");
+
+        // 删除流量标签，以免干扰下一次测试查询
+        RocketMqConsumer.ROCKETMQ_TAG_MAP.remove("rocketmqTag");
+        return trafficTag;
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/rocketmq-consumer-demo/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+common.server.url=http://127.0.0.1:9040/common/httpServer
+rocketmq.address=127.0.0.1:9876
+server.port=9056

--- a/sermant-integration-tests/tag-transmission-test/tomcat-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/tomcat-demo/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tag-transmission-test</artifactId>
+        <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>tomcat-demo</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant.tagtransmission</groupId>
+            <artifactId>tag-transmission-util-demo</artifactId>
+            <version>${tag-transmission.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-integration-tests/tag-transmission-test/tomcat-demo/src/main/java/com/huaweicloud/demo/tagtransmission/tomcatserver/HttpTomcatApplication.java
+++ b/sermant-integration-tests/tag-transmission-test/tomcat-demo/src/main/java/com/huaweicloud/demo/tagtransmission/tomcatserver/HttpTomcatApplication.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.tomcatserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * springboot 启动类
+ *
+ * @author daizhenyu
+ * @since 2023-10-13
+ **/
+@SpringBootApplication
+public class HttpTomcatApplication {
+    /**
+     * 启动类
+     *
+     * @param args 进程启动入参
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(HttpTomcatApplication.class, args);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/tomcat-demo/src/main/java/com/huaweicloud/demo/tagtransmission/tomcatserver/controller/ServerController.java
+++ b/sermant-integration-tests/tag-transmission-test/tomcat-demo/src/main/java/com/huaweicloud/demo/tagtransmission/tomcatserver/controller/ServerController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.demo.tagtransmission.tomcatserver.controller;
+
+import com.huaweicloud.demo.tagtransmission.util.HttpClientUtils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * http Server端，使用tomcat作为容器
+ *
+ * @author daizhenyu
+ * @since 2023-09-07
+ **/
+@RestController
+@RequestMapping(value = "tomcat")
+public class ServerController {
+    @Value("${common.server.url}")
+    private String commonServerUrl;
+
+    /**
+     * 验证tomcat服务端透传流量标签
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "testTomcat", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testTomcat() {
+        return HttpClientUtils.doHttpUrlConnectionGet(commonServerUrl);
+    }
+
+    /**
+     * 用于验证流量透传标签配置项是否生效
+     *
+     * @return 流量标签值
+     */
+    @RequestMapping(value = "testConfig", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testConfig() {
+        return HttpClientUtils.doHttpUrlConnectionGet(commonServerUrl);
+    }
+}

--- a/sermant-integration-tests/tag-transmission-test/tomcat-demo/src/main/resources/application.properties
+++ b/sermant-integration-tests/tag-transmission-test/tomcat-demo/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=9052
+common.server.url=http://127.0.0.1:9040/common/httpServer


### PR DESCRIPTION
【Fix issue】#1333

[Modification] Added a demo of the integration test part of the traffic label transparent transmission plug-in, including:
1.tomcat-demo
2.jetty-demo
3.httpclientv3-demo
4.httpclientv4-demo
5.jdkhttp-demo
6.midware-common-demo
7.rocketmq-consumer-demo

[Use case description] Integration test demo

[Self-test situation] 1. Local static check passed
[Scope of influence] None