### PR TITLE
Bytecode enhancement ignores classes loaded by SermantClassLoader.

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/BufferedAgentBuilder.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/BufferedAgentBuilder.java
@@ -30,6 +30,7 @@ import com.huaweicloud.sermant.core.plugin.agent.transformer.ReentrantTransforme
 import com.huaweicloud.sermant.core.plugin.classloader.PluginClassLoader;
 import com.huaweicloud.sermant.core.plugin.classloader.ServiceClassLoader;
 import com.huaweicloud.sermant.core.utils.FileUtils;
+import com.huaweicloud.sermant.god.common.SermantClassLoader;
 
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.agent.builder.AgentBuilder.Default;
@@ -326,6 +327,9 @@ public class BufferedAgentBuilder {
         }
 
         private boolean checkClassLoader(TypeDescription typeDesc, ClassLoader classLoader) {
+            if (classLoader instanceof SermantClassLoader) {
+                return true;
+            }
             if (classLoader instanceof FrameworkClassLoader) {
                 return true;
             }


### PR DESCRIPTION
[Fix issue] https://github.com/huaweicloud/Sermant/issues/1340

[Modification content] Ignore classes loaded by SermantClassLoader when bytecode is enhanced

[Use case description] No need to modify the use case

[Self-test status] 1. Local static inspection and cleaning status; 2. Self-test passed

[Scope of influence] 1. No impact on users’ use