### PR TITLE
Bug fix: Sermant logs are output to host server logs.

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/AgentCoreEntrance.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/AgentCoreEntrance.java
@@ -87,10 +87,13 @@ public class AgentCoreEntrance {
         artifactCache = artifact;
         adviserCache = new DefaultAdviser();
 
+        // 初始化默认日志，在未加载日志引擎前保证日志可用
+        LoggerFactory.initDefaultLogger(artifact);
+
         // 初始化框架类加载器
         ClassLoaderManager.init(argsMap);
 
-        // 初始化日志
+        // 初始化日志，用于添加SermantBridgeHandler
         LoggerFactory.init(artifact);
 
         // 通过启动配置构建路径索引

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/common/LoggerFactory.java
@@ -69,6 +69,16 @@ public class LoggerFactory {
     }
 
     /**
+     * 初始化默认日志
+     *
+     * @param artifact 归属产品
+     */
+    public static void initDefaultLogger(String artifact) {
+        // 初始化默认日志，默认日志名必须为 sermant.<artifact>，通过这种方式，才能添加上SermantBridgeHandler
+        defaultLogger = java.util.logging.Logger.getLogger("sermant." + artifact);
+    }
+
+    /**
      * 获取jul日志
      *
      * @return jul日志

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/NetworkInterfacesCheckException.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/exception/NetworkInterfacesCheckException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.core.exception;
+
+/**
+ * 网络接口检查异常
+ *
+ * @author luanwenfei
+ * @since 2023-12-18
+ */
+public class NetworkInterfacesCheckException extends RuntimeException {
+    /**
+     * 网络接口检查异常
+     *
+     * @param message 异常信息
+     */
+    public NetworkInterfacesCheckException(String message) {
+        super(message);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
@@ -105,7 +105,7 @@ public class PluginClassLoader extends URLClassLoader {
                 } catch (ClassNotFoundException e) {
                     // 捕获类找不到的异常，下一步会进入localLoader中去加载类
                     // ignored
-                    LOGGER.log(Level.WARNING, "load class failed, msg is {0}", e.getMessage());
+                    LOGGER.log(Level.FINE, "Load class failed, msg is {0}", e.getMessage());
                 }
             }
 
@@ -123,7 +123,7 @@ public class PluginClassLoader extends URLClassLoader {
                         clazz = loader.loadClass(name);
                     } catch (ClassNotFoundException e) {
                         // 无法找到类，忽略，后续抛出异常
-                        LOGGER.log(Level.WARNING, "load class failed, msg is {0}", e.getMessage());
+                        LOGGER.log(Level.FINE, "Load class failed, msg is {0}", e.getMessage());
                     }
                 }
             }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/NetworkUtils.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/utils/NetworkUtils.java
@@ -17,7 +17,7 @@
 package com.huaweicloud.sermant.core.utils;
 
 import com.huaweicloud.sermant.core.common.LoggerFactory;
-import com.huaweicloud.sermant.core.exception.NetInterfacesCheckException;
+import com.huaweicloud.sermant.core.exception.NetworkInterfacesCheckException;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -61,7 +61,7 @@ public class NetworkUtils {
         try {
             Enumeration<NetworkInterface> netInterfaces = NetworkInterface.getNetworkInterfaces();
             if (netInterfaces == null) {
-                throw new NetInterfacesCheckException("netInterfaces is null");
+                throw new NetworkInterfacesCheckException("netInterfaces is null");
             }
             InetAddress ip;
             while (netInterfaces.hasMoreElements()) {
@@ -100,6 +100,5 @@ public class NetworkUtils {
         } catch (UnknownHostException e) {
             return Optional.empty();
         }
-
     }
 }


### PR DESCRIPTION
【Fix issue】#1381
[Modification content] 1. Modified the initialization timing of defaultLogger in LoggerFactory 2. Modified the text description of log printing in PluginClassLoader
[Use case description] No
[Self-test situation] 1. Local static check passed 2. Start service check and no longer output logs to the host service
[Scope of influence] None