### PR TITLE
Jdk17 plugin support problem fix: springboot registration plugin, traffic label transparent transmission test demo

### DIFF
--- a/sermant-integration-tests/tag-transmission-test/grpc-api-demo/pom.xml
+++ b/sermant-integration-tests/tag-transmission-test/grpc-api-demo/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>grpc-protobuf</artifactId>
             <version>${grpc.version}</version>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-service/pom.xml
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-service/pom.xml
@@ -25,7 +25,7 @@
             Curator 3.x.x只兼容Zookeeper 3.5.x-->
         <!--zk  3.4.x, 可向上兼容-->
         <curator.x.version>2.13.0</curator.x.version>
-        <zk.version>3.4.14</zk.version>
+        <zk.version>3.6.3</zk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
【Fix issue】#1283

【Modified content】
1. Modified the zookeeper version number of springboot registration plug-in
2. Modified the traffic label transparent transmission integration test dependency

[Use case description] No

[Self-test situation] 1. The local static check passed; 2. The local warehouse integration test passed

[Scope of influence] Document synchronization update