### PR TITLE
Codecheck bug fix.

### DIFF
--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/GraceSwitchInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/GraceSwitchInterceptor.java
@@ -46,7 +46,12 @@ import java.util.Random;
  * @since 2022-05-17
  */
 public class GraceSwitchInterceptor extends RegisterSwitchSupport {
+    /**
+     * grace配置类
+     */
     protected final GraceConfig graceConfig;
+
+    private Random random = new Random();
 
     /**
      * 优雅上下线开关
@@ -172,7 +177,7 @@ public class GraceSwitchInterceptor extends RegisterSwitchSupport {
         if (totalWeight <= 0) {
             return Optional.empty();
         }
-        int position = new Random().nextInt(totalWeight);
+        int position = random.nextInt(totalWeight);
         for (int i = 0; i < weights.length; i++) {
             position -= weights[i];
             if (position < 0) {

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringRibbonWarmUpInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringRibbonWarmUpInterceptor.java
@@ -100,7 +100,8 @@ public class SpringRibbonWarmUpInterceptor extends GraceSwitchInterceptor {
     }
 
     private Map<String, String> getMetadata(Server server) {
-        if (StringUtils.equals(ZOOKEEPER_SERVER_NAME, server.getClass().getName())) {
+        if (StringUtils.equals(ZOOKEEPER_SERVER_NAME, server.getClass().getName())
+                && server instanceof ZookeeperServer) {
             ZookeeperServer zookeeperServer = (ZookeeperServer) server;
             return zookeeperServer.getInstance().getPayload().getMetadata();
         }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringZuulResponseInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/grace/interceptors/SpringZuulResponseInterceptor.java
@@ -48,7 +48,7 @@ public class SpringZuulResponseInterceptor extends GraceSwitchInterceptor {
     protected ExecuteContext doBefore(ExecuteContext context) {
         RequestContext requestContext = RequestContext.getCurrentContext();
         Map<String, List<String>> map = getGraceIpHeaders();
-        map.forEach((k, v) -> requestContext.addZuulRequestHeader(k, v.get(0)));
+        map.forEach((key, value) -> requestContext.addZuulRequestHeader(key, value.get(0)));
         return context;
     }
 
@@ -61,10 +61,10 @@ public class SpringZuulResponseInterceptor extends GraceSwitchInterceptor {
         }
         HttpServletResponse response = (HttpServletResponse) rawResponse;
         GraceContext.INSTANCE.getGraceShutDownManager()
-            .addShutdownEndpoints(response.getHeaders(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT));
+                .addShutdownEndpoints(response.getHeaders(GraceConstants.MARK_SHUTDOWN_SERVICE_ENDPOINT));
         HttpServletRequest request = (HttpServletRequest) rawRequest;
         RefreshUtils.refreshTargetServiceInstances(request.getRemoteHost(),
-            Collections.singleton(response.getHeader(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME)));
+                Collections.singleton(response.getHeader(GraceConstants.MARK_SHUTDOWN_SERVICE_NAME)));
         return context;
     }
 

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/OriginRegistrySwitchInjectDefine.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/OriginRegistrySwitchInjectDefine.java
@@ -25,7 +25,7 @@ import com.huaweicloud.sermant.core.service.inject.ClassInjectDefine;
  * @author zhouss
  * @since 2022-05-19
  */
-public class OriginRegistrySwitchInjectDefine extends BaseAutoConfigurationDefine implements ClassInjectDefine {
+public class OriginRegistrySwitchInjectDefine extends BaseAutoConfigurationDefine {
     @Override
     public String injectClassName() {
         return "com.huawei.registry.inject.source.SpringEnvironmentProcessor";

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/RibbonConfigurationDefine.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/RibbonConfigurationDefine.java
@@ -26,7 +26,7 @@ import com.huaweicloud.sermant.core.utils.ClassUtils;
  * @author zhouss
  * @since 2022-05-19
  */
-public class RibbonConfigurationDefine extends BaseAutoConfigurationDefine implements ClassInjectDefine {
+public class RibbonConfigurationDefine extends BaseAutoConfigurationDefine {
     @Override
     public String injectClassName() {
         return "com.huawei.registry.auto.sc.configuration.ServiceCombRibbonAutoConfiguration";

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/ScConfigurationInjectDefine.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/inject/ScConfigurationInjectDefine.java
@@ -25,7 +25,7 @@ import com.huaweicloud.sermant.core.service.inject.ClassInjectDefine;
  * @author zhouss
  * @since 2022-05-18
  */
-public class ScConfigurationInjectDefine extends BaseAutoConfigurationDefine implements ClassInjectDefine {
+public class ScConfigurationInjectDefine extends BaseAutoConfigurationDefine {
     @Override
     public String injectClassName() {
         return "com.huawei.registry.auto.sc.configuration.ServiceCombAutoDiscoveryConfiguration";

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/RegistrationInterceptor.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/interceptors/RegistrationInterceptor.java
@@ -29,7 +29,6 @@ import com.huawei.registry.utils.ZoneUtils;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.plugin.service.PluginServiceManager;
-import com.huaweicloud.sermant.core.service.ServiceManager;
 
 import org.springframework.cloud.client.serviceregistry.Registration;
 
@@ -65,7 +64,7 @@ public class RegistrationInterceptor extends RegisterSwitchSupport {
         RegisterContext.INSTANCE.getClientInfo().setHost(registration.getHost());
         RegisterServiceCommonConfig config = PluginConfigManager.getPluginConfig(RegisterServiceCommonConfig.class);
         RegisterContext.INSTANCE.getClientInfo().setMeta(CommonUtils.putSecureToMetaData(registration.getMetadata(),
-            config));
+                config));
         RegisterContext.INSTANCE.getClientInfo().setPort(registration.getPort());
         RegisterContext.INSTANCE.getClientInfo().setServiceId(registration.getServiceId());
     }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/InstanceInterceptorSupport.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/InstanceInterceptorSupport.java
@@ -20,6 +20,7 @@ package com.huawei.registry.support;
 import com.huawei.registry.config.RegisterConfig;
 import com.huawei.registry.entity.MicroServiceInstance;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.core.utils.ClassLoaderUtils;
 import com.huaweicloud.sermant.core.utils.StringUtils;
@@ -30,6 +31,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * 实例获取拦截器支持
@@ -38,6 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 2022-02-22
  */
 public abstract class InstanceInterceptorSupport extends RegisterSwitchSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
     /**
      * 类缓存, 避免多次调用loadClass
      */
@@ -79,7 +84,7 @@ public abstract class InstanceInterceptorSupport extends RegisterSwitchSupport {
                 try {
                     result = contextClassLoader.loadClass(className);
                 } catch (ClassNotFoundException ignored) {
-                    // ignored
+                    LOGGER.log(Level.WARNING, "{0} class not found.", className);
                 }
             }
             return result;
@@ -100,7 +105,7 @@ public abstract class InstanceInterceptorSupport extends RegisterSwitchSupport {
                     .getDeclaredConstructor(MicroServiceInstance.class, String.class);
             return Optional.of(declaredConstructor.newInstance(microServiceInstance, serviceName));
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
-                 | InvocationTargetException ignored) {
+            | InvocationTargetException exception) {
             return Optional.empty();
         }
     }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/RegisterSwitchSupport.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/support/RegisterSwitchSupport.java
@@ -31,6 +31,9 @@ import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
  * @since 2022-03-02
  */
 public abstract class RegisterSwitchSupport implements Interceptor {
+    /**
+     * register配置类
+     */
     protected final RegisterConfig registerConfig;
 
     /**

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/utils/HostUtils.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/com/huawei/registry/utils/HostUtils.java
@@ -68,8 +68,8 @@ public class HostUtils {
                     return ip;
                 }
             }
-        } catch (SocketException ignored) {
-            // ignored
+        } catch (SocketException exception) {
+            LOGGER.warning("An exception occurred while getting the machine's IP address.");
         }
         LOGGER.severe("Can not acquire correct instance ip , it will be replaced by local ip!");
         return LOCAL_IP;
@@ -151,8 +151,9 @@ public class HostUtils {
                     return true;
                 }
             }
-        } catch (UnknownHostException ignored) {
-            // ignored 若域名解析失败, 则无需再比较, 说明本身域名（或者网络）存在问题, 无需再做比较
+        } catch (UnknownHostException exception) {
+            // 若域名解析失败, 则无需再比较, 说明本身域名（或者网络）存在问题, 无需再做比较
+            LOGGER.warning("Domain name resolution failure.");
         }
         return false;
     }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/cache/AddressCache.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/cache/AddressCache.java
@@ -56,6 +56,11 @@ public enum AddressCache {
         cache.put(address, "");
     }
 
+    /**
+     * 获取地址Set
+     *
+     * @return Set 地址Set
+     */
     public Set<String> getAddressSet() {
         return cache.asMap().keySet();
     }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/NacosClient.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/NacosClient.java
@@ -83,11 +83,11 @@ public class NacosClient {
             NamingService namingService = nacosServiceManager.getNamingService();
             namingService.registerInstance(serviceId, group, instance);
             LOGGER.log(Level.INFO, String.format(Locale.ENGLISH, "registry success, group={%s},serviceId={%s},"
-                + "instanceIp={%s},instancePort={%s} register finished", group, serviceId, instance.getIp(),
+                    + "instanceIp={%s},instancePort={%s} register finished", group, serviceId, instance.getIp(),
                     instance.getPort()));
         } catch (NacosException e) {
-            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "failed when registry service，"
-                + "serviceId={%s}", serviceId), e);
+            LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "failed when registry service，serviceId={%s}",
+                    serviceId), e);
         }
     }
 
@@ -106,7 +106,7 @@ public class NacosClient {
             namingService.deregisterInstance(serviceId, group, instance);
         } catch (NacosException e) {
             LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "failed when deRegister service，"
-                + "serviceId={%s}", serviceId), e);
+                    + "serviceId={%s}", serviceId), e);
         }
     }
 
