### PR TITLE
Codecheck bug fix

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/ClassLoaderManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/classloader/ClassLoaderManager.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.core.classloader;
 
 import com.huaweicloud.sermant.core.common.CommonConstant;
+import com.huaweicloud.sermant.core.exception.FileCheckException;
 import com.huaweicloud.sermant.core.plugin.classloader.PluginClassFinder;
 import com.huaweicloud.sermant.core.plugin.classloader.PluginClassLoader;
 import com.huaweicloud.sermant.core.utils.FileUtils;
@@ -25,6 +26,8 @@ import com.huaweicloud.sermant.god.common.SermantClassLoader;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +79,12 @@ public class ClassLoaderManager {
      * @return PluginClassLoader
      */
     public static PluginClassLoader createPluginClassLoader() {
-        return new PluginClassLoader(new URL[0], sermantClassLoader);
+        return AccessController.doPrivileged(new PrivilegedAction<PluginClassLoader>() {
+            @Override
+            public PluginClassLoader run() {
+                return new PluginClassLoader(new URL[0], sermantClassLoader);
+            }
+        });
     }
 
     public static SermantClassLoader getSermantClassLoader() {
@@ -99,11 +107,11 @@ public class ClassLoaderManager {
     private static URL[] listCoreImplementUrls(String coreImplementPath) throws MalformedURLException {
         File coreImplementDir = new File(FileUtils.validatePath(coreImplementPath));
         if (!coreImplementDir.exists() || !coreImplementDir.isDirectory()) {
-            throw new RuntimeException("core implement directory is not exist or is not directory.");
+            throw new FileCheckException("core implement directory is not exist or is not directory.");
         }
         File[] jars = coreImplementDir.listFiles((file, name) -> name.endsWith(".jar"));
         if (jars == null || jars.length == 0) {
-            throw new RuntimeException("core implement directory is empty");
+            throw new FileCheckException("core implement directory is empty");
         }
         List<URL> urlList = new ArrayList<>();
         for (File jar : jars) {
@@ -115,11 +123,11 @@ public class ClassLoaderManager {
     private static URL[] listCommonLibUrls(String commonLibPath) throws MalformedURLException {
         File commonLibDir = new File(FileUtils.validatePath(commonLibPath));
         if (!commonLibDir.exists() || !commonLibDir.isDirectory()) {
-            throw new RuntimeException("common lib is not exist or is not directory.");
+            throw new FileCheckException("common lib is not exist or is not directory.");
         }
         File[] jars = commonLibDir.listFiles((file, name) -> name.endsWith(".jar"));
         if (jars == null || jars.length == 0) {
-            throw new RuntimeException("common lib directory is empty");
+            throw new FileCheckException("common lib directory is empty");
         }
         List<URL> urlList = new ArrayList<>();
         for (File jar : jars) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
@@ -18,6 +18,7 @@ package com.huaweicloud.sermant.core.common;
 
 import com.huaweicloud.sermant.core.classloader.ClassLoaderManager;
 import com.huaweicloud.sermant.core.classloader.FrameworkClassLoader;
+import com.huaweicloud.sermant.core.exception.LoggerInitException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -35,9 +36,9 @@ public class LoggerFactory {
 
     private static final String LOGGER_INIT_METHOD = "init";
 
-    private static Logger defaultLogger;
+    private static volatile Logger defaultLogger;
 
-    private static Logger sermantLogger;
+    private static volatile Logger sermantLogger;
 
     private LoggerFactory() {
     }
@@ -46,19 +47,23 @@ public class LoggerFactory {
      * 初始化logback配置文件路径
      *
      * @param artifact 归属产品
-     * @throws RuntimeException RuntimeException
+     * @throws LoggerInitException LoggerInitException
      */
     public static void init(String artifact) {
         if (sermantLogger == null) {
-            FrameworkClassLoader frameworkClassLoader = ClassLoaderManager.getFrameworkClassLoader();
-            try {
-                Method initMethod = frameworkClassLoader
-                        .loadClass(LOGGER_FACTORY_IMPL_CLASS)
-                        .getMethod(LOGGER_INIT_METHOD, String.class);
-                sermantLogger = (Logger) initMethod.invoke(null, artifact);
-            } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-                     | InvocationTargetException e) {
-                throw new RuntimeException(e);
+            synchronized (LoggerFactory.class) {
+                if (sermantLogger == null) {
+                    FrameworkClassLoader frameworkClassLoader = ClassLoaderManager.getFrameworkClassLoader();
+                    try {
+                        Method initMethod = frameworkClassLoader
+                                .loadClass(LOGGER_FACTORY_IMPL_CLASS)
+                                .getMethod(LOGGER_INIT_METHOD, String.class);
+                        sermantLogger = (Logger) initMethod.invoke(null, artifact);
+                    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+                             | InvocationTargetException e) {
+                        throw new LoggerInitException(e.getMessage());
+                    }
+                }
             }
         }
     }
@@ -75,7 +80,11 @@ public class LoggerFactory {
 
         // 避免日志重复获取
         if (defaultLogger == null) {
-            defaultLogger = java.util.logging.Logger.getLogger("sermant");
+            synchronized (LoggerFactory.class) {
+                if (defaultLogger == null) {
+                    defaultLogger = java.util.logging.Logger.getLogger("sermant");
+                }
+            }
         }
         return defaultLogger;
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/ConfigManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/ConfigManager.java
@@ -205,6 +205,7 @@ public abstract class ConfigManager {
      * <p>文件中声明的所有实现都将会进行遍历，每一个实现类都会通过spi获取实例，然后调用{@code configConsumer}进行消费
      *
      * @param configConsumer 配置处理方法
+     * @param classLoader 类加载器
      */
     private static void foreachConfig(ConfigConsumer configConsumer,
             ClassLoader classLoader) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/common/ConfigFieldKey.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/common/ConfigFieldKey.java
@@ -16,8 +16,6 @@
 
 package com.huaweicloud.sermant.core.config.common;
 
-import com.huaweicloud.sermant.core.config.utils.ConfigKeyUtil;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -25,9 +23,9 @@ import java.lang.annotation.Target;
 
 /**
  * 通用字段键注解
- * <p>用于修饰配置对象的属性，与{@link ConfigTypeKey}一并构建配置信息键
+ * <p>用于修饰配置对象的属性，与ConfigTypeKey一并构建配置信息键
  * <p>主要作用是修正成员属性和配置键之间的差异
- * <p>见{@link ConfigKeyUtil#getFieldKey(java.lang.reflect.Field)}
+ * <p>见ConfigKeyUtil#getFieldKey(java.lang.reflect.Field)
  *
  * @author HapThorin
  * @version 1.0.0
@@ -36,5 +34,10 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})
 public @interface ConfigFieldKey {
+    /**
+     * 属性名
+     *
+     * @return 属性名
+     */
     String value();
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/common/ConfigTypeKey.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/common/ConfigTypeKey.java
@@ -16,8 +16,6 @@
 
 package com.huaweicloud.sermant.core.config.common;
 
-import com.huaweicloud.sermant.core.config.utils.ConfigKeyUtil;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -27,7 +25,7 @@ import java.lang.annotation.Target;
  * 通用配置对象前缀
  * <p>如果配置对象中的所有属性对应的配置键都包含相同的前缀，那么可以使用该注解声明
  * <p>与{@link ConfigFieldKey}一同构建配置键，{@link ConfigFieldKey}不存在时，直接使用属性名
- * <p>见{@link ConfigKeyUtil#getTypeKey(Class)}
+ * <p>见ConfigKeyUtil#getTypeKey(Class)
  *
  * @author HapThorin
  * @version 1.0.0
@@ -36,5 +34,10 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface ConfigTypeKey {
+    /**
+     * 类型名
+     *
+     * @return 类型名
+     */
     String value();
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigFieldUtil.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigFieldUtil.java
@@ -40,10 +40,33 @@ public class ConfigFieldUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger();
 
     /**
+     * boolean类型的get或set方法中属性名的最短长度
+     */
+    private static final int FIELD_NAME_MIN_LENGTH = 3;
+
+    /**
+     * boolean类型的get或set方法中属性名的首字母下标
+     */
+    private static final int FIELD_NAME_CHECK_INDEX = 2;
+
+    /**
+     * boolean类型的get方法前缀，首字母小写字母
+     */
+    private static final String BOOLEAN_FUNCTION_PREFIX_LOWERCASE = "is";
+
+    /**
+     * boolean类型的get方法前缀，首字母大写字母
+     */
+    private static final String BOOLEAN_FUNCTION_PREFIX_UPPERCASE = "Is";
+
+    private ConfigFieldUtil() {
+    }
+
+    /**
      * 设置值，优先查找{@code setter}调用，不存在时尝试直接赋值
      * <p>因此，要求配置对象的属性值需要拥有相应的{@code setter}，或者要求改属性值是公有的
      *
-     * @param obj   被设置值的对象
+     * @param obj 被设置值的对象
      * @param field 被设置的字段
      * @param value 被设置的字段值
      */
@@ -69,17 +92,16 @@ public class ConfigFieldUtil {
     /**
      * 通过属性名称获取{@code setter}
      *
-     * @param cls       配置对象类
+     * @param cls 配置对象类
      * @param fieldName 属性名称
-     * @param type      属性类型
+     * @param type 属性类型
      * @return setter方法
      */
     private static Method getSetter(Class<?> cls, String fieldName, Class<?> type) {
         final String setterName;
-        if ((type == boolean.class || type == Boolean.class) &&
-                fieldName.length() >= 3 && (fieldName.startsWith("is") || fieldName.startsWith("Is")) &&
-                fieldName.charAt(2) >= 'A' && fieldName.charAt(2) <= 'Z') {
-            setterName = "set" + fieldName.substring(2);
+        if ((type == boolean.class || type == Boolean.class) && fieldName.length() >= FIELD_NAME_MIN_LENGTH
+                && checkFieldName(fieldName)) {
+            setterName = "set" + fieldName.substring(FIELD_NAME_CHECK_INDEX);
         } else {
             final char head = fieldName.charAt(0);
             setterName = "set" + (
@@ -109,6 +131,13 @@ public class ConfigFieldUtil {
         }
     }
 
+    /**
+     * 获取属性对象
+     *
+     * @param obj 目标对象
+     * @param field 属性
+     * @return 属性对象
+     */
     public static Object getField(Object obj, Field field) {
         try {
             final Method getter = getGetter(field.getDeclaringClass(), field.getName(), field.getType());
@@ -130,10 +159,9 @@ public class ConfigFieldUtil {
 
     private static Method getGetter(Class<?> cls, String fieldName, Class<?> type) {
         final String getterName;
-        if ((type == boolean.class || type == Boolean.class) &&
-                fieldName.length() >= 3 && (fieldName.startsWith("is") || fieldName.startsWith("Is")) &&
-                fieldName.charAt(2) >= 'A' && fieldName.charAt(2) <= 'Z') {
-            getterName = "is" + fieldName.substring(2);
+        if ((type == boolean.class || type == Boolean.class) && fieldName.length() >= FIELD_NAME_MIN_LENGTH
+                && checkFieldName(fieldName)) {
+            getterName = BOOLEAN_FUNCTION_PREFIX_LOWERCASE + fieldName.substring(FIELD_NAME_CHECK_INDEX);
         } else {
             final char head = fieldName.charAt(0);
             getterName = "get" + (
@@ -167,5 +195,12 @@ public class ConfigFieldUtil {
 
     private static boolean checkMethod(Method method, Field field) {
         return method != null && Modifier.isStatic(method.getModifiers()) == Modifier.isStatic(field.getModifiers());
+    }
+
+    private static boolean checkFieldName(String fieldName) {
+        return (fieldName.startsWith(BOOLEAN_FUNCTION_PREFIX_LOWERCASE) || fieldName.startsWith(
+                BOOLEAN_FUNCTION_PREFIX_UPPERCASE))
+                && fieldName.charAt(FIELD_NAME_CHECK_INDEX) >= 'A'
+                && fieldName.charAt(FIELD_NAME_CHECK_INDEX) <= 'Z';
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/utils/ConfigValueUtil.java
@@ -92,7 +92,7 @@ public class ConfigValueUtil {
             key -> key.toUpperCase(Locale.ROOT).replace('.', '-'),
             key -> key.toLowerCase(Locale.ROOT),
             key -> key.toLowerCase(Locale.ROOT).replace('.', '_'),
-            key -> key.toLowerCase(Locale.ROOT).replace('.', '-'),
+            key -> key.toLowerCase(Locale.ROOT).replace('.', '-')
     };
 
     /**
@@ -326,6 +326,7 @@ public class ConfigValueUtil {
      * @param key 键
      * @param defaultVal 默认值
      * @param provider 配置信息
+     * @param argsMap 参数Map
      * @return 环境变量或系统变量
      */
     private static String getFormatKeyFixVal(String key, String defaultVal, Map<String, Object> argsMap,
@@ -347,17 +348,18 @@ public class ConfigValueUtil {
      *
      * @param key 键
      * @param configVal 配置值
+     * @param argsMap 参数Map
      * @return 最终配置参考值
      */
     private static String getValByFixedKey(String key, String configVal, Map<String, Object> argsMap) {
-        // 1. xxx.xxx.appName直接获取 2. xxx.xxx.app-name处理为xxx.xxx.app.name再获取
+        // appName直接获取、app-name处理为app.name再获取
         String keyReplaceMiddleLine = transFromMiddleLine(key);
         Optional<String> fixedValue = getValueByOrder(argsMap, keyReplaceMiddleLine);
         if (fixedValue.isPresent()) {
             return fixedValue.get();
         }
 
-        // 3. xxx.xxx.appName分割为xxx.xxx.app.name
+        // appName分割为app.name
         String keyWithoutCamel = transFromCamel(keyReplaceMiddleLine);
         if (!keyReplaceMiddleLine.equals(keyWithoutCamel)) {
             fixedValue = getValueByOrder(argsMap, keyWithoutCamel);

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/event/collector/FrameworkEventDefinitions.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/event/collector/FrameworkEventDefinitions.java
@@ -88,6 +88,11 @@ public enum FrameworkEventDefinitions {
         return eventLevel;
     }
 
+    /**
+     * 获取范围
+     *
+     * @return framework
+     */
     public String getScope() {
         return "framework";
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/FileCheckException.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/FileCheckException.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.backend.webhook.dingding;
-
-import com.huaweicloud.sermant.backend.webhook.WebHookConfig;
-import com.huaweicloud.sermant.backend.webhook.WebhookConfigImpl;
+package com.huaweicloud.sermant.core.exception;
 
 /**
- * 钉钉webhook 配置
+ * 文件检查异常
  *
- * @author xuezechao
- * @since 2023-03-02
+ * @author tangle
+ * @since 2023-11-07
  */
-public class DingDingHookConfig extends WebhookConfigImpl {
-    private static final WebHookConfig CONFIG = new WebhookConfigImpl();
-
-    private DingDingHookConfig() {
-    }
+public class FileCheckException extends RuntimeException {
+    private static final long serialVersionUID = 1339575470808108623L;
 
     /**
-     * 获取webhook配置单例
+     * 文件检查异常
      *
-     * @return webhook配置单例
+     * @param message 异常信息
      */
-    public static WebHookConfig getInstance() {
-        return CONFIG;
+    public FileCheckException(String message) {
+        super(message);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/LoggerInitException.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/LoggerInitException.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.backend.webhook.dingding;
-
-import com.huaweicloud.sermant.backend.webhook.WebHookConfig;
-import com.huaweicloud.sermant.backend.webhook.WebhookConfigImpl;
+package com.huaweicloud.sermant.core.exception;
 
 /**
- * 钉钉webhook 配置
+ * 日志初始化异常
  *
- * @author xuezechao
- * @since 2023-03-02
+ * @author tangle
+ * @since 2023-11-08
  */
-public class DingDingHookConfig extends WebhookConfigImpl {
-    private static final WebHookConfig CONFIG = new WebhookConfigImpl();
-
-    private DingDingHookConfig() {
-    }
+public class LoggerInitException extends RuntimeException {
+    private static final long serialVersionUID = 4472931852795263687L;
 
     /**
-     * 获取webhook配置单例
+     * 日志初始化异常
      *
-     * @return webhook配置单例
+     * @param message 异常信息
      */
-    public static WebHookConfig getInstance() {
-        return CONFIG;
+    public LoggerInitException(String message) {
+        super(message);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/NetInterfacesCheckException.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/NetInterfacesCheckException.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.backend.webhook.dingding;
-
-import com.huaweicloud.sermant.backend.webhook.WebHookConfig;
-import com.huaweicloud.sermant.backend.webhook.WebhookConfigImpl;
+package com.huaweicloud.sermant.core.exception;
 
 /**
- * 閽夐拤webhook 閰嶇疆
+ * 网络接口检查异常
  *
- * @author xuezechao
- * @since 2023-03-02
+ * @author tangle
+ * @since 2023-11-21
  */
-public class DingDingHookConfig extends WebhookConfigImpl {
-    private static final WebHookConfig CONFIG = new WebhookConfigImpl();
-
-    private DingDingHookConfig() {
-    }
+public class NetInterfacesCheckException extends RuntimeException {
+    private static final long serialVersionUID = -5485122231044249395L;
 
     /**
-     * 鑾峰彇webhook閰嶇疆鍗曚緥
+     * 网络接口检查异常
      *
-     * @return webhook閰嶇疆鍗曚緥
+     * @param message 异常信息
      */
-    public static WebHookConfig getInstance() {
-        return CONFIG;
+    public NetInterfacesCheckException(String message) {
+        super(message);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/notification/NotificationManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/notification/NotificationManager.java
@@ -50,12 +50,12 @@ public class NotificationManager {
      * @param typeClass 通知类型
      */
     public static void registry(NotificationListener notificationListener,
-                                Class<? extends NotificationType> typeClass) {
+            Class<? extends NotificationType> typeClass) {
         if (!isEnable()) {
             return;
         }
         List<NotificationListener> listenerList = NOTIFICATION_LISTENER_MAP.computeIfAbsent(
-                typeClass.getCanonicalName(), s -> new ArrayList<>());
+                typeClass.getCanonicalName(), key -> new ArrayList<>());
         listenerList.add(notificationListener);
     }
 
@@ -66,7 +66,7 @@ public class NotificationManager {
      * @param typeClass 通知类型
      */
     public static void unRegistry(NotificationListener notificationListener,
-                                  Class<? extends NotificationType> typeClass) {
+            Class<? extends NotificationType> typeClass) {
         if (!isEnable()) {
             return;
         }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/annotations/BeanPropertyFlag.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/annotations/BeanPropertyFlag.java
@@ -16,8 +16,6 @@
 
 package com.huaweicloud.sermant.core.plugin.agent.annotations;
 
-import com.huaweicloud.sermant.core.plugin.agent.declarer.SuperTypeDeclarer;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
@@ -26,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Java Bean标记，被该注解修饰的接口，将根据该注解定义的属性在被增强类中实现get、set方法
- * <p>见{@link SuperTypeDeclarer.ForBeanProperty}
+ * <p>见SuperTypeDeclarer.ForBeanProperty
  *
  * @author HapThorin
  * @version 1.0.0

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/collector/PluginCollector.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/collector/PluginCollector.java
@@ -74,6 +74,7 @@ public class PluginCollector {
     /**
      * 从插件收集器中获取所有插件描述器
      *
+     * @param classLoader 类加载器
      * @return 插件描述器集
      */
     private static List<? extends PluginDescription> getDescriptions(ClassLoader classLoader) {
@@ -99,7 +100,7 @@ public class PluginCollector {
             if (classMatcher instanceof ClassTypeMatcher) {
                 for (String typeName : ((ClassTypeMatcher) classMatcher).getTypeNames()) {
                     List<PluginDeclarer> nameCombinedList = nameCombinedMap.computeIfAbsent(typeName,
-                            k -> new ArrayList<>());
+                            key -> new ArrayList<>());
                     nameCombinedList.add(pluginDeclarer);
                 }
             } else {
@@ -126,7 +127,7 @@ public class PluginCollector {
                 for (PluginDeclarer declarer : combinedList) {
                     if (matchTarget(declarer.getClassMatcher(), target)) {
                         List<PluginDeclarer> declarers = nameCombinedMap.computeIfAbsent(typeName,
-                                k -> new ArrayList<>());
+                                key -> new ArrayList<>());
                         if (!declarers.contains(declarer)) {
                             declarers.add(declarer);
                         }
@@ -140,6 +141,7 @@ public class PluginCollector {
     /**
      * 从插件收集器中获取所有插件声明器
      *
+     * @param classLoader 类加载器
      * @return 插件声明器集
      */
     private static List<? extends PluginDeclarer> getDeclarers(ClassLoader classLoader) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/declarer/InterceptDeclarer.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/declarer/InterceptDeclarer.java
@@ -71,6 +71,7 @@ public abstract class InterceptDeclarer {
      * @param interceptors 拦截器集
      * @return 拦截声明器
      * @throws IllegalArgumentException IllegalArgumentException
+     * @deprecated 已过时
      */
     @Deprecated
     public static InterceptDeclarer build(MethodMatcher methodMatcher, String... interceptors) {
@@ -104,6 +105,7 @@ public abstract class InterceptDeclarer {
      * @throws ClassNotFoundException 找不到类
      * @throws IllegalAccessException 无法访问addURL方法或defineClass方法
      * @throws InstantiationException 实例化失败
+     * @deprecated 已过时
      */
     @Deprecated
     private static Interceptor[] createInterceptors(String[] interceptors)

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/matcher/ClassMatcher.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/matcher/ClassMatcher.java
@@ -234,7 +234,7 @@ public abstract class ClassMatcher implements ElementMatcher<TypeDescription> {
      * 超类检查
      *
      * @param typeDescription 类型描述
-     * @param superTypeNames  超类名称集
+     * @param superTypeNames 超类名称集
      * @return 检查是否通过
      */
     private static boolean superTypeCheck(TypeDescription typeDescription, Collection<String> superTypeNames) {
@@ -245,8 +245,8 @@ public abstract class ClassMatcher implements ElementMatcher<TypeDescription> {
         final Queue<TypeDefinition> queue = new LinkedList<TypeDefinition>();
         queue.add(typeDescription);
         for (TypeDefinition current = queue.poll();
-             current != null && !superTypeNameSet.isEmpty();
-             current = queue.poll()) {
+                current != null && !superTypeNameSet.isEmpty();
+                current = queue.poll()) {
             superTypeNameSet.remove(current.getActualName());
             final TypeList.Generic interfaces = current.getInterfaces();
             if (!interfaces.isEmpty()) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/transformer/AbstractTransformer.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/transformer/AbstractTransformer.java
@@ -161,6 +161,7 @@ public abstract class AbstractTransformer implements AgentBuilder.Transformer {
      * @param methodDesc 方法定义
      * @param interceptors 拦截器列表
      * @param templateCls 增强模板类
+     * @param classLoader 类加载器
      * @return 构建器
      * @throws InvocationTargetException 调用方法错误
      * @throws IllegalAccessException 无法访问属性或方法，正常不会报出

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/transformer/ReentrantTransformer.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/agent/transformer/ReentrantTransformer.java
@@ -61,9 +61,9 @@ public class ReentrantTransformer extends AbstractTransformer {
             throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, NoSuchFieldException {
         final String adviceKey = getAdviceKey(templateCls, classLoader, methodDesc);
         List<Interceptor> interceptorsForAdviceKey = BaseAdviseHandler.getInterceptorListMap()
-                .computeIfAbsent(adviceKey, k -> new ArrayList<>());
+                .computeIfAbsent(adviceKey, key -> new ArrayList<>());
         Set<String> createdInterceptorForAdviceKey = plugin.getInterceptors()
-                .computeIfAbsent(adviceKey, k -> new HashSet<>());
+                .computeIfAbsent(adviceKey, key -> new HashSet<>());
         for (Interceptor interceptor : interceptors) {
             // 需要先校验该Interceptor是否被创建过
             if (checkInterceptor(adviceKey, interceptor.getClass().getCanonicalName())) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassFinder.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassFinder.java
@@ -16,12 +16,15 @@
 
 package com.huaweicloud.sermant.core.plugin.classloader;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.Plugin;
 
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * 用于适配从多个PluginClassLoader中寻找对应类和资源
@@ -30,6 +33,11 @@ import java.util.Optional;
  * @since 2023-05-30
  */
 public class PluginClassFinder {
+    /**
+     * 日志
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
     private final Map<String, PluginClassLoader> pluginClassLoaderMap = new HashMap<>();
 
     /**
@@ -64,8 +72,8 @@ public class PluginClassFinder {
                 if (clazz != null) {
                     return clazz;
                 }
-            } catch (ClassNotFoundException ignore) {
-                // ignore
+            } catch (ClassNotFoundException e) {
+                LOGGER.log(Level.WARNING, "load sermant class failed, msg is {0}", e.getMessage());
             }
         }
         throw new ClassNotFoundException("Can not load class in pluginClassLoaders: " + name);

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
@@ -16,6 +16,7 @@
 
 package com.huaweicloud.sermant.core.plugin.classloader;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.plugin.agent.config.AgentConfig;
 
@@ -23,6 +24,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * 加载插件主模块的类加载器
@@ -31,6 +34,11 @@ import java.util.Map;
  * @since 2023-04-27
  */
 public class PluginClassLoader extends URLClassLoader {
+    /**
+     * 日志
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
     private final HashMap<Long, ClassLoader> localLoader = new HashMap<>();
 
     /**
@@ -94,9 +102,10 @@ public class PluginClassLoader extends URLClassLoader {
             if (clazz == null) {
                 try {
                     clazz = super.loadClass(name, resolve);
-                } catch (ClassNotFoundException ignored) {
+                } catch (ClassNotFoundException e) {
                     // 捕获类找不到的异常，下一步会进入localLoader中去加载类
                     // ignored
+                    LOGGER.log(Level.WARNING, "load class failed, msg is {0}", e.getMessage());
                 }
             }
 
@@ -114,6 +123,7 @@ public class PluginClassLoader extends URLClassLoader {
                         clazz = loader.loadClass(name);
                     } catch (ClassNotFoundException e) {
                         // 无法找到类，忽略，后续抛出异常
+                        LOGGER.log(Level.WARNING, "load class failed, msg is {0}", e.getMessage());
                     }
                 }
             }
@@ -145,8 +155,9 @@ public class PluginClassLoader extends URLClassLoader {
             if (clazz == null) {
                 try {
                     clazz = super.loadClass(name, false);
-                } catch (ClassNotFoundException ignored) {
+                } catch (ClassNotFoundException e) {
                     // 无法找到类，忽略，后续抛出异常
+                    LOGGER.log(Level.WARNING, "load sermant class failed, msg is {0}", e.getMessage());
                 }
             }
 

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/processor/ConfigDataHolder.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/processor/ConfigDataHolder.java
@@ -58,6 +58,16 @@ public class ConfigDataHolder implements Comparable<ConfigDataHolder> {
         return Integer.compare(target.order, this.order);
     }
 
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
     public String getGroup() {
         return group;
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/processor/OrderConfigEvent.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/processor/OrderConfigEvent.java
@@ -36,14 +36,14 @@ public class OrderConfigEvent extends DynamicConfigEvent {
     /**
      * 构造器
      *
-     * @param key       配置键
-     * @param group     组
-     * @param content   配置内容
+     * @param key 配置键
+     * @param group 组
+     * @param content 配置内容
      * @param eventType 事件类型
-     * @param allData   所有数据
+     * @param allData 所有数据
      */
     public OrderConfigEvent(String key, String group, String content, DynamicConfigEventType eventType, Map<String,
-        Object> allData) {
+            Object> allData) {
         super(key, group, content, eventType);
         this.allData = allData;
     }
@@ -55,5 +55,20 @@ public class OrderConfigEvent extends DynamicConfigEvent {
      */
     public Map<String, Object> getAllData() {
         return this.allData;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    @Override
+    public boolean equals(Object target) {
+        return super.equals(target);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/BaseService.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/BaseService.java
@@ -1,41 +1,37 @@
 /*
- * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (C) 2022-2022 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.huaweicloud.sermant.core.service;
 
-import com.huaweicloud.sermant.core.utils.SpiLoadUtils;
-
 /**
  * Agent服务接口
  * <p>
- * 实现{@link BaseService}的服务实例会在agent启动时被创建，
- * 并在创建完成之后，依次调用的它们的{@link #start()}方法，
+ * 实现{@link BaseService}的服务实例会在agent启动时被创建， 并在创建完成之后，依次调用的它们的{@link #start()}方法，
  * 同时为他们创建钩子，用于在JVM结束时调用服务是{@link #stop()}方法
  * <p>
  * 所有{@link BaseService}实例将由{@link ServiceManager}管理，
  * 可通过{@link ServiceManager#getService(Class)}方法传入{@link BaseService}子类获取服务实例。
- * {@link ServiceManager}将根据传入的{@link BaseService}类型，返回最佳的实现类。
- * 可以通过{@link SpiLoadUtils.SpiWeight}注解设置多实现类的权重。
+ * {@link ServiceManager}将根据传入的{@link BaseService}类型，返回最佳的实现类。 可以通过SpiLoadUtils.SpiWeight注解设置多实现类的权重。
  *
  * @author justforstudy-A, beetle-man, HapThorin
  * @version 1.0.0
  * @since 2022-01-21
  */
 public interface BaseService {
-
     /**
      * 服务启动方法
      */

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/ServiceManager.java
@@ -181,11 +181,11 @@ public class ServiceManager {
     private static void addStopHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             offerEvent();
-            for (String serviceName : SERVICES.keySet()) {
+            for (Map.Entry<String, BaseService> entry : SERVICES.entrySet()) {
                 try {
-                    SERVICES.get(serviceName).stop();
+                    entry.getValue().stop();
                 } catch (Exception ex) {
-                    LOGGER.log(Level.SEVERE, "Error occurs while stopping service: " + serviceName, ex);
+                    LOGGER.log(Level.SEVERE, "Error occurs while stopping service: " + entry.getKey(), ex);
                 }
             }
         }));

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/common/DynamicConfigServiceType.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/dynamicconfig/common/DynamicConfigServiceType.java
@@ -16,16 +16,13 @@
 
 package com.huaweicloud.sermant.core.service.dynamicconfig.common;
 
-
 /**
+ * Enum for DynamicConfigType, Currently support ZooKeeper, Kie, Nop. Probably will support Nacos, etcd in the future.
  *
- * Enum for DynamicConfigType,
- * Currently support ZooKeeper, Kie, Nop.
- * Probably will support Nacos, etcd in the future.
- *
+ * @author yangyshdan, HapThorin
+ * @since 2021-12-27
  */
 public enum DynamicConfigServiceType {
-
     /**
      * zookeeper 配置中心
      */
@@ -40,9 +37,9 @@ public enum DynamicConfigServiceType {
      * Nacos 配置中心
      */
     NACOS,
+
     /**
      * 配置中心无实现
      */
     NOP;
-
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/heartbeat/common/HeartbeatMessage.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/heartbeat/common/HeartbeatMessage.java
@@ -52,7 +52,7 @@ public class HeartbeatMessage {
      * 构造函数
      */
     public HeartbeatMessage() {
-        this.hostName = NetworkUtils.getHostName();
+        this.hostName = NetworkUtils.getHostName().orElse(null);
         this.ip = NetworkUtils.getAllNetworkIp();
         this.service = BootArgsIndexer.getServiceName();
         this.appType = BootArgsIndexer.getAppType();
@@ -68,7 +68,7 @@ public class HeartbeatMessage {
     public void updateHeartbeatVersion() {
         this.lastHeartbeatTime = this.heartbeatTime;
         this.heartbeatTime = System.currentTimeMillis();
-        this.hostName = NetworkUtils.getHostName();
+        this.hostName = NetworkUtils.getHostName().orElse(null);
         this.ip = NetworkUtils.getAllNetworkIp();
     }
 

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/tracing/common/TracingRequest.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/service/tracing/common/TracingRequest.java
@@ -46,7 +46,7 @@ public class TracingRequest {
     /**
      * 构造函数
      *
-     * @param  traceId traceId
+     * @param traceId traceId
      * @param parentSpanId parentSpanId
      * @param spanIdPrefix spanIdPrefix
      * @param className className

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/LabelGroupUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/LabelGroupUtils.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -84,7 +85,7 @@ public class LabelGroupUtils {
             String value = labels.get(key);
             if (key == null || value == null) {
                 LOGGER.warning(String.format(Locale.ENGLISH, "Invalid group label, key = %s, value = %s",
-                    key, value));
+                        key, value));
                 continue;
             }
             group.append(key).append(KV_SEPARATOR).append(value).append(GROUP_SEPARATOR);
@@ -148,8 +149,8 @@ public class LabelGroupUtils {
                     LOGGER.warning(String.format(Locale.ENGLISH, "Invalid label [%s]", label));
                 }
             }
-        } catch (UnsupportedEncodingException ignored) {
-            // ignored
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.log(Level.WARNING, "UnsupportedEncodingException, msg is {0}.", e.getMessage());
         }
         return result;
     }
@@ -169,8 +170,8 @@ public class LabelGroupUtils {
         final StringBuilder finalGroup = new StringBuilder();
         for (Map.Entry<String, String> entry : labels.entrySet()) {
             finalGroup.append(LABEL_PREFIX)
-                .append(buildSingleLabel(entry.getKey(), entry.getValue()))
-                .append(GROUP_SEPARATOR);
+                    .append(buildSingleLabel(entry.getKey(), entry.getValue()))
+                    .append(GROUP_SEPARATOR);
         }
         return finalGroup.deleteCharAt(finalGroup.length() - 1).toString();
     }
@@ -178,9 +179,9 @@ public class LabelGroupUtils {
     private static String buildSingleLabel(String key, String value) {
         try {
             return URLEncoder.encode(key + LABEL_QUERY_SEPARATOR + value, "UTF-8");
-        } catch (UnsupportedEncodingException ignored) {
-            // ignored
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.log(Level.WARNING, "UnsupportedEncodingException, msg is {0}.", e.getMessage());
+            return StringUtils.EMPTY;
         }
-        return StringUtils.EMPTY;
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/NetworkUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/NetworkUtils.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.core.utils;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.exception.NetInterfacesCheckException;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -25,6 +26,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -59,7 +61,7 @@ public class NetworkUtils {
         try {
             Enumeration<NetworkInterface> netInterfaces = NetworkInterface.getNetworkInterfaces();
             if (netInterfaces == null) {
-                throw new RuntimeException("netInterfaces is null");
+                throw new NetInterfacesCheckException("netInterfaces is null");
             }
             InetAddress ip;
             while (netInterfaces.hasMoreElements()) {
@@ -90,13 +92,13 @@ public class NetworkUtils {
      *
      * @return String
      */
-    public static String getHostName() {
+    public static Optional<String> getHostName() {
         InetAddress ia;
         try {
             ia = InetAddress.getLocalHost();
-            return ia.getHostName();
+            return Optional.ofNullable(ia.getHostName());
         } catch (UnknownHostException e) {
-            return null;
+            return Optional.empty();
         }
 
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/ReflectUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/ReflectUtils.java
@@ -194,7 +194,7 @@ public class ReflectUtils {
             if (method != null) {
                 return Optional.of(method);
             }
-            method = setAccessible(clazz.getDeclaredMethod(methodName, paramsType));
+            method = setObjectAccessible(clazz.getDeclaredMethod(methodName, paramsType));
             METHOD_CACHE.put(methodKey, method);
             return Optional.of(method);
         } catch (NoSuchMethodException ex) {
@@ -271,7 +271,7 @@ public class ReflectUtils {
         // 增加构造方法缓存
         return CONSTRUCTOR_CACHE.computeIfAbsent(buildMethodKey(clazz, "<init>", paramsTypes), key -> {
             try {
-                return Optional.of(setAccessible(clazz.getDeclaredConstructor(paramsTypes)));
+                return Optional.of(setObjectAccessible(clazz.getDeclaredConstructor(paramsTypes)));
             } catch (NoSuchMethodException e) {
                 LOGGER.warning(String.format(Locale.ENGLISH, "Can not find constructor for class [%s] with params [%s]",
                         clazz.getName(), Arrays.toString(paramsTypes)));
@@ -314,7 +314,7 @@ public class ReflectUtils {
             return true;
         } catch (IllegalAccessException ex) {
             LOGGER.warning(String.format(Locale.ENGLISH, "Set value for field [%s] failed! %s", fieldName,
-                ex.getMessage()));
+                    ex.getMessage()));
             return false;
         }
     }
@@ -422,7 +422,7 @@ public class ReflectUtils {
         Field field = cache.get(fieldName);
         try {
             if (field == null) {
-                field = setAccessible(clazz.getDeclaredField(fieldName));
+                field = setObjectAccessible(clazz.getDeclaredField(fieldName));
                 cache.putIfAbsent(fieldName, field);
             }
         } catch (IllegalArgumentException | NoSuchFieldException ex) {
@@ -460,7 +460,7 @@ public class ReflectUtils {
         return Optional.empty();
     }
 
-    private static <T extends AccessibleObject> T setAccessible(T object) {
+    private static <T extends AccessibleObject> T setObjectAccessible(T object) {
         AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
             object.setAccessible(true);
             return object;

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/RsaUtil.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/RsaUtil.java
@@ -72,7 +72,7 @@ public class RsaUtil {
      * 加密
      *
      * @param publicKey 公钥
-     * @param text      报文
+     * @param text 报文
      * @return 密文
      */
     public static Optional<String> encrypt(String publicKey, String text) {
@@ -93,7 +93,7 @@ public class RsaUtil {
      * 解密
      *
      * @param privateKey 私钥
-     * @param text       报文
+     * @param text 报文
      * @return 明文
      */
     public static Optional<String> decrypt(String privateKey, String text) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/ThreadFactoryUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/ThreadFactoryUtils.java
@@ -16,8 +16,13 @@
 
 package com.huaweicloud.sermant.core.utils;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * ThreadFactoryUtils
@@ -26,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 2022-03-26
  */
 public class ThreadFactoryUtils implements ThreadFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
 
     private static final AtomicInteger FACTORY_NUMBER = new AtomicInteger(0);
 
@@ -70,6 +76,13 @@ public class ThreadFactoryUtils implements ThreadFactory {
     public Thread newThread(Runnable job) {
         String newThreadName = createThreadName();
         Thread thread = new Thread(job, newThreadName);
+        thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                LOGGER.log(Level.WARNING, "uncaughtException, thread is {0}, msg is {1}", new String[]{t.getName(),
+                        e.getMessage()});
+            }
+        });
         if (isDaemon) {
             thread.setDaemon(true);
         }

--- a/sermant-agentcore/sermant-agentcore-god/src/main/java/com/huaweicloud/sermant/core/plugin/agent/entity/ExecuteContext.java
+++ b/sermant-agentcore/sermant-agentcore-god/src/main/java/com/huaweicloud/sermant/core/plugin/agent/entity/ExecuteContext.java
@@ -341,6 +341,7 @@ public class ExecuteContext {
      *
      * @param fieldName 属性名
      * @param value 属性值
+     * @deprecated 已经过时
      */
     @Deprecated
     public void setExtStaticFieldValue(String fieldName, Object value) {
@@ -355,6 +356,7 @@ public class ExecuteContext {
      *
      * @param fieldName 属性名
      * @return 属性值
+     * @deprecated 已经过时
      */
     @Deprecated
     public Object getExtStaticFieldValue(String fieldName) {
@@ -366,6 +368,7 @@ public class ExecuteContext {
      *
      * @param fieldName 属性名
      * @param value 属性值
+     * @deprecated 已经过时
      */
     @Deprecated
     public void setExtMemberFieldValue(String fieldName, Object value) {
@@ -380,6 +383,7 @@ public class ExecuteContext {
      *
      * @param fieldName 属性名
      * @return 属性值
+     * @deprecated 已经过时
      */
     @Deprecated
     public Object getExtMemberFieldValue(String fieldName) {

--- a/sermant-agentcore/sermant-agentcore-god/src/main/java/com/huaweicloud/sermant/god/common/RemoveSermantException.java
+++ b/sermant-agentcore/sermant-agentcore-god/src/main/java/com/huaweicloud/sermant/god/common/RemoveSermantException.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.backend.webhook.dingding;
-
-import com.huaweicloud.sermant.backend.webhook.WebHookConfig;
-import com.huaweicloud.sermant.backend.webhook.WebhookConfigImpl;
+package com.huaweicloud.sermant.god.common;
 
 /**
- * 钉钉webhook 配置
+ * 移除sermant异常
  *
- * @author xuezechao
- * @since 2023-03-02
+ * @author tangle
+ * @since 2023-11-03
  */
-public class DingDingHookConfig extends WebhookConfigImpl {
-    private static final WebHookConfig CONFIG = new WebhookConfigImpl();
-
-    private DingDingHookConfig() {
-    }
+public class RemoveSermantException extends RuntimeException {
+    private static final long serialVersionUID = -3051156765163094177L;
 
     /**
-     * 获取webhook配置单例
+     * 移除sermant异常
      *
-     * @return webhook配置单例
+     * @param cause 抛出对象
      */
-    public static WebHookConfig getInstance() {
-        return CONFIG;
+    public RemoveSermantException(Throwable cause) {
+        super(cause);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/LoadPropertiesStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/LoadPropertiesStrategy.java
@@ -19,8 +19,6 @@ package com.huaweicloud.sermant.implement.config;
 import com.huaweicloud.sermant.core.common.CommonConstant;
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.config.common.BaseConfig;
-import com.huaweicloud.sermant.core.config.common.ConfigFieldKey;
-import com.huaweicloud.sermant.core.config.common.ConfigTypeKey;
 import com.huaweicloud.sermant.core.config.strategy.LoadConfigStrategy;
 import com.huaweicloud.sermant.core.config.utils.ConfigFieldUtil;
 import com.huaweicloud.sermant.core.config.utils.ConfigKeyUtil;
@@ -84,7 +82,7 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
      * <p>要求配置文件必须存放在当前jar包的同级目录中
      * <p>最终的配置信息将被{@code argsMap}覆盖，{@code argsMap}拥有最高优先级
      *
-     * @param config      配置文件
+     * @param config 配置文件
      * @param bootArgsMap 启动时设定的参数
      * @return 配置信息承载对象
      */
@@ -96,14 +94,14 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
 
     /**
      * 加载配置对象
-     * <p>通过{@link ConfigTypeKey}和{@link ConfigFieldKey}注解定位到properties的配置信息
-     * <p>如果{@link ConfigFieldKey}不存在，则直接使用配置对象的属性名拼接
+     * <p>通过ConfigTypeKey和ConfigFieldKey注解定位到properties的配置信息
+     * <p>如果ConfigFieldKey不存在，则直接使用配置对象的属性名拼接
      * <p>设置配置对象属性值时，优先查找{@code setter}调用，不存在时尝试直接赋值
      * <p>因此，要求配置对象的属性值需要拥有相应的{@code setter}，或者要求改属性值是公有的
      *
      * @param holder 配置信息主要承载对象
      * @param config 配置对象
-     * @param <R>    配置对象泛型
+     * @return 配置对象泛型
      */
     @Override
     public <R extends BaseConfig> R loadConfig(Properties holder, R config) {
@@ -133,6 +131,7 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
      * 读取配置文件
      *
      * @param config 配置文件对象
+     * @return 配置内容
      */
     private Properties readConfig(File config) {
         final Properties properties = new Properties();
@@ -159,8 +158,8 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
      * 获取配置信息内容
      *
      * @param config 配置主要承载对象{@link Properties}
-     * @param key    配置键
-     * @param field  属性
+     * @param key 配置键
+     * @param field 属性
      * @return 配置信息
      */
     private Object getConfig(Properties config, String key, Field field) {
@@ -172,7 +171,7 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
      * 获取配置值，通过{@link ConfigValueUtil#fixValue}方法，修正形如"${}"的配置
      *
      * @param config 配置
-     * @param key    配置键
+     * @param key 配置键
      * @return 配置值
      */
     private String getConfigStr(Properties config, String key) {
@@ -181,7 +180,7 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
         if (arg == null) {
             configVal = config.getProperty(key);
             if (configVal == null) {
-                configVal = readMapOrCollection(configVal, config, key);
+                configVal = readMapOrCollection(null, config, key);
             }
         } else {
             configVal = arg.toString();
@@ -196,13 +195,11 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
     }
 
     /**
-     * 匹配Map/List/Set
-     * (1) 支持xxx.mapName.key1=value1配置Map
-     * (2) 支持xxx.xxx.listName[0]=elem1配置List或Set
+     * 匹配Map/List/Set (1) 支持xxx.mapName.key1=value1配置Map (2) 支持xxx.xxx.listName[0]=elem1配置List或Set
      *
      * @param configVal 配置值
-     * @param config    配置
-     * @param key       配置键
+     * @param config 配置
+     * @param key 配置键
      * @return 配置值
      */
     public String readMapOrCollection(String configVal, Properties config, String key) {
@@ -210,12 +207,12 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
         StringBuilder sb = new StringBuilder();
         for (String propertyName : config.stringPropertyNames()) {
             if (propertyName.startsWith(key)) {
-                // xxx.xxx.listName[0]=elem1 方式匹配List和Set
+                // 匹配List和Set
                 if (propertyName.matches("(.*)\\[[0-9]*]$")) {
                     sb.append(config.getProperty(propertyName))
                             .append(CommonConstant.COMMA);
                 } else {
-                    // xxx.mapName.key1=value1 方式匹配Map
+                    // 匹配Map
                     sb.append(propertyName.replace(key + CommonConstant.DOT, ""))
                             .append(CommonConstant.COLON)
                             .append(config.getProperty(propertyName))
@@ -234,7 +231,7 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
      * <p>支持int、short、long、float、double、枚举、String和Object类型，以及他们构成的数组、List和Map
      *
      * @param configStr 配置值
-     * @param field     属性字段
+     * @param field 属性字段
      * @return 转换后的类型
      */
     private Object transType(String configStr, Field field) {

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/LoadYamlStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/LoadYamlStrategy.java
@@ -75,6 +75,7 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
      * Yaml对象
      */
     private final Yaml yaml;
+
     /**
      * 启动参数
      */
@@ -153,7 +154,8 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
      * 修正键，如果属性被{@link ConfigFieldKey}修饰，则将{@link ConfigFieldKey#value()}转化为属性值
      *
      * @param typeMap 类对应的配置信息
-     * @param cls     类Class
+     * @param cls 类Class
+     * @return 类的字段map
      */
     private Map fixEntry(Map typeMap, Class<?> cls) {
         if (cls == Object.class || Map.class.isAssignableFrom(cls)) {
@@ -197,8 +199,9 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
     /**
      * 修正值中形如"${}"的部分
      *
-     * @param configKey  配置键
-     * @param typeMap    父Map
+     * @param field 类的字段名
+     * @param configKey 配置键
+     * @param typeMap 父Map
      * @param subTypeVal 当前值
      * @return 修正后的值
      */
@@ -231,7 +234,7 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
                         subTypeVal.getClass());
             }
         } catch (ConstructorException exception) {
-            LOGGER.severe(String.format(Locale.ENGLISH,"Error occurs while parsing configKey: %s", configKey));
+            LOGGER.severe(String.format(Locale.ENGLISH, "Error occurs while parsing configKey: %s", configKey));
         }
 
         return fixedVal;

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/KieDynamicConfigService.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/KieDynamicConfigService.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -82,12 +81,13 @@ public class KieDynamicConfigService extends DynamicConfigService {
 
     @Override
     public boolean addConfigListener(String key, String group, DynamicConfigListener listener, boolean ifNotify) {
+        String newGroup = group;
         if (!LabelGroupUtils.isLabelGroup(group)) {
             // 增加标签group判断, 对不规则的group进行适配处理
-            group = LabelGroupUtils
-                .createLabelGroup(Collections.singletonMap(fixSeparator(group, true), fixSeparator(key, false)));
+            newGroup = LabelGroupUtils
+                    .createLabelGroup(Collections.singletonMap(fixSeparator(group, true), fixSeparator(key, false)));
         }
-        return subscriberManager.addConfigListener(key, group, listener, ifNotify);
+        return subscriberManager.addConfigListener(key, newGroup, listener, ifNotify);
     }
 
     @Override
@@ -99,7 +99,7 @@ public class KieDynamicConfigService extends DynamicConfigService {
     @Override
     public Optional<String> doGetConfig(String key, String group) {
         final KieResponse kieResponse =
-            subscriberManager.queryConfigurations(null, LabelGroupUtils.getLabelCondition(group));
+                subscriberManager.queryConfigurations(null, LabelGroupUtils.getLabelCondition(group));
         if (!isValidResponse(kieResponse)) {
             return Optional.empty();
         }
@@ -125,7 +125,7 @@ public class KieDynamicConfigService extends DynamicConfigService {
     @Override
     public List<String> doListKeysFromGroup(String group) {
         final KieResponse kieResponse =
-            subscriberManager.queryConfigurations(null, LabelGroupUtils.getLabelCondition(group));
+                subscriberManager.queryConfigurations(null, LabelGroupUtils.getLabelCondition(group));
         if (isValidResponse(kieResponse)) {
             final List<KieConfigEntity> data = kieResponse.getData();
             final List<String> keys = new ArrayList<String>(data.size());
@@ -142,17 +142,16 @@ public class KieDynamicConfigService extends DynamicConfigService {
     }
 
     /**
-     * 更新监听器（删除||添加）
-     * 若第一次添加监听器，则会将数据通知给监听器
+     * 更新监听器（删除||添加） 若第一次添加监听器，则会将数据通知给监听器
      *
-     * @param group        分组， 针对KIE特别处理生成group方法{@link LabelGroupUtils#createLabelGroup(Map)}
-     * @param listener     对应改组的监听器
+     * @param group 分组， 针对KIE特别处理生成group方法LabelGroupUtils#createLabelGroup(Map)
+     * @param listener 对应改组的监听器
      * @param forSubscribe 是否为订阅
-     * @param ifNotify     初次添加监听器，是否通知监听的数据
+     * @param ifNotify 初次添加监听器，是否通知监听的数据
      * @return 更新是否成功
      */
     private synchronized boolean updateGroupListener(String group, DynamicConfigListener listener, boolean forSubscribe,
-        boolean ifNotify) {
+            boolean ifNotify) {
         if (listener == null) {
             LOGGER.warning("Empty listener is not allowed. ");
             return false;
@@ -172,19 +171,20 @@ public class KieDynamicConfigService extends DynamicConfigService {
     /**
      * 去除路径分隔符
      *
-     * @param str     key or group
+     * @param str key or group
      * @param isGroup 是否为组
      * @return 修正值
      */
     private String fixSeparator(String str, boolean isGroup) {
+        String newStr = str;
         if (str == null) {
             if (isGroup) {
                 // 默认分组
-                str = CONFIG.getDefaultGroup();
+                newStr = CONFIG.getDefaultGroup();
             } else {
                 throw new IllegalArgumentException("Key must not be empty!");
             }
         }
-        return str.startsWith("/") ? str.substring(1) : str;
+        return newStr.startsWith("/") ? newStr.substring(1) : newStr;
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/AbstractClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/AbstractClient.java
@@ -31,8 +31,14 @@ public abstract class AbstractClient implements Client {
      */
     private static final int DEFAULT_TIMEOUT_MS = 60000;
 
+    /**
+     * 客户端请求地址管理器
+     */
     protected final ClientUrlManager clientUrlManager;
 
+    /**
+     * http请求客户端
+     */
     protected HttpClient httpClient;
 
     /**

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/ClientUrlManager.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/ClientUrlManager.java
@@ -39,6 +39,7 @@ public class ClientUrlManager {
     private static final String KIE_PROTOCOL_SSL = "https://";
 
     private final UrlSelector urlSelector = new UrlSelector();
+
     private List<String> urls;
 
     /**
@@ -60,12 +61,11 @@ public class ClientUrlManager {
     }
 
     /**
-     * 解析url
-     * 默认多个url使用逗号隔开
+     * 解析url 默认多个url使用逗号隔开
      *
      * @param serverAddress 服务器地址字符串
      */
-    public void resolveUrls(String serverAddress) {
+    private void resolveUrls(String serverAddress) {
         if (serverAddress == null || serverAddress.trim().length() == 0) {
             return;
         }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
@@ -66,7 +66,7 @@ import javax.net.ssl.SSLContext;
  * @since 2021-11-17
  */
 public class DefaultHttpClient
-    implements com.huaweicloud.sermant.implement.service.dynamicconfig.kie.client.http.HttpClient {
+        implements com.huaweicloud.sermant.implement.service.dynamicconfig.kie.client.http.HttpClient {
     private static final Logger LOGGER = LoggerFactory.getLogger();
 
     /**
@@ -88,10 +88,10 @@ public class DefaultHttpClient
      */
     public DefaultHttpClient(int timeout) {
         httpClient = HttpClientBuilder.create().setDefaultRequestConfig(
-            RequestConfig.custom().setConnectTimeout(timeout)
-                .setSocketTimeout(timeout)
-                .setConnectionRequestTimeout(timeout)
-                .build()
+                RequestConfig.custom().setConnectTimeout(timeout)
+                        .setSocketTimeout(timeout)
+                        .setConnectionRequestTimeout(timeout)
+                        .build()
         ).setConnectionManager(buildConnectionManager()).build();
     }
 
@@ -102,9 +102,9 @@ public class DefaultHttpClient
      */
     public DefaultHttpClient(RequestConfig requestConfig) {
         this.httpClient = HttpClientBuilder.create()
-            .setDefaultRequestConfig(requestConfig)
-            .setConnectionManager(buildConnectionManager())
-            .build();
+                .setDefaultRequestConfig(requestConfig)
+                .setConnectionManager(buildConnectionManager())
+                .build();
     }
 
     /**
@@ -120,7 +120,7 @@ public class DefaultHttpClient
         // 如果需配置SSL 在此处注册https
         Registry<ConnectionSocketFactory> connectionSocketFactoryRegistry = builder.build();
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(
-            connectionSocketFactoryRegistry);
+                connectionSocketFactoryRegistry);
         connectionManager.setMaxTotal(MAX_TOTAL);
         connectionManager.setDefaultMaxPerRoute(DEFAULT_MAX_PER_ROUTE);
         return connectionManager;
@@ -155,8 +155,9 @@ public class DefaultHttpClient
     /**
      * get请求
      *
-     * @param url     请求地址
+     * @param url 请求地址
      * @param headers 请求头
+     * @param requestConfig 请求配置
      * @return HttpResult
      */
     @Override
@@ -178,7 +179,7 @@ public class DefaultHttpClient
 
     @Override
     public HttpResult doPost(String url, Map<String, Object> params, RequestConfig requestConfig,
-        Map<String, String> headers) {
+            Map<String, String> headers) {
         HttpPost httpPost = new HttpPost(url);
         beforeRequest(httpPost, requestConfig, headers);
         addParams(httpPost, params);
@@ -264,12 +265,20 @@ public class DefaultHttpClient
 
     /**
      * 添加默认的请求头
+     *
+     * @param base http请求base
      */
     private void addDefaultHeaders(HttpRequestBase base) {
         base.addHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8");
         base.addHeader(HttpHeaders.USER_AGENT, "sermant/client");
     }
 
+    /**
+     * SSL信任策略
+     *
+     * @author zhouss
+     * @since 2021-11-17
+     */
     static class SslTrustStrategy implements TrustStrategy {
         @Override
         public boolean isTrusted(X509Certificate[] chain, String authType) {

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/KieClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/KieClient.java
@@ -41,9 +41,9 @@ public class KieClient extends AbstractClient {
      */
     private static final String ABSENT_REVISION = "0";
 
-    private final ResultHandler<KieResponse> defaultHandler = new ResultHandler.DefaultResultHandler();
+    private static final String KIE_API_TEMPLATE = "/v1/%s/kie/kv?";
 
-    private final String kieApiTemplate = "/v1/%s/kie/kv?";
+    private final ResultHandler<KieResponse> defaultHandler = new ResultHandler.DefaultResultHandler();
 
     private String kieApi;
 
@@ -51,7 +51,7 @@ public class KieClient extends AbstractClient {
      * kei客户端构造器
      *
      * @param clientUrlManager kie url管理器
-     * @param timeout          超时时间
+     * @param timeout 超时时间
      */
     public KieClient(ClientUrlManager clientUrlManager, int timeout) {
         this(clientUrlManager, ConfigManager.getConfig(KieDynamicConfig.class).getProject(), timeout);
@@ -61,8 +61,8 @@ public class KieClient extends AbstractClient {
      * kei客户端构造器
      *
      * @param clientUrlManager kie url管理器
-     * @param project          命名空间
-     * @param timeout          超时时间
+     * @param project 命名空间
+     * @param timeout 超时时间
      */
     public KieClient(ClientUrlManager clientUrlManager, String project, int timeout) {
         this(clientUrlManager, null, project, timeout);
@@ -72,17 +72,22 @@ public class KieClient extends AbstractClient {
      * kei客户端构造器
      *
      * @param clientUrlManager kie url管理器
-     * @param httpClient       指定请求器
-     * @param project          命名空间
-     * @param timeout          超时时间
+     * @param httpClient 指定请求器
+     * @param project 命名空间
+     * @param timeout 超时时间
      */
     public KieClient(ClientUrlManager clientUrlManager, HttpClient httpClient, String project, int timeout) {
         super(clientUrlManager, httpClient, timeout);
-        kieApi = String.format(kieApiTemplate, project);
+        kieApi = String.format(KIE_API_TEMPLATE, project);
     }
 
+    /**
+     * 设置kieApi为命名空间
+     *
+     * @param project 命名空间
+     */
     public void setProject(String project) {
-        this.kieApi = String.format(kieApiTemplate, project);
+        this.kieApi = String.format(KIE_API_TEMPLATE, project);
     }
 
     /**
@@ -98,9 +103,9 @@ public class KieClient extends AbstractClient {
     /**
      * 查询Kie配置
      *
-     * @param request         请求体
+     * @param request 请求体
      * @param responseHandler http结果处理器
-     * @param <T>             转换后的目标类型
+     * @param <T> 转换后的目标类型
      * @return 响应结果
      */
     public <T> T queryConfigurations(KieRequest request, ResultHandler<T> responseHandler) {
@@ -109,8 +114,8 @@ public class KieClient extends AbstractClient {
         }
         final StringBuilder requestUrl = new StringBuilder().append(clientUrlManager.getUrl()).append(kieApi);
         requestUrl.append(formatNullString(request.getLabelCondition()))
-            .append("&revision=")
-            .append(formatNullString(request.getRevision()));
+                .append("&revision=")
+                .append(formatNullString(request.getRevision()));
         if (request.isAccurateMatchLabel()) {
             requestUrl.append("&match=exact");
         }
@@ -124,9 +129,10 @@ public class KieClient extends AbstractClient {
     /**
      * 发布配置
      *
-     * @param key     请求键
-     * @param labels  标签
+     * @param key 请求键
+     * @param labels 标签
      * @param content 配置
+     * @param enabled 配置的状态开关
      * @return 是否发布成功
      */
     public boolean publishConfig(String key, Map<String, String> labels, String content, boolean enabled) {
@@ -142,7 +148,7 @@ public class KieClient extends AbstractClient {
     /**
      * 更新配置
      *
-     * @param keyId   key-id
+     * @param keyId key-id
      * @param content 更新内容
      * @param enabled 是否开启
      * @return 是否更新成功
@@ -157,7 +163,7 @@ public class KieClient extends AbstractClient {
 
     private String buildKeyIdUrl(String keyId) {
         return String.format(Locale.ENGLISH, "%s/%s",
-            clientUrlManager.getUrl() + kieApi.substring(0, kieApi.length() - 1), keyId);
+                clientUrlManager.getUrl() + kieApi.substring(0, kieApi.length() - 1), keyId);
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
@@ -70,7 +70,7 @@ public class KieListenerWrapper {
         this.group = kieRequest.getLabelCondition();
         this.kvDataHolder = kvDataHolder;
         this.kieRequest = kieRequest;
-        addKeyListener(key, dynamicConfigListener, ifNotify);
+        this.addKeyListener(key, dynamicConfigListener, ifNotify);
     }
 
     /**
@@ -198,7 +198,7 @@ public class KieListenerWrapper {
      * @param dynamicConfigListener 监听器
      * @param ifNotify 是否初始化通知
      */
-    public void addKeyListener(String key, DynamicConfigListener dynamicConfigListener, boolean ifNotify) {
+    public final void addKeyListener(String key, DynamicConfigListener dynamicConfigListener, boolean ifNotify) {
         VersionListenerWrapper versionListenerWrapper = keyListenerMap.get(key);
         if (versionListenerWrapper == null) {
             versionListenerWrapper = new VersionListenerWrapper();

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/ResultHandler.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/client/kie/ResultHandler.java
@@ -28,6 +28,7 @@ import java.util.List;
 /**
  * Kie结果处理器
  *
+ * @param <R> handle泛型
  * @author zhouss
  * @since 2021-11-17
  */
@@ -42,9 +43,13 @@ public interface ResultHandler<R> {
 
     /**
      * 默认结果处理器
+     *
+     * @author zhouss
+     * @since 2021-11-17
      */
     class DefaultResultHandler implements ResultHandler<KieResponse> {
         private final boolean onlyEnabled;
+
         public DefaultResultHandler() {
             onlyEnabled = true;
         }
@@ -67,6 +72,7 @@ public interface ResultHandler<R> {
                 // KIE如果响应状态码为304，则表示没有相关键变更
                 kieResponse.setChanged(false);
             }
+
             // 过滤掉disabled的kv配置
             final List<KieConfigEntity> data = kieResponse.getData();
             if (data == null) {
@@ -77,6 +83,7 @@ public interface ResultHandler<R> {
             kieResponse.setTotal(data.size());
             return kieResponse;
         }
+
         /**
          * 过滤未开启的kv
          *

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/KvDataHolder.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/KvDataHolder.java
@@ -23,8 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 监听键响应数据
- * 用于对比新旧数据并保留旧数据
+ * 监听键响应数据 用于对比新旧数据并保留旧数据
  *
  * @author zhouss
  * @since 2021-11-18
@@ -180,6 +179,11 @@ public class KvDataHolder {
             this.added = added;
         }
 
+        /**
+         * 通过操作不为空判断是否有行为变化
+         *
+         * @return boolean
+         */
         public boolean isChanged() {
             return !added.isEmpty() || !deleted.isEmpty() || !modified.isEmpty();
         }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/SubscriberManager.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/kie/listener/SubscriberManager.java
@@ -100,7 +100,7 @@ public class SubscriberManager {
      * map< 监听键, 监听该键的监听器列表 >  一个group，仅有一个KieListenerWrapper
      */
     private final Map<KieRequest, KieListenerWrapper> listenerMap =
-        new ConcurrentHashMap<>();
+            new ConcurrentHashMap<>();
 
     /**
      * kie客户端
@@ -116,18 +116,18 @@ public class SubscriberManager {
      * 订阅执行器 最大支持MAX_THREAD_SIZE个任务 由于是长连接请求，必然会占用线程，因此这里不考虑将任务存在队列中
      */
     private final ThreadPoolExecutor longRequestExecutor = new ThreadPoolExecutor(THREAD_SIZE, MAX_THREAD_SIZE, 0,
-        TimeUnit.MILLISECONDS, new SynchronousQueue<>(), new ThreadFactoryUtils("kie-subscribe-long-task"));
+            TimeUnit.MILLISECONDS, new SynchronousQueue<>(), new ThreadFactoryUtils("kie-subscribe-long-task"));
 
     /**
      * 快速返回的请求
      */
-    private ScheduledExecutorService scheduledExecutorService;
+    private volatile ScheduledExecutorService scheduledExecutorService;
 
     /**
      * 构造函数
      *
      * @param serverAddress serverAddress
-     * @param timeout       超时时间
+     * @param timeout 超时时间
      */
     public SubscriberManager(String serverAddress, int timeout) {
         kieClient = new KieClient(new ClientUrlManager(serverAddress), timeout);
@@ -137,8 +137,8 @@ public class SubscriberManager {
      * SubscriberManager
      *
      * @param serverAddress serverAddress
-     * @param project       project
-     * @param timeout       超时时间
+     * @param project project
+     * @param timeout 超时时间
      */
     public SubscriberManager(String serverAddress, String project, int timeout) {
         kieClient = new KieClient(new ClientUrlManager(serverAddress), project, timeout);
@@ -147,7 +147,7 @@ public class SubscriberManager {
     /**
      * 添加组监听
      *
-     * @param group    标签组
+     * @param group 标签组
      * @param listener 监听器
      * @param ifNotify 是否在第一次添加时，将所有数据查询返回给调用者
      * @return 是否添加成功
@@ -155,8 +155,9 @@ public class SubscriberManager {
     public boolean addGroupListener(String group, DynamicConfigListener listener, boolean ifNotify) {
         try {
             return subscribe(KieConstants.DEFAULT_GROUP_KEY,
-                new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener,
-                ifNotify);
+                    new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT),
+                    listener,
+                    ifNotify);
         } catch (Exception ex) {
             LOGGER.warning(String.format(Locale.ENGLISH, "Add group listener failed, %s", ex.getMessage()));
             return false;
@@ -166,8 +167,8 @@ public class SubscriberManager {
     /**
      * 添加单个key监听器
      *
-     * @param key      键
-     * @param group    标签组
+     * @param key 键
+     * @param group 标签组
      * @param listener 监听器
      * @param ifNotify 是否在第一次添加时，将所有数据查询返回给调用者
      * @return 是否添加成功
@@ -175,8 +176,9 @@ public class SubscriberManager {
     public boolean addConfigListener(String key, String group, DynamicConfigListener listener, boolean ifNotify) {
         try {
             return subscribe(key,
-                new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener,
-                ifNotify);
+                    new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT),
+                    listener,
+                    ifNotify);
         } catch (Exception ex) {
             LOGGER.warning(String.format(Locale.ENGLISH, "Add group listener failed, %s", ex.getMessage()));
             return false;
@@ -186,14 +188,15 @@ public class SubscriberManager {
     /**
      * 移除组监听
      *
-     * @param group    标签组
+     * @param group 标签组
      * @param listener 监听器
      * @return 是否添加成功
      */
     public boolean removeGroupListener(String group, DynamicConfigListener listener) {
         try {
             return unSubscribe(KieConstants.DEFAULT_GROUP_KEY,
-                new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener);
+                    new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT),
+                    listener);
         } catch (Exception ex) {
             LOGGER.warning(String.format(Locale.ENGLISH, "Removed group listener failed, %s", ex.getMessage()));
             return false;
@@ -203,8 +206,8 @@ public class SubscriberManager {
     /**
      * 发布配置, 若配置已存在则转为更新配置
      *
-     * @param key     配置键
-     * @param group   分组
+     * @param key 配置键
+     * @param group 分组
      * @param content 配置内容
      * @return 是否发布成功
      */
@@ -222,7 +225,7 @@ public class SubscriberManager {
     /**
      * 移除配置
      *
-     * @param key   键名称
+     * @param key 键名称
      * @param group 分组
      * @return 是否删除成功
      */
@@ -234,7 +237,7 @@ public class SubscriberManager {
     /**
      * 获取key_id
      *
-     * @param key   键
+     * @param key 键
      * @param group 组
      * @return key_id, 若不存在则返回null
      */
@@ -274,14 +277,14 @@ public class SubscriberManager {
     /**
      * 注册监听器
      *
-     * @param key                   key
-     * @param kieRequest            请求
+     * @param key key
+     * @param kieRequest 请求
      * @param dynamicConfigListener 监听器
-     * @param ifNotify              是否在第一次添加时，将所有数据查询返回给调用者
+     * @param ifNotify 是否在第一次添加时，将所有数据查询返回给调用者
      * @return boolean
      */
     public boolean subscribe(String key, KieRequest kieRequest, DynamicConfigListener dynamicConfigListener,
-        boolean ifNotify) {
+            boolean ifNotify) {
         final KieListenerWrapper oldWrapper = listenerMap.get(kieRequest);
         if (oldWrapper == null) {
             return firstSubscribeForGroup(key, kieRequest, dynamicConfigListener, ifNotify);
@@ -299,18 +302,18 @@ public class SubscriberManager {
     }
 
     private boolean firstSubscribeForGroup(String key, KieRequest kieRequest,
-        DynamicConfigListener dynamicConfigListener, boolean ifNotify) {
+            DynamicConfigListener dynamicConfigListener, boolean ifNotify) {
         final KieSubscriber kieSubscriber = new KieSubscriber(kieRequest);
         Task task;
         KieListenerWrapper kieListenerWrapper =
-            new KieListenerWrapper(key, dynamicConfigListener, new KvDataHolder(), kieRequest, ifNotify);
+                new KieListenerWrapper(key, dynamicConfigListener, new KvDataHolder(), kieRequest, ifNotify);
         if (!kieSubscriber.isLongConnectionRequest()) {
             task = new ShortTimerTask(kieSubscriber, kieListenerWrapper);
         } else {
             if (exceedMaxLongRequestCount()) {
                 LOGGER.warning(String.format(Locale.ENGLISH,
-                    "Exceeded max long connection request subscribers, the max number is %s, it will be discarded!",
-                    curLongConnectionRequestCount.get()));
+                        "Exceeded max long connection request subscribers, the max number is %s, it will be discarded!",
+                        curLongConnectionRequestCount.get()));
                 return false;
             }
             buildRequestConfig(kieRequest);
@@ -335,7 +338,7 @@ public class SubscriberManager {
     /**
      * 针对长请求的场景需要做第一次拉取，获取已有的数据
      *
-     * @param kieRequest         请求体
+     * @param kieRequest 请求体
      * @param kieListenerWrapper 监听器
      */
     public void firstRequest(KieRequest kieRequest, KieListenerWrapper kieListenerWrapper) {
@@ -354,7 +357,7 @@ public class SubscriberManager {
      * 单独查询配置
      *
      * @param revision 版本
-     * @param label    关联标签组
+     * @param label 关联标签组
      * @return kv配置
      */
     public KieResponse queryConfigurations(String revision, String label) {
@@ -364,8 +367,8 @@ public class SubscriberManager {
     /**
      * 单独查询配置
      *
-     * @param revision    版本
-     * @param label       关联标签组
+     * @param revision 版本
+     * @param label 关联标签组
      * @param onlyEnabled 是否仅可用status=enabled
      * @return kv配置
      */
@@ -380,8 +383,8 @@ public class SubscriberManager {
     /**
      * 取消订阅
      *
-     * @param key                   key
-     * @param kieRequest            kieRequest
+     * @param key key
+     * @param kieRequest kieRequest
      * @param dynamicConfigListener dynamicConfigListener
      * @return boolean
      */
@@ -405,7 +408,7 @@ public class SubscriberManager {
             }
         }
         LOGGER.warning(
-            String.format(Locale.ENGLISH, "The subscriber of group %s not found!", kieRequest.getLabelCondition()));
+                String.format(Locale.ENGLISH, "The subscriber of group %s not found!", kieRequest.getLabelCondition()));
         return false;
     }
 
@@ -413,7 +416,7 @@ public class SubscriberManager {
         int wait = (Integer.parseInt(kieRequest.getWait()) + 1) * SECONDS_UNIT;
         if (kieRequest.getRequestConfig() == null) {
             kieRequest.setRequestConfig(RequestConfig.custom().setConnectionRequestTimeout(wait).setConnectTimeout(wait)
-                .setSocketTimeout(wait).build());
+                    .setSocketTimeout(wait).build());
         }
     }
 
@@ -426,12 +429,12 @@ public class SubscriberManager {
                     synchronized (SubscriberManager.class) {
                         if (scheduledExecutorService == null) {
                             scheduledExecutorService = new ScheduledThreadPoolExecutor(THREAD_SIZE,
-                                new ThreadFactoryUtils("kie-subscribe-task"));
+                                    new ThreadFactoryUtils("kie-subscribe-task"));
                         }
                     }
                 }
                 scheduledExecutorService.scheduleAtFixedRate(new TaskRunnable(task), 0, SCHEDULE_REQUEST_INTERVAL_MS,
-                    TimeUnit.MILLISECONDS);
+                        TimeUnit.MILLISECONDS);
             }
         } catch (RejectedExecutionException ex) {
             LOGGER.warning("Rejected the task " + task.getClass() + " " + ex.getMessage());
@@ -464,7 +467,7 @@ public class SubscriberManager {
                 task.execute();
             } catch (Exception ex) {
                 LOGGER.warning(
-                    String.format(Locale.ENGLISH, "The error occurred when execute task , %s", ex.getMessage()));
+                        String.format(Locale.ENGLISH, "The error occurred when execute task , %s", ex.getMessage()));
             }
         }
     }
@@ -499,7 +502,7 @@ public class SubscriberManager {
      * @since 2021-11-17
      */
     abstract static class AbstractTask implements Task {
-        protected volatile boolean isContinue = true;
+        private volatile boolean isContinue = true;
 
         @Override
         public void execute() {
@@ -581,7 +584,7 @@ public class SubscriberManager {
                 SubscriberManager.this.executeTask(new SleepCallBackTask(this, LONG_CONNECTION_REQUEST_INTERVAL_MS));
             } catch (Exception ex) {
                 LOGGER.warning(
-                    String.format(Locale.ENGLISH, "pull kie config failed, %s, it will rePull", ex.getMessage()));
+                        String.format(Locale.ENGLISH, "pull kie config failed, %s, it will rePull", ex.getMessage()));
                 ++failCount;
                 SubscriberManager.this.executeTask(new SleepCallBackTask(this, failCount));
             }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribe.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribe.java
@@ -50,8 +50,6 @@ public class DynamicConfigSubscribe implements ConfigSubscriber {
 
     private DynamicConfigListener listener;
 
-    private String pluginName;
-
     private String key;
 
     private NacosDynamicConfigService nacosDynamicConfigService;
@@ -61,13 +59,11 @@ public class DynamicConfigSubscribe implements ConfigSubscriber {
      *
      * @param serviceName 服务名称
      * @param listener 动态配置监听器
-     * @param pluginName 插件名称
      * @param key 配置名称
      */
-    public DynamicConfigSubscribe(String serviceName, DynamicConfigListener listener, String pluginName, String key) {
+    public DynamicConfigSubscribe(String serviceName, DynamicConfigListener listener, String key) {
         this.serviceName = serviceName;
         this.listener = listener;
-        this.pluginName = pluginName;
         this.key = key;
         try {
             this.nacosDynamicConfigService = ServiceManager.getService(NacosDynamicConfigService.class);

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigService.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/NacosDynamicConfigService.java
@@ -363,7 +363,7 @@ public class NacosDynamicConfigService extends DynamicConfigService {
                 if (content == null) {
                     // 移除
                     isCreateOrModify = false;
-                    return DynamicConfigEvent.deleteEvent(key, validGroup, content);
+                    return DynamicConfigEvent.deleteEvent(key, validGroup, null);
                 } else if (isCreateOrModify) {
                     // 修改
                     return DynamicConfigEvent.modifyEvent(key, validGroup, content);

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperBufferedClient.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/dynamicconfig/zookeeper/ZooKeeperBufferedClient.java
@@ -106,7 +106,7 @@ public class ZooKeeperBufferedClient implements Closeable {
      * @param key 用户密钥
      */
     public ZooKeeperBufferedClient(String connectString, int sessionTimeout, String userName,
-                                   String password, String key) {
+            String password, String key) {
         String authInfo = userName + ZK_AUTH_SEPARATOR + AesUtil.decrypt(key, password).orElse(null);
         zkClient = newZkClient(connectString, sessionTimeout, new Watcher() {
             @Override

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/send/netty/BaseHandler.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/send/netty/BaseHandler.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.implement.service.send.netty;
 
 import com.huaweicloud.sermant.implement.service.send.netty.pojo.Message;
+import com.huaweicloud.sermant.implement.service.send.netty.pojo.Message.NettyMessage.MessageType;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -39,13 +40,10 @@ public abstract class BaseHandler extends SimpleChannelInboundHandler<Message.Ne
     public void channelRead0(ChannelHandlerContext ctx, Message.NettyMessage msg) {
         // 获取收到的消息类型
         int type = msg.getMessageTypeValue();
-        switch (type) {
-            // 如果为业务数据进行各自的处理
-            case Message.NettyMessage.MessageType.SERVICE_DATA_VALUE:
-                handlerData(ctx, msg);
-                break;
-            default:
-                break;
+
+        // 如果为业务数据进行各自的处理
+        if (type == MessageType.SERVICE_DATA_VALUE) {
+            handlerData(ctx, msg);
         }
     }
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/send/netty/NettyClientFactory.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/send/netty/NettyClientFactory.java
@@ -34,6 +34,11 @@ public class NettyClientFactory {
 
     private static final Map<String, NettyClient> CLIENT_MAP = new HashMap<>();
 
+    /**
+     * 获取netty客户端工厂单例
+     *
+     * @return netty客户端工厂单例
+     */
     public static NettyClientFactory getInstance() {
         return FACTORY;
     }
@@ -74,8 +79,8 @@ public class NettyClientFactory {
      * 关闭工厂，清空Client示例
      */
     public static void stop() {
-        for (String key : CLIENT_MAP.keySet()) {
-            CLIENT_MAP.get(key).stop();
+        for (Map.Entry<String, NettyClient> entry : CLIENT_MAP.entrySet()) {
+            entry.getValue().stop();
         }
         CLIENT_MAP.clear();
     }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/tracing/TracingServiceImpl.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/service/tracing/TracingServiceImpl.java
@@ -85,7 +85,7 @@ public class TracingServiceImpl implements TracingService {
 
     @Override
     public <T> Optional<SpanEvent> onProviderSpanStart(TracingRequest tracingRequest, ExtractService<T> extractService,
-        T carrier) {
+            T carrier) {
         if (!isTracing) {
             return Optional.empty();
         }
@@ -118,7 +118,7 @@ public class TracingServiceImpl implements TracingService {
 
     @Override
     public <T> Optional<SpanEvent> onConsumerSpanStart(TracingRequest tracingRequest, InjectService<T> injectService,
-        T carrier) {
+            T carrier) {
         if (!isTracing) {
             return Optional.empty();
         }
@@ -187,13 +187,14 @@ public class TracingServiceImpl implements TracingService {
      * 通过SpanId来限制采样深度
      *
      * @param tracingRequest 调用链路追踪生命周期时需要传入的参数
+     * @return tracingRequest长度是否合法
      */
     private boolean filterSpanDepth(TracingRequest tracingRequest) {
         // 检查spanId长度 大于100忽略
         String spanIdPrefix = tracingRequest.getSpanIdPrefix();
         if (spanIdPrefix != null && spanIdPrefix.length() > MAX_SPAN_EVENT_DEPTH) {
             LOGGER.info(String.format(Locale.ROOT, "SpanId is too long, discard this span : [%s]",
-                JSON.toJSONString(tracingRequest, SerializerFeature.WriteMapNullValue)));
+                    JSON.toJSONString(tracingRequest, SerializerFeature.WriteMapNullValue)));
             return false;
         }
         return true;
@@ -201,7 +202,7 @@ public class TracingServiceImpl implements TracingService {
 
     private void sendSpanEvent(SpanEvent spanEvent) {
         LOGGER.info(String.format(Locale.ROOT, "Add spanEvent to queue , TraceId : [%s] , SpanId [%s] . ",
-            spanEvent.getTraceId(), spanEvent.getSpanId()));
+                spanEvent.getTraceId(), spanEvent.getSpanId()));
         tracingSender.offerSpanEvent(spanEvent);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribeTest.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/test/java/com/huaweicloud/sermant/implement/service/dynamicconfig/nacos/DynamicConfigSubscribeTest.java
@@ -46,7 +46,7 @@ public class DynamicConfigSubscribeTest extends NacosBaseTest {
         try {
             // 测试订阅
             TestListener testListener = new TestListener();
-            dynamicConfigSubscribe = new DynamicConfigSubscribe("testServiceName", testListener, "testPluginName",
+            dynamicConfigSubscribe = new DynamicConfigSubscribe("testServiceName", testListener,
                     "testSubscribeKey");
             Assert.assertTrue(dynamicConfigSubscribe.subscribe());
             Thread.sleep(SLEEP_TIME_MILLIS);

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huaweicloud/sermant/premain/AgentLauncher.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huaweicloud/sermant/premain/AgentLauncher.java
@@ -21,6 +21,7 @@ import com.huaweicloud.sermant.god.common.SermantManager;
 import com.huaweicloud.sermant.premain.common.AgentArgsResolver;
 import com.huaweicloud.sermant.premain.common.BootArgsBuilder;
 import com.huaweicloud.sermant.premain.common.BootConstant;
+import com.huaweicloud.sermant.premain.common.DirectoryCheckException;
 import com.huaweicloud.sermant.premain.common.PathDeclarer;
 import com.huaweicloud.sermant.premain.utils.LoggerUtils;
 import com.huaweicloud.sermant.premain.utils.StringUtils;
@@ -159,11 +160,11 @@ public class AgentLauncher {
     private static void appendGodLibToBootStrapClassLoaderSearch(Instrumentation instrumentation) {
         final File bootstrapDir = new File(PathDeclarer.getGodLibPath(PathDeclarer.getAgentPath()));
         if (!bootstrapDir.exists() || !bootstrapDir.isDirectory()) {
-            throw new RuntimeException("God directory is not exist or is not directory.");
+            throw new DirectoryCheckException("God directory is not exist or is not directory.");
         }
         File[] jars = bootstrapDir.listFiles((dir, name) -> name.endsWith(".jar"));
         if (jars == null || jars.length == 0) {
-            throw new RuntimeException("God directory is empty");
+            throw new DirectoryCheckException("God directory is empty");
         }
 
         for (File jar : jars) {
@@ -179,11 +180,11 @@ public class AgentLauncher {
         String realPath = StringUtils.isBlank(agentPath) ? PathDeclarer.getAgentPath() : agentPath;
         final File coreDir = new File(PathDeclarer.getCorePath(realPath));
         if (!coreDir.exists() || !coreDir.isDirectory()) {
-            throw new RuntimeException("Core directory is not exist or is not directory.");
+            throw new DirectoryCheckException("Core directory is not exist or is not directory.");
         }
         final File[] jars = coreDir.listFiles((dir, name) -> name.endsWith(".jar"));
         if (jars == null || jars.length == 0) {
-            throw new RuntimeException("Core directory is empty.");
+            throw new DirectoryCheckException("Core directory is empty.");
         }
         List<URL> list = new ArrayList<>();
         for (File jar : jars) {

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huaweicloud/sermant/premain/common/DirectoryCheckException.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huaweicloud/sermant/premain/common/DirectoryCheckException.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.huaweicloud.sermant.backend.webhook.dingding;
-
-import com.huaweicloud.sermant.backend.webhook.WebHookConfig;
-import com.huaweicloud.sermant.backend.webhook.WebhookConfigImpl;
+package com.huaweicloud.sermant.premain.common;
 
 /**
- * 钉钉webhook 配置
+ * 目录检查异常
  *
- * @author xuezechao
- * @since 2023-03-02
+ * @author tangle
+ * @since 2023-11-03
  */
-public class DingDingHookConfig extends WebhookConfigImpl {
-    private static final WebHookConfig CONFIG = new WebhookConfigImpl();
-
-    private DingDingHookConfig() {
-    }
+public class DirectoryCheckException extends RuntimeException {
+    private static final long serialVersionUID = 1623401059405718814L;
 
     /**
-     * 获取webhook配置单例
+     * 目录检查异常
      *
-     * @return webhook配置单例
+     * @param message 异常信息
      */
-    public static WebHookConfig getInstance() {
-        return CONFIG;
+    public DirectoryCheckException(String message) {
+        super(message);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huaweicloud/sermant/premain/utils/LoggerUtils.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/com/huaweicloud/sermant/premain/utils/LoggerUtils.java
@@ -29,21 +29,13 @@ import java.util.logging.Logger;
  * @since 2023-07-20
  */
 public class LoggerUtils {
-    private static Logger logger;
+    private static final Logger LOGGER = initLogger();
 
     private LoggerUtils() {
     }
 
-    /**
-     * 获取基础日志
-     *
-     * @return Logger
-     */
-    public static Logger getLogger() {
-        if (logger != null) {
-            return logger;
-        }
-        logger = Logger.getLogger("sermant.agent");
+    private static Logger initLogger() {
+        Logger tmpLogger = Logger.getLogger("sermant.agent");
         final ConsoleHandler handler = new ConsoleHandler();
         final String lineSeparator = System.getProperty("line.separator");
         handler.setFormatter(new Formatter() {
@@ -53,8 +45,17 @@ public class LoggerUtils {
                 return "[" + time + "] " + "[" + record.getLevel() + "] " + record.getMessage() + lineSeparator;
             }
         });
-        logger.addHandler(handler);
-        logger.setUseParentHandlers(false);
-        return logger;
+        tmpLogger.addHandler(handler);
+        tmpLogger.setUseParentHandlers(false);
+        return tmpLogger;
+    }
+
+    /**
+     * 获取基础日志
+     *
+     * @return Logger
+     */
+    public static Logger getLogger() {
+        return LOGGER;
     }
 }

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/common/conf/BackendConfig.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/common/conf/BackendConfig.java
@@ -33,7 +33,6 @@ import java.util.Locale;
 @Component
 @Configuration
 public class BackendConfig {
-
     /**
      * 数据库类型
      */
@@ -110,8 +109,8 @@ public class BackendConfig {
         return eventExpire;
     }
 
-    public void setExpire(int expire) {
-        this.eventExpire = expire;
+    public void setEventExpire(int eventExpire) {
+        this.eventExpire = eventExpire;
     }
 
     public int getFieldExpire() {

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/common/handler/BaseHandler.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/common/handler/BaseHandler.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.backend.common.handler;
 
 import com.huaweicloud.sermant.backend.pojo.Message;
+import com.huaweicloud.sermant.backend.pojo.Message.NettyMessage.MessageType;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -26,8 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * handler的基类
- * 不同数据类型选择处理方式，心跳触发等功能
+ * handler的基类 不同数据类型选择处理方式，心跳触发等功能
  *
  * @author lilai
  * @version 0.0.1
@@ -40,13 +40,10 @@ public abstract class BaseHandler extends SimpleChannelInboundHandler<Message.Ne
     public void channelRead0(ChannelHandlerContext ctx, Message.NettyMessage msg) {
         // 获取收到的消息类型
         int type = msg.getMessageTypeValue();
-        switch (type) {
-            // 如果为业务数据进行各自的处理
-            case Message.NettyMessage.MessageType.SERVICE_DATA_VALUE:
-                handlerData(ctx, msg);
-                break;
-            default:
-                break;
+
+        // 如果为业务数据进行各自的处理
+        if (type == MessageType.SERVICE_DATA_VALUE) {
+            handlerData(ctx, msg);
         }
     }
 
@@ -60,7 +57,7 @@ public abstract class BaseHandler extends SimpleChannelInboundHandler<Message.Ne
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-        IdleStateEvent stateEvent = (IdleStateEvent)evt;
+        IdleStateEvent stateEvent = (IdleStateEvent) evt;
         switch (stateEvent.state()) {
             case READER_IDLE:
                 handlerReaderIdle(ctx);

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/controller/EventController.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/controller/EventController.java
@@ -59,7 +59,6 @@ import javax.servlet.http.HttpSession;
 @RestController
 @RequestMapping("/sermant")
 public class EventController {
-
     @Autowired
     private BackendConfig backendConfig;
 
@@ -132,7 +131,7 @@ public class EventController {
      */
     @PutMapping("/event/webhooks/{id}")
     public boolean setWebhook(@RequestBody(required = false) WebhooksIdRequestEntity webhooksIdRequestEntity,
-                              @PathVariable String id) {
+            @PathVariable String id) {
         List<WebHookClient> webHookClients = eventPushHandler.getWebHookClients();
         for (WebHookClient webHookClient : webHookClients) {
             WebHookConfig config = webHookClient.getConfig();

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/controller/HeartBeatInfoController.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/controller/HeartBeatInfoController.java
@@ -42,6 +42,11 @@ import java.util.Map;
 public class HeartBeatInfoController {
     private static final Logger LOGGER = LoggerFactory.getLogger(HeartBeatInfoController.class);
 
+    /**
+     * 返回插件信息
+     *
+     * @return 插件信息
+     */
     @GetMapping("/getPluginsInfo")
     public String getPluginsInfo() {
         return JSONObject.toJSONString(getHeartbeatMessageCache());

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/memory/MemoryClientImpl.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/memory/MemoryClientImpl.java
@@ -47,11 +47,17 @@ import java.util.stream.Collectors;
 @Component
 public class MemoryClientImpl implements EventDao {
     private ExpiringMap<String, QueryResultEventInfoEntity> eventMap;
+
     private ExpiringMap<String, InstanceMeta> agentInstanceMap;
+
     private ExpiringMap<String, Long> eventTimeKeyMap;
+
     private ExpiringMap<String, List<String>> sessionMap;
+
     private ExpiringMap<String, String> emergency;
+
     private ExpiringMap<String, String> important;
+
     private ExpiringMap<String, String> normal;
 
     /**
@@ -61,7 +67,7 @@ public class MemoryClientImpl implements EventDao {
      */
     public MemoryClientImpl(BackendConfig backendConfig) {
         this.eventMap = ExpiringMap.builder().expiration(
-                backendConfig.getEventExpire(), TimeUnit.DAYS)
+                        backendConfig.getEventExpire(), TimeUnit.DAYS)
                 .expirationPolicy(ExpirationPolicy.CREATED).build();
         this.agentInstanceMap = ExpiringMap.builder()
                 .expiration(backendConfig.getEventExpire(), TimeUnit.DAYS)
@@ -163,7 +169,9 @@ public class MemoryClientImpl implements EventDao {
      */
     public List<String> getQueryEventKey(long startTime, long endTime, String pattern) {
         List<Map.Entry<String, Long>> queryResultByTime = eventTimeKeyMap.entrySet().stream().filter(
-                s -> s.getValue() >= startTime && s.getValue() <= endTime && s.getKey().matches(pattern))
+                        ent -> ent.getValue() >= startTime
+                                && ent.getValue() <= endTime
+                                && ent.getKey().matches(pattern))
                 .collect(Collectors.toList());
         return queryResultByTime.stream().sorted(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey).collect(Collectors.toList());

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/redis/EventDaoForRedis.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/dao/redis/EventDaoForRedis.java
@@ -39,7 +39,6 @@ import java.util.List;
  * @since 2023-03-02
  */
 public class EventDaoForRedis implements EventDao {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(EventDaoForRedis.class);
 
     private EventDao jedis;
@@ -93,6 +92,7 @@ public class EventDaoForRedis implements EventDao {
     /**
      * 获取某一页数据
      *
+     * @param sessionId 会话ID
      * @param page 页码
      * @return 查询数据
      */
@@ -104,6 +104,7 @@ public class EventDaoForRedis implements EventDao {
     /**
      * 获取查询数据类型数量
      *
+     * @param eventsRequestEntity 事件请求体
      * @return 查询结果数量
      */
     @Override

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/entity/event/DingDingMessageType.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/entity/event/DingDingMessageType.java
@@ -27,7 +27,7 @@ public enum DingDingMessageType {
     /**
      * 文本
      */
-    Text("text"),
+    TEXT("text"),
 
     /**
      * 富文本

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/handler/EventPushHandler.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/handler/EventPushHandler.java
@@ -60,13 +60,13 @@ public class EventPushHandler {
      * 构造函数
      */
     public EventPushHandler() {
-        init();
+        this.init();
     }
 
     /**
      * 初始化webhook
      */
-    public void init() {
+    private void init() {
         ServiceLoader<WebHookClient> loader = ServiceLoader.load(WebHookClient.class);
         for (WebHookClient webHookClient : loader) {
             webHookClients.add(webHookClient);

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/server/EventServer.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/server/EventServer.java
@@ -17,6 +17,7 @@
 package com.huaweicloud.sermant.backend.server;
 
 import com.huaweicloud.sermant.backend.common.conf.BackendConfig;
+import com.huaweicloud.sermant.backend.dao.DatabaseType;
 import com.huaweicloud.sermant.backend.dao.EventDao;
 import com.huaweicloud.sermant.backend.dao.memory.MemoryClientImpl;
 import com.huaweicloud.sermant.backend.dao.redis.EventDaoForRedis;
@@ -32,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 
@@ -43,12 +45,13 @@ import javax.annotation.PostConstruct;
  */
 @Component
 public class EventServer {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(EventServer.class);
+
     private static EventServer eventServer;
 
     @Autowired
     private BackendConfig backendConfig;
+
     private EventDao daoService;
 
     private EventServer() {
@@ -60,13 +63,10 @@ public class EventServer {
     @PostConstruct
     public void init() {
         eventServer = this;
-        switch (backendConfig.getDatabase()) {
-            case REDIS:
-                eventServer.daoService = new EventDaoForRedis(backendConfig);
-                break;
-            default:
-                eventServer.daoService = new MemoryClientImpl(backendConfig);
-                break;
+        if (Objects.requireNonNull(backendConfig.getDatabase()) == DatabaseType.REDIS) {
+            eventServer.daoService = new EventDaoForRedis(backendConfig);
+        } else {
+            eventServer.daoService = new MemoryClientImpl(backendConfig);
         }
     }
 

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/server/ServerHandler.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/server/ServerHandler.java
@@ -71,12 +71,6 @@ public class ServerHandler extends BaseHandler {
     private EventServer eventServer;
 
     /**
-     * ServerHandler
-     */
-    public ServerHandler() {
-    }
-
-    /**
      * 初始化事件推送服务
      */
     @PostConstruct
@@ -165,6 +159,8 @@ public class ServerHandler extends BaseHandler {
 
     /**
      * 配置服务可见性数据有效时间
+     *
+     * @param instanceId 实例ID
      */
     private void setServiceValidityPeriod(String instanceId) {
         ServerInfo serverInfo = new ServerInfo();

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/util/DbUtils.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/util/DbUtils.java
@@ -49,7 +49,6 @@ import java.util.stream.Collectors;
  * @since 2023-03-02
  */
 public class DbUtils {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(DbUtils.class);
 
     private static final int EVENT_LEVEL_INDEX = 3;
@@ -175,7 +174,7 @@ public class DbUtils {
      * @return 过滤结果
      */
     public static List<Tuple> filterQueryResult(BackendConfig backendConfig,
-                                                 List<Tuple> queryResultByTime, String pattern) {
+            List<Tuple> queryResultByTime, String pattern) {
         List<Tuple> fanList = new ArrayList<>();
         if (queryResultByTime.size() <= 0) {
             return fanList;
@@ -206,9 +205,9 @@ public class DbUtils {
                 @Override
                 public List<Tuple> call() throws Exception {
                     List<Tuple> newList = new ArrayList<>();
-                    for (Tuple a : finalCutList) {
-                        if (a.getElement().matches(pattern)) {
-                            newList.add(a);
+                    for (Tuple tuple : finalCutList) {
+                        if (tuple.getElement().matches(pattern)) {
+                            newList.add(tuple);
                         }
                     }
                     return newList;

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/util/GzipUtils.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/util/GzipUtils.java
@@ -50,25 +50,17 @@ public class GzipUtils {
      * @return 压缩完成的数据
      */
     public static byte[] compress(byte[] data) {
-        ByteArrayInputStream bais = new ByteArrayInputStream(data);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        // 压缩
-        compress(bais, baos);
-        byte[] output = baos.toByteArray();
-        try {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            // 压缩
+            compress(bais, baos);
+            byte[] output = baos.toByteArray();
             baos.flush();
+            return output;
         } catch (IOException e) {
-            LOGGER.error("Exception occurs when compress. Exception info: {}", e);
-        } finally {
-            try {
-                baos.close();
-                bais.close();
-            } catch (IOException e) {
-                LOGGER.error("Exception occurs when close IOStream. Exception info: {}", e);
-            }
+            LOGGER.error("Exception occurs when compress or close IOStream. Exception info: {}", e.getMessage());
+            return new byte[0];
         }
-        return output;
     }
 
     /**
@@ -89,14 +81,14 @@ public class GzipUtils {
             gos.finish();
             gos.flush();
         } catch (IOException e) {
-            LOGGER.error("Exception occurs when compress. Exception info: {}", e);
+            LOGGER.error("Exception occurs when compress. Exception info: {}", e.getMessage());
         } finally {
             try {
                 if (gos != null) {
                     gos.close();
                 }
             } catch (IOException e) {
-                LOGGER.error("Exception occurs when close IOStream. Exception info: {}", e);
+                LOGGER.error("Exception occurs when close IOStream, Exception info: {}", e.getMessage());
             }
         }
     }
@@ -113,20 +105,20 @@ public class GzipUtils {
 
         // 解压缩
         decompress(bais, baos);
-        data = baos.toByteArray();
+        byte[] newData = baos.toByteArray();
         try {
             baos.flush();
         } catch (IOException e) {
-            LOGGER.error("Exception occurs when decompress. Exception info: {}", e);
+            LOGGER.error("Exception occurs when decompress. Exception info: {}", e.getMessage());
         } finally {
             try {
                 baos.close();
                 bais.close();
             } catch (IOException e) {
-                LOGGER.error("Exception occurs when close IOStream. Exception info: {}", e);
+                LOGGER.error("Exception occurs when close IOStream. Exception info: {}", e.getMessage());
             }
         }
-        return data;
+        return newData;
     }
 
     /**
@@ -145,14 +137,14 @@ public class GzipUtils {
                 os.write(data, 0, count);
             }
         } catch (IOException e) {
-            LOGGER.error("Exception occurs when decompress. Exception info: {}", e);
+            LOGGER.error("Exception occurs when decompress. Exception info: {}", e.getMessage());
         } finally {
             try {
                 if (gis != null) {
                     gis.close();
                 }
             } catch (IOException e) {
-                LOGGER.error("Exception occurs when close IOStream. Exception info: {}", e);
+                LOGGER.error("Exception occurs when close IOStream. Exception info: {}", e.getMessage());
             }
         }
     }

--- a/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/webhook/feishu/FeiShuHookClient.java
+++ b/sermant-backend/src/main/java/com/huaweicloud/sermant/backend/webhook/feishu/FeiShuHookClient.java
@@ -48,7 +48,6 @@ import java.util.List;
  * @since 2023-03-02
  */
 public class FeiShuHookClient implements WebHookClient {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(FeiShuHookClient.class);
 
     private final RestTemplate restTemplate = new RestTemplate();
@@ -69,11 +68,10 @@ public class FeiShuHookClient implements WebHookClient {
      * webhook推送事件
      *
      * @param events 事件信息
-     * @return
+     * @return 唤醒feishu的webhook结果
      */
     @Override
     public boolean doNotify(List<QueryResultEventInfoEntity> events) {
-
         FeiShuEntity feiShuEntity = new FeiShuEntity();
         feiShuEntity.setMsgType(FeiShuMessageType.POST.getType());
         feiShuEntity.setContent(new HashMap<String, Object>() {
@@ -126,7 +124,6 @@ public class FeiShuHookClient implements WebHookClient {
                 content.add(getContent("logLineNumber:" + logInfo.getLogLineNumber()));
                 content.add(getContent("logThreadId" + logInfo.getLogThreadId()));
                 content.add(getContent("throwable:" + logInfo.getLogThrowable()));
-
             } else {
                 EventInfo eventInfo = (EventInfo) event.getInfo();
                 content.add(getContent("name:" + eventInfo.getName()));


### PR DESCRIPTION
【Fix issue】#1365

【Modified content】
The codecheck problems in the existing code have been modified, which are mainly summarized into the following categories;
| mudule | codecheck |
| --- | --- |
| sermant-agentcore-core | Code that needs to use AccessController.doPrivileged for security permission checking |
| sermant-agentcore-core | RuntimeException should not be thrown directly |
| sermant-agentcore-core | Possible multi-thread conflict, double check lock required |
| sermant-agentcore-core | Unused import |
| sermant-agentcore-core | Javadoc issues |
| sermant-agentcore-core | Devil's numbers |
| sermant-agentcore-core | Space indentation |
| sermant-agentcore-core | Multiple Boolean expressions in conditional statements |
| sermant-agentcore-core | An extra comma is added to the last element when defining the array |
| sermant-agentcore-core | Lambda expressions should use 2 or more letters |
| sermant-agentcore-core | deprecated annotations should add doc comments |
| sermant-agentcore-core | Exception code block cannot be empty |
| sermant-agentcore-core | Rewriting compareTo should also rewrite hashCode and equals |
| sermant-agentcore-core | When the parent class overrides the method of Object, the subclass also needs to rewrite it |
| sermant-agentcore-core | return null problem |
| sermant-agentcore-core | Use EntrySet instead of KeySet when traversing Map |
| sermant-agentcore-core | After creating a thread through new Thread, you should use the setUncaughtExceptionHandler method to register a runtime exception Handler |
| sermant-agentcore-god | deprecated annotations should add doc comments |
| sermant-agentcore-god | Code that needs to use AccessController.doPrivileged for security permission checking |
| sermant-agentcore-god | RuntimeException should not be thrown directly |
| sermant-agentcore-implement | Javadoc issues |
| sermant-agentcore-implement | Space indentation |
| sermant-agentcore-implement | Unused import |
| sermant-agentcore-implement | When it is determined that the incoming variable is null, the value null should be passed directly instead of the empty variable |
| sermant-agentcore-implement | Static string application static final definition |
| sermant-agentcore-implement | The parent class constructor should not call methods that may be overridden by subclasses. Instead, use final or private to modify the method |
| sermant-agentcore-implement | Double check lock acquisition singleton should add volatile to the singleton |
| sermant-agentcore-implement | Input parameter variables should not be modified directly |
| sermant-agentcore-implement | Unused variables |
| sermant-agentcore-implement | Simple logic without using switch code blocks |
| sermant-agentcore-implement | Use EntrySet instead of KeySet when traversing Map |
| sermant-agentcore-premain | Log objects should be decorated with final |
| sermant-agentcore-premain | RuntimeException should not be thrown directly |
| sermant-backend | Space indentation |
| sermant-backend | The get and set method names of entity classes should be consistent with the variable names |
| sermant-backend | Javadoc issues |
| sermant-backend | Simple logic without using switch code block |
| sermant-backend | lambda expressions should use 2 or more characters |
| sermant-backend | Mold variables of enumeration classes should be capitalized |
| sermant-backend | The parent class constructor should not call methods that may be overridden by subclasses. Instead, use final or private to modify the method |
| sermant-backend | Delete empty public constructor |
| sermant-backend | Variable names should use 2 or more characters |
| sermant-backend | The close method should not be used within the try structure, but the try catch resources structure should be used |
| sermant-backend | Input parameter variables should not be modified directly |

[Use case description] No

[Self-test situation] 1. Local static check passed

[Scope of influence] None