### PR TITLE
Message queue consumption prohibition plugin: dynamic configuration management module

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/config.properties
@@ -84,6 +84,8 @@ gateway.initReconnectInternalTime=5
 # 指定统一网关重连退避算法最大连接间隔（s）
 gateway.maxReconnectInternalTime=180
 #=============================元数据配置================================#
+# 指定服务名
+service.meta.service=default
 # 指定应用名称, 用于服务注册等服务治理场景
 service.meta.application=default
 # 指定服务版本, 用于服务注册、标签路由等服务治理场景

--- a/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
+++ b/sermant-agentcore/sermant-agentcore-config/config/test/config.properties
@@ -84,6 +84,8 @@ gateway.initReconnectInternalTime=5
 # 指定统一网关重连退避算法最大连接间隔（s）
 gateway.maxReconnectInternalTime=180
 #=============================元数据配置================================#
+# 指定服务名
+service.meta.service=default
 # 指定应用名称, 用于服务注册等服务治理场景
 service.meta.application=default
 # 指定服务版本, 用于服务注册、标签路由等服务治理场景

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/config/ServiceMeta.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/config/ServiceMeta.java
@@ -30,9 +30,19 @@ import java.util.Map;
 @ConfigTypeKey("service.meta")
 public class ServiceMeta implements BaseConfig {
     /**
+     * 默认配置值
+     */
+    public static final String DEFAULT = "default";
+
+    /**
+     * 服务名
+     */
+    private String service = DEFAULT;
+
+    /**
      * app名称 服务分组
      */
-    private String application = "default";
+    private String application = DEFAULT;
 
     /**
      * 当前版本
@@ -47,7 +57,7 @@ public class ServiceMeta implements BaseConfig {
     /**
      * 命名空间
      */
-    private String project = "default";
+    private String project = DEFAULT;
 
     /**
      * 环境
@@ -62,7 +72,7 @@ public class ServiceMeta implements BaseConfig {
     /**
      * 自定义标签值
      */
-    private String customLabelValue = "default";
+    private String customLabelValue = DEFAULT;
 
     private Map<String, String> parameters;
 
@@ -128,5 +138,13 @@ public class ServiceMeta implements BaseConfig {
 
     public void setParameters(Map<String, String> parameters) {
         this.parameters = parameters;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/CommonGroupConfigSubscriber.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/CommonGroupConfigSubscriber.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.core.plugin.subscribe;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.ConfigDataHolder;
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.ConfigOrderIntegratedProcessor;
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.ConfigProcessor;
+import com.huaweicloud.sermant.core.plugin.subscribe.processor.IntegratedEventListenerAdapter;
+import com.huaweicloud.sermant.core.service.dynamicconfig.DynamicConfigService;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+import com.huaweicloud.sermant.core.utils.LabelGroupUtils;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 通用配置订阅器
+ *
+ * @author lilai
+ * @since 2023-12-09
+ */
+public class CommonGroupConfigSubscriber extends AbstractGroupConfigSubscriber {
+    /**
+     * application的key
+     */
+    public static final String APP = "app";
+
+    /**
+     * service的key
+     */
+    public static final String SERVICE = "service";
+
+    /**
+     * environment的key
+     */
+    public static final String ENVIRONMENT = "environment";
+
+    /**
+     * zone的key
+     */
+    public static final String ZONE = "zone";
+
+    private static final int REQUEST_MAP_SIZE = 4;
+
+    private static final int CUSTOM_ORDER = 400;
+
+    private static final int ZONE_ORDER = 300;
+
+    private static final int APP_ORDER = 200;
+
+    private static final int SERVICE_ORDER = 100;
+
+    private final Map<String, DynamicConfigListener> listenerCache = new HashMap<>(REQUEST_MAP_SIZE);
+
+    private final String serviceName;
+
+    private final ServiceMeta config;
+
+    private final ConfigProcessor configOrderIntegratedProcessor;
+
+    /**
+     * 构造方法
+     *
+     * @param serviceName 服务名
+     * @param listener 监听器
+     * @param pluginName 插件名称
+     */
+    public CommonGroupConfigSubscriber(String serviceName, DynamicConfigListener listener, String pluginName) {
+        this(serviceName, listener, null, pluginName);
+    }
+
+    /**
+     * 自定义配置中心实现的构造方法
+     *
+     * @param serviceName 服务名
+     * @param listener 监听器
+     * @param dynamicConfigService 配置中心实现
+     * @param pluginName 插件名称
+     */
+    public CommonGroupConfigSubscriber(String serviceName, DynamicConfigListener listener,
+            DynamicConfigService dynamicConfigService, String pluginName) {
+        super(dynamicConfigService, pluginName);
+        this.serviceName = serviceName;
+        this.config = ConfigManager.getConfig(ServiceMeta.class);
+        this.configOrderIntegratedProcessor = new ConfigOrderIntegratedProcessor(listener);
+    }
+
+    @Override
+    protected Map<String, DynamicConfigListener> buildGroupSubscribers() {
+        buildAppRequest();
+        buildServiceRequest();
+        buildCustomRequest();
+        buildZoneRequest();
+        return listenerCache;
+    }
+
+    private void buildServiceRequest() {
+        final HashMap<String, String> map = new HashMap<>(REQUEST_MAP_SIZE);
+        map.put(APP, config.getApplication());
+        map.put(SERVICE, serviceName);
+        map.put(ENVIRONMENT, config.getEnvironment());
+        final String labelGroup = LabelGroupUtils.createLabelGroup(map);
+        listenerCache.put(labelGroup, new IntegratedEventListenerAdapter(configOrderIntegratedProcessor, labelGroup));
+        configOrderIntegratedProcessor.addHolder(new ConfigDataHolder(labelGroup, SERVICE_ORDER));
+    }
+
+    private void buildAppRequest() {
+        final HashMap<String, String> map = new HashMap<>(REQUEST_MAP_SIZE);
+        map.put(APP, config.getApplication());
+        map.put(ENVIRONMENT, config.getEnvironment());
+        final String labelGroup = LabelGroupUtils.createLabelGroup(map);
+        listenerCache.put(labelGroup, new IntegratedEventListenerAdapter(configOrderIntegratedProcessor, labelGroup));
+        configOrderIntegratedProcessor.addHolder(new ConfigDataHolder(labelGroup, APP_ORDER));
+    }
+
+    private void buildZoneRequest() {
+        final HashMap<String, String> map = new HashMap<>(REQUEST_MAP_SIZE);
+        map.put(APP, config.getApplication());
+        map.put(ENVIRONMENT, config.getEnvironment());
+        map.put(ZONE, config.getEnvironment());
+        final String labelGroup = LabelGroupUtils.createLabelGroup(map);
+        listenerCache.put(labelGroup, new IntegratedEventListenerAdapter(configOrderIntegratedProcessor, labelGroup));
+        configOrderIntegratedProcessor.addHolder(new ConfigDataHolder(labelGroup, ZONE_ORDER));
+    }
+
+    private void buildCustomRequest() {
+        if (StringUtils.isBlank(config.getCustomLabel()) || StringUtils.isBlank(config.getCustomLabelValue())) {
+            return;
+        }
+        final HashMap<String, String> map = new HashMap<>(REQUEST_MAP_SIZE);
+        map.put(config.getCustomLabel(), config.getCustomLabelValue());
+        final String labelGroup = LabelGroupUtils.createLabelGroup(map);
+        listenerCache.put(labelGroup, new IntegratedEventListenerAdapter(configOrderIntegratedProcessor, labelGroup));
+        configOrderIntegratedProcessor.addHolder(new ConfigDataHolder(labelGroup, CUSTOM_ORDER));
+    }
+
+    @Override
+    protected boolean isReady() {
+        return StringUtils.isNoneBlank(serviceName, config.getApplication());
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/config-service/pom.xml
+++ b/sermant-plugins/sermant-mq-consume-prohibition/config-service/pom.xml
@@ -9,11 +9,41 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>config-service</artifactId>
-
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>service</package.plugin.type>
+        <snakeyaml.version>2.0</snakeyaml.version>
     </properties>
+
+    <artifactId>config-service</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>consumer-controller</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/java/com/huaweicloud/sermant/mq/dynamicconfig/MqConfigListener.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/java/com/huaweicloud/sermant/mq/dynamicconfig/MqConfigListener.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.dynamicconfig;
+
+import com.huaweicloud.sermant.config.ProhibitionConfig;
+import com.huaweicloud.sermant.config.ProhibitionConfigManager;
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+import com.huaweicloud.sermant.kafka.controller.KafkaConsumerController;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.util.Locale;
+import java.util.logging.Logger;
+
+/**
+ * 消息队列禁止消费插件的动态配置监听器
+ *
+ * @author lilai
+ * @since 2023-12-08
+ */
+public class MqConfigListener implements DynamicConfigListener {
+    /**
+     * 全局配置的Key
+     */
+    public static final String GLOBAL_CONFIG_KEY = "sermant.mq.consume.globalConfig";
+
+    /**
+     * 局部配置的key的前缀
+     */
+    public static final String LOCAL_CONFIG_KEY_PREFIX = "sermant.mq.consume.";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private final Yaml yaml;
+
+    /**
+     * 监听器构造方法
+     */
+    public MqConfigListener() {
+        Representer representer = new Representer(new DumperOptions());
+        representer.getPropertyUtils().setSkipMissingProperties(true);
+        this.yaml = new Yaml(representer);
+    }
+
+    @Override
+    public void process(DynamicConfigEvent event) {
+        try {
+            if (event.getEventType() == DynamicConfigEventType.INIT) {
+                processInitEvent(event);
+                return;
+            }
+
+            if (event.getEventType() == DynamicConfigEventType.DELETE) {
+                processDeleteEvent(event);
+                return;
+            }
+            processCreateOrUpdateEvent(event);
+        } catch (YAMLException e) {
+            LOGGER.severe(String.format(Locale.ROOT, "Fail to convert dynamic mq-consume-prohibition config, %s",
+                    e.getMessage()));
+        }
+    }
+
+    /**
+     * 处理创建或者更新配置的事件
+     *
+     * @param event 事件
+     */
+    private void processCreateOrUpdateEvent(DynamicConfigEvent event) {
+        if (GLOBAL_CONFIG_KEY.equals(event.getKey())) {
+            ProhibitionConfigManager.updateGlobalConfig(yaml.loadAs(event.getContent(), ProhibitionConfig.class));
+            executeProhibition();
+        }
+        if ((LOCAL_CONFIG_KEY_PREFIX + ConfigManager.getConfig(ServiceMeta.class).getService()).equals(
+                event.getKey())) {
+            ProhibitionConfigManager.updateLocalConfig(yaml.loadAs(event.getContent(), ProhibitionConfig.class));
+            executeProhibition();
+        }
+        LOGGER.info(String.format(Locale.ROOT, "Update mq-consume-prohibition config, current config: %s",
+                ProhibitionConfigManager.printConfig()));
+    }
+
+    /**
+     * 处理删除配置的事件
+     *
+     * @param event 事件
+     */
+    private void processDeleteEvent(DynamicConfigEvent event) {
+        if (GLOBAL_CONFIG_KEY.equals(event.getKey())) {
+            ProhibitionConfigManager.updateGlobalConfig(new ProhibitionConfig());
+            executeProhibition();
+        }
+        if ((LOCAL_CONFIG_KEY_PREFIX + ConfigManager.getConfig(ServiceMeta.class).getService()).equals(
+                event.getKey())) {
+            ProhibitionConfigManager.updateLocalConfig(new ProhibitionConfig());
+            executeProhibition();
+        }
+        LOGGER.info(String.format(Locale.ROOT, "Delete mq-consume-prohibition config, current config: %s",
+                ProhibitionConfigManager.printConfig()));
+    }
+
+    private void executeProhibition() {
+        KafkaConsumerController.getConsumerCache()
+                .forEach(obj -> KafkaConsumerController.disableConsumption(obj,
+                        ProhibitionConfigManager.getKafkaProhibitionTopics()));
+    }
+
+    /**
+     * 处理启动时初始化配置的事件
+     *
+     * @param event 事件
+     */
+    private void processInitEvent(DynamicConfigEvent event) {
+        if (GLOBAL_CONFIG_KEY.equals(event.getKey())) {
+            ProhibitionConfigManager.updateGlobalConfig(
+                    yaml.loadAs(event.getContent(), ProhibitionConfig.class));
+        }
+        if ((LOCAL_CONFIG_KEY_PREFIX + ConfigManager.getConfig(ServiceMeta.class).getService()).equals(
+                event.getKey())) {
+            ProhibitionConfigManager.updateLocalConfig(
+                    yaml.loadAs(event.getContent(), ProhibitionConfig.class));
+        }
+        LOGGER.info(String.format(Locale.ROOT, "Init mq-consume-prohibition config, current config: %s",
+                ProhibitionConfigManager.printConfig()));
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/java/com/huaweicloud/sermant/mq/dynamicconfig/MqConfigService.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/java/com/huaweicloud/sermant/mq/dynamicconfig/MqConfigService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.dynamicconfig;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.plugin.service.PluginService;
+import com.huaweicloud.sermant.core.plugin.subscribe.CommonGroupConfigSubscriber;
+import com.huaweicloud.sermant.core.plugin.subscribe.ConfigSubscriber;
+
+import java.util.logging.Logger;
+
+/**
+ * 消息队列禁止消费的动态配置服务
+ *
+ * @author lilai
+ * @since 2023-12-08
+ */
+public class MqConfigService implements PluginService {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    public void start() {
+        ConfigSubscriber subscriber = new CommonGroupConfigSubscriber(
+                ConfigManager.getConfig(ServiceMeta.class).getService(),
+                new MqConfigListener(), "mq-consume-prohibition");
+        subscriber.subscribe();
+        LOGGER.info("Success to subscribe mq-consume-prohibition config");
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
+++ b/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.huaweicloud.sermant.mq.dynamicconfig.MqConfigService

--- a/sermant-plugins/sermant-mq-consume-prohibition/config/config.yaml
+++ b/sermant-plugins/sermant-mq-consume-prohibition/config/config.yaml
@@ -1,7 +1,0 @@
-kafka:
-  enableProhibition: true
-  topic:
-    - test1
-    - test2
-  rocketMq:
-    enableProhibition: true

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/config/ProhibitionConfig.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/config/ProhibitionConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.config;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 消息队列禁止消费配置
+ *
+ * @author lilai
+ * @since 2023-12-07
+ */
+public class ProhibitionConfig {
+    private boolean enableKafkaProhibition = false;
+
+    private Set<String> kafkaTopics = new HashSet<>();
+
+    private boolean enableRocketMqProhibition = false;
+
+    private Set<String> rocketMqTopics = new HashSet<>();
+
+    public boolean isEnableKafkaProhibition() {
+        return enableKafkaProhibition;
+    }
+
+    public void setEnableKafkaProhibition(boolean enableKafkaProhibition) {
+        this.enableKafkaProhibition = enableKafkaProhibition;
+    }
+
+    public Set<String> getKafkaTopics() {
+        return kafkaTopics;
+    }
+
+    public void setKafkaTopics(Set<String> kafkaTopics) {
+        this.kafkaTopics = kafkaTopics;
+    }
+
+    public boolean isEnableRocketMqProhibition() {
+        return enableRocketMqProhibition;
+    }
+
+    public void setEnableRocketMqProhibition(boolean enableRocketMqProhibition) {
+        this.enableRocketMqProhibition = enableRocketMqProhibition;
+    }
+
+    public Set<String> getRocketMqTopics() {
+        return rocketMqTopics;
+    }
+
+    public void setRocketMqTopics(Set<String> rocketMqTopics) {
+        this.rocketMqTopics = rocketMqTopics;
+    }
+
+    @Override
+    public String toString() {
+        return "enableKafkaProhibition=" + enableKafkaProhibition + ", kafkaTopics=" + kafkaTopics + "; "
+                + "enableRocketMqProhibition=" + enableRocketMqProhibition + ", rocketMqTopics=" + rocketMqTopics;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/config/ProhibitionConfigManager.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/config/ProhibitionConfigManager.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.config;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 消息队列禁止消费配置管理类
+ *
+ * @author lilai
+ * @since 2023-12-07
+ */
+public class ProhibitionConfigManager {
+    private static ProhibitionConfig globalConfig = new ProhibitionConfig();
+
+    private static ProhibitionConfig localConfig = new ProhibitionConfig();
+
+    private ProhibitionConfigManager() {
+    }
+
+    /**
+     * 获取kafka要禁止消费的Topic集合
+     *
+     * @return kafka要禁止消费的Topic集合
+     */
+    public static Set<String> getKafkaProhibitionTopics() {
+        if (globalConfig.isEnableKafkaProhibition()) {
+            return globalConfig.getKafkaTopics();
+        }
+        if (localConfig.isEnableKafkaProhibition()) {
+            return localConfig.getKafkaTopics();
+        }
+        return new HashSet<>();
+    }
+
+    /**
+     * 获取rocketmq要禁止消费的Topic集合
+     *
+     * @return rocketmq要禁止消费的Topic集合
+     */
+    public static Set<String> getRocketMqProhibitionTopics() {
+        if (globalConfig.isEnableRocketMqProhibition()) {
+            return globalConfig.getRocketMqTopics();
+        }
+        if (localConfig.isEnableRocketMqProhibition()) {
+            return localConfig.getRocketMqTopics();
+        }
+        return new HashSet<>();
+    }
+
+    /**
+     * 获取全局配置
+     *
+     * @return 全局配置
+     */
+    public static ProhibitionConfig getGlobalConfig() {
+        return globalConfig;
+    }
+
+    /**
+     * 获取局部配置
+     *
+     * @return 局部配置
+     */
+    public ProhibitionConfig getLocalConfig() {
+        return localConfig;
+    }
+
+    /**
+     * 更新全局配置
+     *
+     * @param config 禁止消费配置
+     */
+    public static void updateGlobalConfig(ProhibitionConfig config) {
+        if (config == null) {
+            globalConfig = new ProhibitionConfig();
+            return;
+        }
+        globalConfig = config;
+    }
+
+    /**
+     * 更新局部配置
+     *
+     * @param config 禁止消费配置
+     */
+    public static void updateLocalConfig(ProhibitionConfig config) {
+        if (config == null) {
+            localConfig = new ProhibitionConfig();
+            return;
+        }
+        localConfig = config;
+    }
+
+    /**
+     * 打印配置信息
+     *
+     * @return 配置信息
+     */
+    public static String printConfig() {
+        return "Global ProhibitionConfig: " + globalConfig.toString() + "; Local ProhibitionConfig: "
+                + localConfig.toString();
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/kafka/controller/KafkaConsumerController.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/kafka/controller/KafkaConsumerController.java
@@ -59,4 +59,13 @@ public class KafkaConsumerController {
     public static void updateConsumerCache(KafkaConsumer<?, ?> kafkaConsumer) {
         KafkaConsumerCache.INSTANCE.updateCache(kafkaConsumer);
     }
+
+    /**
+     * 获取消费者缓存
+     *
+     * @return 消费者缓存
+     */
+    public static Set<KafkaConsumerWrapper> getConsumerCache() {
+        return KafkaConsumerCache.INSTANCE.getCache();
+    }
 }


### PR DESCRIPTION
【Fix issue】#1379

[Modification] Add the dynamic configuration management module of the message queue consumption ban plug-in
(1) service.meta adds service configuration
(2) Disable consumer plug-ins to monitor Group: app=${appName}&environment=${environmentName}&zone=${zoneName}, Key: sermant.mq.consume.globalConfig and sermant.mq.consume.${serviceName}
(3) Process and configure various events, and provide corresponding interfaces to obtain topics that need to be prohibited from consumption.

[Use case description] None, will be added later

[Self-test status] 1. Local static check and cleanup passed; 2. Dynamic configuration self-test passed

[Scope of influence] None