@@ -133,7 +133,7 @@ public class NacosClient {
     public void updateInstanceStatus(String status) {
         if (!STATUS_UP.equalsIgnoreCase(status) && !STATUS_DOWN.equalsIgnoreCase(status)) {
             LOGGER.warning(String.format(Locale.ENGLISH,"can't support status={%s},"
-                + "please choose UP or DOWN", status));
+                    + "please choose UP or DOWN", status));
             return;
         }
         String serviceId = RegisterContext.INSTANCE.getClientInfo().getServiceId();
@@ -144,7 +144,7 @@ public class NacosClient {
             nacosServiceManager.getNamingMaintainService().updateInstance(serviceId, group, updateInstance);
         } catch (NacosException e) {
             LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "update nacos instance status failed,"
-                + "serviceId={%s}", serviceId), e);
+                    + "serviceId={%s}", serviceId), e);
         }
     }
 
@@ -159,15 +159,15 @@ public class NacosClient {
         try {
             NamingService namingService = nacosServiceManager.getNamingService();
             List<Instance> instances = namingService.getAllInstances(serviceId, group);
-            for (Instance instance : instances) {
-                if (instance.getIp().equalsIgnoreCase(RegisterContext.INSTANCE.getClientInfo().getIp())
-                        && instance.getPort() == RegisterContext.INSTANCE.getClientInfo().getPort()) {
-                    return instance.isEnabled() ? "UP" : "DOWN";
+            for (Instance serviceInstance : instances) {
+                if (serviceInstance.getIp().equalsIgnoreCase(RegisterContext.INSTANCE.getClientInfo().getIp())
+                        && serviceInstance.getPort() == RegisterContext.INSTANCE.getClientInfo().getPort()) {
+                    return serviceInstance.isEnabled() ? "UP" : "DOWN";
                 }
             }
         } catch (NacosException e) {
             LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "getInstanceStatus failed,serviceId={%s}",
-                serviceId), e);
+                    serviceId), e);
         }
         return STATUS_UNKNOW;
     }
