### PR TITLE
Rocketmq consumption prohibition plugin: controller

### DIFF
--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/cache/RocketMqConsumerCache.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/cache/RocketMqConsumerCache.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.cache;
+
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * rocketmq消费者缓存
+ *
+ * @author daizhenyu
+ * @since 2023-12-04
+ **/
+public class RocketMqConsumerCache {
+    /**
+     * push消费者wrapper缓存
+     */
+    public static final Set<DefaultMqPushConsumerWrapper> PUSH_CONSUMERS_CACHE =
+            new CopyOnWriteArraySet<>();
+
+    /**
+     * pull消费者wrapper缓存
+     */
+    public static final Set<DefaultLitePullConsumerWrapper> PULL_CONSUMERS_CACHE =
+            new CopyOnWriteArraySet<>();
+
+    private RocketMqConsumerCache() {
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/constant/SubscriptionType.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/constant/SubscriptionType.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.constant;
+
+/**
+ * rocketmq pull消费者订阅方式枚举类
+ *
+ * @author daizhenyu
+ * @since 2023-12-05
+ **/
+public enum SubscriptionType {
+    /**
+     * 订阅方式为NONE
+     */
+    NONE("NONE"),
+    /**
+     * 通过订阅topic进行消费
+     */
+    SUBSCRIBE("SUBSCRIBE"),
+    /**
+     * 通过指定队列进行消费
+     */
+    ASSIGN("ASSIGN");
+
+    private final String subscriptionName;
+
+    SubscriptionType(String subscriptionName) {
+        this.subscriptionName = subscriptionName;
+    }
+
+    public String getSubscriptionTypeName() {
+        return this.subscriptionName;
+    }
+
+    /**
+     * 用于根据订阅方式名称获取订阅枚举对象
+     *
+     * @param name 订阅方式名称
+     * @return SubscriptionType
+     */
+    public static SubscriptionType getSubscriptionTypeByName(String name) {
+        for (SubscriptionType value : values()) {
+            if (value.getSubscriptionTypeName().equals(name)) {
+                return value;
+            }
+        }
+        return NONE;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/extension/RocketMqConsumerHandler.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/extension/RocketMqConsumerHandler.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.extension;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
+/**
+ * RocketmqConsumer处理器接口，供外部实现在rocketmq消费者拦截点执行扩展操作
+ *
+ * @author daizhenyu
+ * @since 2023-12-13
+ **/
+public interface RocketMqConsumerHandler {
+    /**
+     * 拦截点前置处理
+     *
+     * @param context 上下文信息
+     */
+    void doBefore(ExecuteContext context);
+
+    /**
+     * 拦截点后置处理
+     *
+     * @param context 上下文信息
+     */
+    void doAfter(ExecuteContext context);
+
+    /**
+     * 拦截点异常处理
+     *
+     * @param context 上下文信息
+     */
+    void doOnThrow(ExecuteContext context);
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/AbstractConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/AbstractConsumerWrapper.java
@@ -1,0 +1,198 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.wrapper;
+
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 消费者包装抽象类
+ *
+ * @author daizhenyu
+ * @since 2023-12-04
+ **/
+public abstract class AbstractConsumerWrapper {
+    /**
+     * rocketmq消费者的私有属性，用于加入或退出消费者组
+     */
+    protected final MQClientInstance clientFactory;
+
+    /**
+     * 消费者是否已经禁止消费
+     */
+    protected boolean pause = false;
+
+    /**
+     * nameserver地址
+     */
+    protected String nameServerAddress;
+
+    /**
+     * rocketmq消费者组
+     */
+    protected String consumerGroup;
+
+    /**
+     * 消费者实例ip
+     */
+    protected String clientIp;
+
+    /**
+     * 消费者实例名称
+     */
+    protected String instanceName;
+
+    /**
+     * 当前消费者的服务所在可用区
+     */
+    protected String zone;
+
+    /**
+     * 当前消费者的服务所在可用区命名空间
+     */
+    protected String project;
+
+    /**
+     * 当前消费者的服务所在环境
+     */
+    protected String environment;
+
+    /**
+     * 当前消费者的服务所在应用
+     */
+    protected String application;
+
+    /**
+     * 当前消费者所在服务的名称
+     */
+    protected String service;
+
+    /**
+     * 消费者已订阅消费主题
+     */
+    protected Set<String> subscribedTopics = new HashSet<>();
+
+    /**
+     * 有参构造方法
+     *
+     * @param clientFactory 消费者内部工厂类
+     */
+    protected AbstractConsumerWrapper(MQClientInstance clientFactory) {
+        this.clientFactory = clientFactory;
+    }
+
+    /**
+     * 初始化消费者实例的信息
+     */
+    protected abstract void initClientInfo();
+
+    public boolean isPause() {
+        return pause;
+    }
+
+    public void setPause(boolean pause) {
+        this.pause = pause;
+    }
+
+    public MQClientInstance getClientFactory() {
+        return clientFactory;
+    }
+
+    public String getNameServerAddress() {
+        return nameServerAddress;
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public String getZone() {
+        return zone;
+    }
+
+    public void setZone(String zone) {
+        this.zone = zone;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
+    }
+
+    public Set<String> getSubscribedTopics() {
+        return subscribedTopics;
+    }
+
+    public void setSubscribedTopics(Set<String> subscribedTopics) {
+        this.subscribedTopics = subscribedTopics;
+    }
+
+    /**
+     * 添加订阅的topic
+     *
+     * @param topic 订阅的主题
+     */
+    public void addSubscribedTopics(String topic) {
+        this.subscribedTopics.add(topic);
+    }
+
+    /**
+     * 移除取消订阅的topic
+     *
+     * @param topic 取消订阅的主题
+     */
+    public void removeSubscribedTopics(String topic) {
+        this.subscribedTopics.remove(topic);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultLitePullConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultLitePullConsumerWrapper.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.wrapper;
+
+import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
+
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
+import org.apache.rocketmq.client.impl.consumer.RebalanceImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.apache.rocketmq.common.message.MessageQueue;
+
+import java.util.Collection;
+
+/**
+ * DefaultLitePullConsumer包装类
+ *
+ * @author daizhenyu
+ * @since 2023-12-04
+ **/
+public class DefaultLitePullConsumerWrapper extends AbstractConsumerWrapper {
+    private final DefaultLitePullConsumer pullConsumer;
+
+    private final DefaultLitePullConsumerImpl pullConsumerImpl;
+
+    private final RebalanceImpl rebalanceImpl;
+
+    private Collection<MessageQueue> assignedMessageQueues;
+
+    private SubscriptionType subscriptionType = SubscriptionType.NONE;
+
+    /**
+     * 有参构造方法
+     *
+     * @param pullConsumer pull消费者
+     * @param pullConsumerImpl 内部pull消费者
+     * @param rebalanceImpl 重平衡实现类
+     * @param clientFactory rocketmq客户端工厂类
+     */
+    public DefaultLitePullConsumerWrapper(DefaultLitePullConsumer pullConsumer,
+            DefaultLitePullConsumerImpl pullConsumerImpl, RebalanceImpl rebalanceImpl,
+            MQClientInstance clientFactory) {
+        super(clientFactory);
+        this.pullConsumer = pullConsumer;
+        this.pullConsumerImpl = pullConsumerImpl;
+        this.rebalanceImpl = rebalanceImpl;
+        initClientInfo();
+    }
+
+    @Override
+    protected void initClientInfo() {
+        ClientConfig clientConfig = clientFactory.getClientConfig();
+        nameServerAddress = clientConfig.getClientIP();
+        clientIp = clientConfig.getClientIP();
+        instanceName = clientConfig.getInstanceName();
+        consumerGroup = pullConsumer.getConsumerGroup();
+    }
+
+    public void setAssignedMessageQueues(
+            Collection<MessageQueue> assignedMessageQueues) {
+        this.assignedMessageQueues = assignedMessageQueues;
+    }
+
+    public void setSubscriptionType(SubscriptionType subscriptionType) {
+        this.subscriptionType = subscriptionType;
+    }
+
+    public DefaultLitePullConsumer getPullConsumer() {
+        return pullConsumer;
+    }
+
+    public DefaultLitePullConsumerImpl getPullConsumerImpl() {
+        return pullConsumerImpl;
+    }
+
+    public RebalanceImpl getRebalanceImpl() {
+        return rebalanceImpl;
+    }
+
+    public Collection<MessageQueue> getAssignedMessageQueues() {
+        return assignedMessageQueues;
+    }
+
+    public SubscriptionType getSubscriptionType() {
+        return subscriptionType;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultMqPushConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultMqPushConsumerWrapper.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.wrapper;
+
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.impl.consumer.DefaultMQPushConsumerImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+
+/**
+ * DefaultMQPushConsumer包装类
+ *
+ * @author daizhenyu
+ * @since 2023-12-04
+ **/
+public class DefaultMqPushConsumerWrapper extends AbstractConsumerWrapper {
+    private final DefaultMQPushConsumer pushConsumer;
+
+    private final DefaultMQPushConsumerImpl pushConsumerImpl;
+
+    /**
+     * 有参构造方法
+     *
+     * @param consumer push消费者
+     * @param pushConsumerImpl 内部push消费者
+     * @param clientFactory rocketmq客户端工厂类
+     */
+    public DefaultMqPushConsumerWrapper(DefaultMQPushConsumer consumer, DefaultMQPushConsumerImpl pushConsumerImpl,
+            MQClientInstance clientFactory) {
+        super(clientFactory);
+        this.pushConsumer = consumer;
+        this.pushConsumerImpl = pushConsumerImpl;
+    }
+
+    @Override
+    protected void initClientInfo() {
+        ClientConfig clientConfig = clientFactory.getClientConfig();
+        nameServerAddress = clientConfig.getClientIP();
+        clientIp = clientConfig.getClientIP();
+        instanceName = clientConfig.getInstanceName();
+        consumerGroup = pushConsumer.getConsumerGroup();
+    }
+
+    public DefaultMQPushConsumer getPushConsumer() {
+        return pushConsumer;
+    }
+
+    public DefaultMQPushConsumerImpl getPushConsumerImpl() {
+        return pushConsumerImpl;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtils.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtils.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.utils;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.rocketmq.wrapper.AbstractConsumerWrapper;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
+
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
+import org.apache.rocketmq.client.impl.consumer.DefaultMQPushConsumerImpl;
+import org.apache.rocketmq.client.impl.consumer.RebalanceImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+
+import java.util.Optional;
+
+/**
+ * 消费者包装工具类
+ *
+ * @author daizhenyu
+ * @since 2023-12-14
+ **/
+public class RocketmqWrapperUtils {
+    private RocketmqWrapperUtils() {
+    }
+
+    /**
+     * 包装PullConsumer
+     *
+     * @param pullConsumer
+     * @return PullConsumer包装类实例
+     */
+    public static Optional<DefaultLitePullConsumerWrapper> wrapPullConsumer(
+            DefaultLitePullConsumer pullConsumer) {
+        // 获取消费者相关的defaultLitePullConsumerImpl、rebalanceImpl和mQClientFactory属性值，若获取失败说明消费者启动失败，不缓存该消费者
+        Optional<DefaultLitePullConsumerImpl> pullConsumerImplOptional = getPullConsumerImpl(pullConsumer);
+        if (!pullConsumerImplOptional.isPresent()) {
+            return Optional.empty();
+        }
+        DefaultLitePullConsumerImpl pullConsumerImpl = pullConsumerImplOptional.get();
+
+        Optional<RebalanceImpl> rebalanceImplOptional = getRebalanceImpl(pullConsumerImpl);
+        if (!rebalanceImplOptional.isPresent()) {
+            return Optional.empty();
+        }
+        RebalanceImpl rebalanceImpl = rebalanceImplOptional.get();
+
+        Optional<MQClientInstance> clientFactoryOptional = getClientFactory(pullConsumerImpl);
+        if (!clientFactoryOptional.isPresent()) {
+            return Optional.empty();
+        }
+        MQClientInstance clientFactory = clientFactoryOptional.get();
+
+        DefaultLitePullConsumerWrapper wrapper = new DefaultLitePullConsumerWrapper(pullConsumer, pullConsumerImpl,
+                rebalanceImpl, clientFactory);
+        initWrapperServiceMeta(wrapper);
+        return Optional.of(wrapper);
+    }
+
+    /**
+     * 包装PushConsumer
+     *
+     * @param pushConsumer
+     * @return PushConsumer包装类实例
+     */
+    public static Optional<DefaultMqPushConsumerWrapper> wrapPushConsumer(DefaultMQPushConsumer pushConsumer) {
+        DefaultMQPushConsumerImpl pushConsumerImpl = pushConsumer.getDefaultMQPushConsumerImpl();
+        MQClientInstance mqClientFactory = pushConsumerImpl.getmQClientFactory();
+
+        // 获取消费者相关的defaultMQPushConsumerImpl和mQClientFactory属性值，若属性值为null，不缓存该消费者;
+        if (pushConsumerImpl != null && mqClientFactory != null) {
+            DefaultMqPushConsumerWrapper wrapper = new DefaultMqPushConsumerWrapper(pushConsumer, pushConsumerImpl,
+                    mqClientFactory);
+            initWrapperServiceMeta(wrapper);
+            return Optional.of(wrapper);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<DefaultLitePullConsumerImpl> getPullConsumerImpl(DefaultLitePullConsumer pullConsumer) {
+        Optional<Object> consumerImplOptional = ReflectUtils
+                .getFieldValue(pullConsumer, "defaultLitePullConsumerImpl");
+        if (consumerImplOptional.isPresent()
+                && consumerImplOptional.get() instanceof DefaultLitePullConsumerImpl) {
+            return Optional.of((DefaultLitePullConsumerImpl) consumerImplOptional.get());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<RebalanceImpl> getRebalanceImpl(DefaultLitePullConsumerImpl pullConsumerImpl) {
+        Optional<Object> rebalanceImplOptional = ReflectUtils.getFieldValue(pullConsumerImpl, "rebalanceImpl");
+        if (rebalanceImplOptional.isPresent()
+                && rebalanceImplOptional.get() instanceof RebalanceImpl) {
+            return Optional.of((RebalanceImpl) rebalanceImplOptional.get());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<MQClientInstance> getClientFactory(DefaultLitePullConsumerImpl pullConsumerImpl) {
+        Optional<Object> clientFactoryOptional = ReflectUtils.getFieldValue(pullConsumerImpl,
+                "mQClientFactory");
+        if (clientFactoryOptional.isPresent()) {
+            return Optional.of((MQClientInstance) clientFactoryOptional.get());
+        }
+        return Optional.empty();
+    }
+
+    private static void initWrapperServiceMeta(AbstractConsumerWrapper wrapper) {
+        ServiceMeta serviceMeta = ConfigManager.getConfig(ServiceMeta.class);
+        wrapper.setZone(serviceMeta.getZone());
+        wrapper.setProject(serviceMeta.getProject());
+        wrapper.setEnvironment(serviceMeta.getEnvironment());
+        wrapper.setApplication(serviceMeta.getApplication());
+        wrapper.setService(serviceMeta.getService());
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/pom.xml
+++ b/sermant-plugins/sermant-mq-consume-prohibition/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <sermant.basedir>${pom.basedir}/../../..</sermant.basedir>
         <package.plugin.name>mq-consume-prohibition</package.plugin.name>
+        <rocketmq-client.version>4.9.7</rocketmq-client.version>
     </properties>
 
     <dependencyManagement>
@@ -23,6 +24,11 @@
                 <groupId>com.huaweicloud.sermant</groupId>
                 <artifactId>message-common</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.rocketmq</groupId>
+                <artifactId>rocketmq-client</artifactId>
+                <version>${rocketmq-client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -37,6 +43,7 @@
                 <module>kafka-1.x-plugin</module>
                 <module>consumer-controller</module>
                 <module>config-service</module>
+                <module>rocketmq-plugin</module>
             </modules>
         </profile>
         <profile>
@@ -45,6 +52,7 @@
                 <module>kafka-1.x-plugin</module>
                 <module>consumer-controller</module>
                 <module>config-service</module>
+                <module>rocketmq-plugin</module>
             </modules>
         </profile>
         <profile>
@@ -53,6 +61,7 @@
                 <module>kafka-1.x-plugin</module>
                 <module>consumer-controller</module>
                 <module>config-service</module>
+                <module>rocketmq-plugin</module>
             </modules>
         </profile>
     </profiles>

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/pom.xml
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/pom.xml
@@ -9,10 +9,13 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>consumer-controller</artifactId>
+    <artifactId>rocketmq-plugin</artifactId>
+
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>plugin</package.plugin.type>
     </properties>
 
     <dependencies>
@@ -22,15 +25,37 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>1.1.0</version>
-            <scope>provided</scope>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>consumer-controller</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-client</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
【Fix issue】#1379

【Modified content】
1. Added a controller module for rocketmq to prohibit consumption, including consumer packaging class and extended handler

[Use case description] No

[Self-test status] 1. Local static check passed 2. UT will be supplemented later.
[Scope of Impact] Integration testing and plug-in usage documentation need to be added in the future.