@@ -187,8 +187,8 @@ public class NacosClient {
                     }).get();
         } catch (NacosException e) {
             LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "getInstances failed from nacos，"
-                + "serviceId={%s}，isFailureToleranceEnabled={%s}", serviceId,
-                nacosRegisterConfig.isFailureToleranceEnabled()), e);
+                    + "serviceId={%s}，isFailureToleranceEnabled={%s}", serviceId,
+                    nacosRegisterConfig.isFailureToleranceEnabled()), e);
             if (nacosRegisterConfig.isFailureToleranceEnabled()) {
                 return ServiceCache.getInstances(serviceId);
             }
@@ -209,7 +209,7 @@ public class NacosClient {
             }).get();
         } catch (NacosException e) {
             LOGGER.log(Level.SEVERE, String.format(Locale.ENGLISH, "getServices failed，"
-                + "isFailureToleranceEnabled={%s}", nacosRegisterConfig.isFailureToleranceEnabled()), e);
+                    + "isFailureToleranceEnabled={%s}", nacosRegisterConfig.isFailureToleranceEnabled()), e);
             return nacosRegisterConfig.isFailureToleranceEnabled() ? ServiceCache.getServiceIds()
                     : Collections.emptyList();
         }

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-service/src/main/java/com/huawei/registry/service/client/ScClient.java
@@ -67,7 +67,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -102,8 +101,6 @@ public class ScClient {
     private static final int FLAG = -1;
 
     private static final int MAX_HOST_NAME_LENGTH = 64;
-
-    private final AtomicBoolean isDelayed = new AtomicBoolean();
 
     private ServiceCenterConfiguration serviceCenterConfiguration;
 

--- a/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/cache/InstanceCache.java
+++ b/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/cache/InstanceCache.java
@@ -45,7 +45,7 @@ public class InstanceCache {
      */
     public static void saveInstanceInfo(RequestInfo requestInfo) {
         String key = requestInfo.getHost() + RemovalConstants.CONNECTOR + requestInfo.getPort();
-        InstanceInfo info = INSTANCE_MAP.computeIfAbsent(key, s -> {
+        InstanceInfo info = INSTANCE_MAP.computeIfAbsent(key, value -> {
             InstanceInfo instanceInfo = new InstanceInfo();
             instanceInfo.setHost(requestInfo.getHost());
             instanceInfo.setPort(requestInfo.getPort());

--- a/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/AbstractCallInterceptor.java
+++ b/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/AbstractCallInterceptor.java
@@ -65,9 +65,7 @@ public abstract class AbstractCallInterceptor<T> extends AbstractSwitchIntercept
      *
      * @return 例信息的参数下标
      */
-    protected int getIndex() {
-        return 0;
-    }
+    protected abstract int getIndex();
 
     /**
      * 获取实例IP

--- a/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/AlibabaDubboInvokeInterceptor.java
+++ b/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/AlibabaDubboInvokeInterceptor.java
@@ -28,6 +28,11 @@ import com.alibaba.dubbo.rpc.Invocation;
  */
 public class AlibabaDubboInvokeInterceptor extends AbstractCallInterceptor<Invocation> {
     @Override
+    protected int getIndex() {
+        return 0;
+    }
+
+    @Override
     protected String getHost(Invocation invocation) {
         if (invocation == null || invocation.getInvoker() == null || invocation.getInvoker().getUrl() == null) {
             return StringUtils.EMPTY;

--- a/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/ApacheDubboInvokeInterceptor.java
+++ b/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/ApacheDubboInvokeInterceptor.java
@@ -48,6 +48,7 @@ public class ApacheDubboInvokeInterceptor extends AbstractCallInterceptor<Invoca
      *
      * @return 例信息的参数下标
      */
+    @Override
     protected int getIndex() {
         return 1;
     }

--- a/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/SpringBootApplyInterceptor.java
+++ b/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/SpringBootApplyInterceptor.java
@@ -53,6 +53,7 @@ public class SpringBootApplyInterceptor extends AbstractCallInterceptor<Object> 
      *
      * @return 例信息的参数下标
      */
+    @Override
     protected int getIndex() {
         return 1;
     }

--- a/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/SpringCloudClientInterceptor.java
+++ b/sermant-plugins/sermant-service-removal/removal-plugin/src/main/java/com/huaweicloud/sermant/interceptor/SpringCloudClientInterceptor.java
@@ -28,6 +28,11 @@ import com.netflix.client.ClientRequest;
  */
 public class SpringCloudClientInterceptor extends AbstractCallInterceptor<ClientRequest> {
     @Override
+    protected int getIndex() {
+        return 0;
+    }
+
+    @Override
     protected String getHost(ClientRequest request) {
         if (request.getUri() == null) {
             return StringUtils.EMPTY;

--- a/sermant-plugins/sermant-service-removal/removal-service/src/main/java/com/huaweicloud/sermant/event/RemovalEventDefinitions.java
+++ b/sermant-plugins/sermant-service-removal/removal-service/src/main/java/com/huaweicloud/sermant/event/RemovalEventDefinitions.java
@@ -37,6 +37,7 @@ public enum RemovalEventDefinitions {
      */
     INSTANCE_RECOVERY("INSTANCE_RECOVERY", EventType.GOVERNANCE, EventLevel.IMPORTANT, "removal",
             "The outlier instance is recovery and the instance information is: "),;
+
     /**
      * 事件名称
      */

--- a/sermant-plugins/sermant-service-removal/removal-service/src/main/java/com/huaweicloud/sermant/service/RemovalEventServiceImpl.java
+++ b/sermant-plugins/sermant-service-removal/removal-service/src/main/java/com/huaweicloud/sermant/service/RemovalEventServiceImpl.java
@@ -17,11 +17,9 @@
 package com.huaweicloud.sermant.service;
 
 import com.huaweicloud.sermant.common.RemovalConstants;
-import com.huaweicloud.sermant.config.RemovalConfig;
 import com.huaweicloud.sermant.core.event.Event;
 import com.huaweicloud.sermant.core.event.EventInfo;
 import com.huaweicloud.sermant.core.event.EventManager;
-import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
 import com.huaweicloud.sermant.entity.InstanceInfo;
 import com.huaweicloud.sermant.event.RemovalEventCollector;
 import com.huaweicloud.sermant.event.RemovalEventDefinitions;

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/config/LbConfig.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/config/LbConfig.java
@@ -19,7 +19,6 @@ package com.huawei.discovery.config;
 import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
 import com.huaweicloud.sermant.core.plugin.config.PluginConfig;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
@@ -83,7 +82,7 @@ public class LbConfig implements PluginConfig {
 
     /**
      * 是否开启缓存代理, 针对{@link java.net.HttpURLConnection} 拦截该类, 针对每个host将生成一个代理缓存到map中, 见{@link
-     * com.huawei.discovery.interceptors.httpconnection.HttpUrlConnectionConnectInterceptor#getProxy(URL)} 开启此开关,
+     * com.huawei.discovery.interceptors.httpconnection.HttpUrlConnectionConnectInterceptor} getProxy方法 开启此开关,
      * 增加内存消耗, 但可避免频繁创建Proxy
      */
     private boolean enableCacheProxy = false;

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventDefinition.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/event/SpringBootRegistryEventDefinition.java
@@ -66,6 +66,11 @@ public enum SpringBootRegistryEventDefinition {
         return eventLevel;
     }
 
+    /**
+     * 获取scope
+     *
+     * @return string 插件主模块名称
+     */
     public String getScope() {
         return "springboot-registry-plugin";
     }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/FeignInvokeInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/FeignInvokeInterceptor.java
@@ -71,6 +71,10 @@ public class FeignInvokeInterceptor extends MarkInterceptor {
         return context;
     }
 
+    @Override
+    protected void ready() {
+    }
+
     private Function<InvokerContext, Object> buildInvokerFunc(ExecuteContext context, Request request,
             Map<String, String> urlInfo) {
         return invokerContext -> {

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/HttpComponentsClientHttpConnectorInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/HttpComponentsClientHttpConnectorInterceptor.java
@@ -95,6 +95,10 @@ public class HttpComponentsClientHttpConnectorInterceptor extends MarkIntercepto
         return context;
     }
 
+    @Override
+    protected void ready() {
+    }
+
     private Object buildInvokerFunc(ExecuteContext context, InvokerContext invokerContext,
             AbstractClientHttpRequest request, Map<String, String> uriInfo) {
         String url = RequestInterceptorUtils.buildUrl(uriInfo, invokerContext.getServiceInstance());

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/JettyRequestInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/JettyRequestInterceptor.java
@@ -88,6 +88,10 @@ public class JettyRequestInterceptor extends MarkInterceptor {
         return context;
     }
 
+    @Override
+    protected void ready() {
+    }
+
     private Object buildInvokerFunc(ExecuteContext context, InvokerContext invokerContext, Request request,
             String path) {
         ServiceInstance instance = invokerContext.getServiceInstance();

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/MarkInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/MarkInterceptor.java
@@ -57,6 +57,5 @@ public abstract class MarkInterceptor implements Interceptor {
     /**
      * 调用前的准备
      */
-    protected void ready() {
-    }
+    protected abstract void ready();
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/MonoHttpConnectInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/MonoHttpConnectInterceptor.java
@@ -97,6 +97,10 @@ public class MonoHttpConnectInterceptor extends MarkInterceptor {
         return context;
     }
 
+    @Override
+    protected void ready() {
+    }
+
     private Object buildInvokerFunc(ExecuteContext context, InvokerContext invokerContext, Object config, String uri,
             Map<String, String> uriInfo) {
         context.setLocalFieldValue(ORIGIN_URI_FIELD_NAME, uri);

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttp3ClientInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttp3ClientInterceptor.java
@@ -80,8 +80,12 @@ public class OkHttp3ClientInterceptor extends MarkInterceptor {
                 buildInvokerFunc(uri, hostAndPath, request, rebuildRequest, context),
                 buildExFunc(rebuildRequest),
                 hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
-                .ifPresent(o -> setResultOrThrow(context, o, uri.getPath()));
+                .ifPresent(object -> setResultOrThrow(context, object, uri.getPath()));
         return context;
+    }
+
+    @Override
+    protected void ready() {
     }
 
     private void setResultOrThrow(ExecuteContext context, Object result, String url) {
@@ -141,6 +145,7 @@ public class OkHttp3ClientInterceptor extends MarkInterceptor {
     /**
      * 构建okHttp3响应
      *
+     * @param request 请求对象
      * @param ex 指定异常
      * @return 响应
      */

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttpClientInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/OkHttpClientInterceptor.java
@@ -82,8 +82,12 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
                         buildInvokerFunc(uri, hostAndPath, request, rebuildRequest, context),
                         buildExFunc(rebuildRequest),
                         hostAndPath.get(HttpConstants.HTTP_URI_SERVICE))
-                .ifPresent(o -> setResultOrThrow(context, o, uri.getPath()));
+                .ifPresent(object -> setResultOrThrow(context, object, uri.getPath()));
         return context;
+    }
+
+    @Override
+    protected void ready() {
     }
 
     private void setResultOrThrow(ExecuteContext context, Object result, String url) {
@@ -149,6 +153,7 @@ public class OkHttpClientInterceptor extends MarkInterceptor {
     /**
      * 构建okHttp响应
      *
+     * @param request 请求对象
      * @param ex 指定异常
      * @return 响应
      */

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/RestTemplateInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/RestTemplateInterceptor.java
@@ -76,6 +76,10 @@ public class RestTemplateInterceptor extends MarkInterceptor {
         return context;
     }
 
+    @Override
+    protected void ready() {
+    }
+
     private URI rebuildUri(String url, URI uri) {
         final Optional<URI> optionalUri = formatUri(url, uri);
         if (optionalUri.isPresent()) {

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpAsyncClient4xInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpAsyncClient4xInterceptor.java
@@ -178,7 +178,7 @@ public class HttpAsyncClient4xInterceptor implements Interceptor {
                         new Class[]{HttpAsyncRequestProducer.class, Function.class, Function.class},
                         new Object[]{producer, buildRequestDecorator(uriNew, method),
                                 buildHostDecorator(uriNew)});
-        return result.map(o -> (HttpAsyncRequestProducer) o).orElse(producer);
+        return result.map(object -> (HttpAsyncRequestProducer) object).orElse(producer);
     }
 
     private BiFunction<Long, TimeUnit, HttpAsyncInvokerResult> buildInvokerBiFunc(HttpAsyncContext asyncContext,
@@ -225,7 +225,7 @@ public class HttpAsyncClient4xInterceptor implements Interceptor {
             return;
         }
         FutureCallback<HttpResponse> cur = (FutureCallback<HttpResponse>) callback;
-        if (response instanceof Throwable) {
+        if (response instanceof Exception) {
             cur.failed((Exception) response);
         } else {
             cur.completed((HttpResponse) response);

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpclient/HttpClient4xInterceptor.java
@@ -150,7 +150,7 @@ public class HttpClient4xInterceptor extends MarkInterceptor {
                 }
             }
         } catch (IOException ex) {
-            // ignored
+            LOGGER.warning("An exception occurred when attempting to close the httpResponse.");
         }
     }
 

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpconnection/HttpUrlConnectionConnectInterceptor.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/interceptors/httpconnection/HttpUrlConnectionConnectInterceptor.java
@@ -92,18 +92,22 @@ public class HttpUrlConnectionConnectInterceptor extends MarkInterceptor {
         HttpConnectionUtils.save(new HttpConnectionContext(urlInfo, url));
         RequestInterceptorUtils.printRequestLog("HttpURLConnection", urlInfo);
         invokerService.invoke(
-            buildInvokerFunc(context, url, urlInfo),
-            ex -> ex,
-            urlInfo.get(HttpConstants.HTTP_URI_SERVICE))
-                .ifPresent(obj -> {
-                    if (obj instanceof Exception) {
-                        LOGGER.log(Level.SEVERE, "request is error, uri is " + fullUrl, (Exception) obj);
-                        context.setThrowableOut((Exception) obj);
-                        return;
-                    }
-                    context.skip(obj);
-                });
+                buildInvokerFunc(context, url, urlInfo),
+                ex -> ex,
+                urlInfo.get(HttpConstants.HTTP_URI_SERVICE))
+                    .ifPresent(obj -> {
+                        if (obj instanceof Exception) {
+                            LOGGER.log(Level.SEVERE, "request is error, uri is " + fullUrl, (Exception) obj);
+                            context.setThrowableOut((Exception) obj);
+                            return;
+                        }
+                        context.skip(obj);
+                    });
         return context;
+    }
+
+    @Override
+    protected void ready() {
     }
 
     private Optional<URL> getUrl(Object target) {
@@ -131,6 +135,9 @@ public class HttpUrlConnectionConnectInterceptor extends MarkInterceptor {
 
     /**
      * 针对指定代理的场景下, 需将代理的地址替换为实际下游地址, 否则将出现404
+     *
+     * @param newUrl 实际下游地址
+     * @param context 拦截器上下文
      */
     private void tryResetProxy(URL newUrl, ExecuteContext context) {
         final Optional<Object> instProxy = ReflectUtils.getFieldValue(context.getObject(), "instProxy");

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/retry/DefaultRetryImpl.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/retry/DefaultRetryImpl.java
@@ -103,7 +103,7 @@ public class DefaultRetryImpl implements Retry {
         }
 
         @Override
-        public void onError(Recorder serviceInstanceStats, Throwable ex, long consumeTimeMs) throws Exception {
+        public void onError(Recorder serviceInstanceStats, Throwable ex, long consumeTimeMs) throws RetryException {
             serviceInstanceStats.errorRequest(ex, consumeTimeMs);
             final Predicate<Throwable> throwablePredicate = config().getThrowablePredicate();
             if (throwablePredicate != null && throwablePredicate.test(ex)) {

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/retry/Retry.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/retry/Retry.java
@@ -88,9 +88,9 @@ public interface Retry {
          * @param serviceInstanceStats 选择调用的实例
          * @param ex 调用异常时调用
          * @param consumeTimeMs 调用的消耗时间
-         * @throws Exception 不满足异常重试条件时抛出异常
+         * @throws RetryException 不满足异常重试条件时抛出异常
          */
-        void onError(T serviceInstanceStats, Throwable ex, long consumeTimeMs) throws Exception;
+        void onError(T serviceInstanceStats, Throwable ex, long consumeTimeMs) throws RetryException;
 
         /**
          * 最终结束, 在重试彻底结束后调用该方法

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/utils/HttpConstants.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/utils/HttpConstants.java
@@ -16,8 +16,8 @@
 
 package com.huawei.discovery.utils;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * 参数标签类
@@ -79,7 +79,7 @@ public class HttpConstants {
     /**
      * 时间格式
      */
-    public static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     private HttpConstants() {
     }
@@ -90,6 +90,7 @@ public class HttpConstants {
      * @return 时间
      */
     public static String currentTime() {
-        return SIMPLE_DATE_FORMAT.format(new Date());
+        LocalDateTime now = LocalDateTime.now();
+        return now.format(DATE_TIME_FORMATTER);
     }
 }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/utils/PlugEffectWhiteBlackUtils.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/com/huawei/discovery/utils/PlugEffectWhiteBlackUtils.java
@@ -37,7 +37,7 @@ public class PlugEffectWhiteBlackUtils {
     /**
      * 域名列表
      */
-    private static String[] domainNames;
+    private static volatile String[] domainNames;
 
     private PlugEffectWhiteBlackUtils() {
     }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/interceptors/MarkInterceptorTest.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/test/java/com/huawei/discovery/interceptors/MarkInterceptorTest.java
@@ -39,6 +39,10 @@ public class MarkInterceptorTest {
             }
 
             @Override
+            protected void ready() {
+            }
+
+            @Override
             public ExecuteContext after(ExecuteContext context) {
                 return context;
             }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/lb/discovery/zk/ZkServiceManager.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/lb/discovery/zk/ZkServiceManager.java
@@ -37,7 +37,7 @@ public class ZkServiceManager {
 
     private final LbConfig lbConfig;
 
-    private ZkService zkService;
+    private volatile ZkService zkService;
 
     /**
      * 构造器

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/lb/discovery/zk/listen/ZkInstanceListenable.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/lb/discovery/zk/listen/ZkInstanceListenable.java
@@ -72,7 +72,7 @@ public class ZkInstanceListenable implements InstanceListenable {
 
     private final Predicate<ServiceInstance<ZookeeperInstance>> predicate;
 
-    private TreeCache childrenCache;
+    private volatile TreeCache childrenCache;
 
     /**
      * 构造器

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/lb/stats/InstanceStats.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/lb/stats/InstanceStats.java
@@ -86,6 +86,7 @@ public class InstanceStats implements Recorder {
     /**
      * 异常调用统计
      *
+     * @param consumeTimeMs 消费时间
      * @param ex 异常类型
      */
     @Override
@@ -96,6 +97,8 @@ public class InstanceStats implements Recorder {
 
     /**
      * 结果调用
+     *
+     * @param consumeTimeMs 消费时间
      */
     @Override
     public void afterRequest(long consumeTimeMs) {

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/registry/RegistryImpl.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/registry/RegistryImpl.java
@@ -52,7 +52,7 @@ public class RegistryImpl implements RegistryService {
         try {
             heartbeatService = ServiceManager.getService(HeartbeatService.class);
         } catch (IllegalArgumentException ex) {
-            // ignored 不存在心跳服务
+            LOGGER.warning("No heartbeat service found.");
         }
     }
 

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/retry/RetryServiceImpl.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/retry/RetryServiceImpl.java
@@ -87,13 +87,13 @@ public class RetryServiceImpl implements InvokerService {
 
     @Override
     public Optional<Object> invoke(Function<InvokerContext, Object> invokeFunc, Function<Throwable, Object> exFunc,
-                                   String serviceName) {
+            String serviceName) {
         return invoke(invokeFunc, exFunc, serviceName, getRetry(null));
     }
 
     @Override
     public Optional<Object> invoke(Function<InvokerContext, Object> invokeFunc, Function<Throwable, Object> exFunc,
-                                   String serviceName, RetryConfig retryConfig) {
+            String serviceName, RetryConfig retryConfig) {
         return invoke(invokeFunc, exFunc, serviceName, getRetry(retryConfig));
     }
 

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/util/ApplyUtil.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/src/main/java/com/huawei/discovery/service/util/ApplyUtil.java
@@ -71,7 +71,7 @@ public class ApplyUtil {
      * @throws Exception 调用异常信息
      */
     public static Optional<Object> invokeWithEx(Function<InvokerContext, Object> invokeFunc, String serviceName,
-             Retry retry, InvokerContext invokerContext, RetryPolicy retryPolicy) throws Exception {
+            Retry retry, InvokerContext invokerContext, RetryPolicy retryPolicy) throws Exception {
         final Retry.RetryContext<Recorder> context = retry.context();
         final PolicyContext policyContext = new PolicyContext();
         boolean isInRetry = false;
@@ -102,7 +102,7 @@ public class ApplyUtil {
                     context.onComplete(stats);
                     return Optional.ofNullable(result);
                 }
-            } catch (Exception ex) {
+            } catch (RetryException ex) {
                 handleEx(ex, context, stats, System.currentTimeMillis() - start);
             }
         } while (true);
@@ -115,12 +115,12 @@ public class ApplyUtil {
      * @param context 上下文信息
      * @param stats 实例指标数据
      * @param consumeTimeMs 调用事件
-     * @throws Exception 服务调用异常信息
+     * @throws RetryException 服务调用异常信息
      */
     private static void handleEx(Exception ex, Retry.RetryContext<Recorder> context, InstanceStats stats,
-                                 long consumeTimeMs) throws Exception {
+            long consumeTimeMs) throws RetryException {
         if (ex instanceof RetryException) {
-            throw ex;
+            throw (RetryException) ex;
         }
         context.onError(stats, ex, consumeTimeMs);
     }


### PR DESCRIPTION
【Fix issue】#1365

[Modification content] Modified the codecheck problem in the existing code, which is mainly summarized into the following categories;
| plugin | codecheck |
| --- | --- |
| service-registry | Javadoc issues |
| service-registry | Type judgment is required before the variable type is forced to be transferred |
| service-registry | Variable names must conform to regular expressions |
| service-registry | The subclass inherits the interface that the parent class has inherited, and duplicate interfaces need to be deleted |
| service-registry | Remove unused references |
| service-registry | Space indentation |
| service-registry | Exception code block cannot be empty |
| service-registry | Avoid reusing names between unrelated variables or unrelated concepts |
| service-registry | Remove unused variables |
| service-removal | Empty methods of abstract classes should be abstract methods |
| service-removal | There should be blank lines or spaces between comments and code, and there should be spaces between comment characters and comment content |
| service-removal | Remove unused references |
| springboot-registry | Remove unused references |
| springboot-registry | Double check lock acquisition singleton should add volatile to the singleton |
| springboot-registry | Javadoc issues |
| springboot-registry | Variable names must conform to regular expressions |
| springboot-registry | Double check lock acquisition singleton should add volatile to the singleton |
| springboot-registry | The exception code block cannot be empty |
| springboot-registry | Type judgment is required before the variable type is forced to be transferred |
| springboot-registry | Space indentation |
| springboot-registry | When the time formatting class is used as a static variable, a thread-safe class must be used |
[Use case description] Not required

[Self-test situation] 1. Local static check passed

[Scope of influence] None