### PR TITLE
Rocketmq consumption prohibition plugin: add consumer's controller and interceptor.

### DIFF
--- a/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/java/com/huaweicloud/sermant/mq/dynamicconfig/MqConfigListener.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/config-service/src/main/java/com/huaweicloud/sermant/mq/dynamicconfig/MqConfigListener.java
@@ -25,6 +25,8 @@ import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEv
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
 import com.huaweicloud.sermant.kafka.controller.KafkaConsumerController;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPullConsumerController;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPushConsumerController;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -125,6 +127,12 @@ public class MqConfigListener implements DynamicConfigListener {
         KafkaConsumerController.getConsumerCache()
                 .forEach(obj -> KafkaConsumerController.disableConsumption(obj,
                         ProhibitionConfigManager.getKafkaProhibitionTopics()));
+        RocketMqPushConsumerController.getPushConsumerCache().entrySet()
+                .forEach(obj -> RocketMqPushConsumerController.disablePushConsumption(obj.getValue(),
+                        ProhibitionConfigManager.getRocketMqProhibitionTopics()));
+        RocketMqPullConsumerController.getPullConsumerCache().entrySet()
+                .forEach(obj -> RocketMqPullConsumerController.disablePullConsumption(obj.getValue(),
+                        ProhibitionConfigManager.getRocketMqProhibitionTopics()));
     }
 
     /**

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/cache/RocketMqConsumerCache.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/cache/RocketMqConsumerCache.java
@@ -19,8 +19,8 @@ package com.huaweicloud.sermant.rocketmq.cache;
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * rocketmq消费者缓存
@@ -32,14 +32,14 @@ public class RocketMqConsumerCache {
     /**
      * push消费者wrapper缓存
      */
-    public static final Set<DefaultMqPushConsumerWrapper> PUSH_CONSUMERS_CACHE =
-            new CopyOnWriteArraySet<>();
+    public static final Map<Integer, DefaultMqPushConsumerWrapper> PUSH_CONSUMERS_CACHE =
+            new ConcurrentHashMap<>();
 
     /**
      * pull消费者wrapper缓存
      */
-    public static final Set<DefaultLitePullConsumerWrapper> PULL_CONSUMERS_CACHE =
-            new CopyOnWriteArraySet<>();
+    public static final Map<Integer, DefaultLitePullConsumerWrapper> PULL_CONSUMERS_CACHE =
+            new ConcurrentHashMap<>();
 
     private RocketMqConsumerCache() {
     }

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerController.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerController.java
@@ -1,0 +1,321 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.controller;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.utils.ReflectUtils;
+import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.impl.consumer.AssignedMessageQueue;
+import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
+import org.apache.rocketmq.client.impl.consumer.RebalanceImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.heartbeat.SubscriptionData;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * pull消费者控制类
+ *
+ * @author daizhenyu
+ * @since 2023-12-15
+ **/
+public class RocketMqPullConsumerController {
+    private static final long DELAY_TIME = 1000L;
+
+    private static final int MAXIMUM_RETRY = 5;
+
+    private static final int THREAD_SIZE = 1;
+
+    private static final long THREAD_KEEP_ALIVE_TIME = 60L;
+
+    private static final int THREAD_QUEUE_CAPACITY = 20;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private static volatile ThreadPoolExecutor executor;
+
+    private RocketMqPullConsumerController() {
+    }
+
+    /**
+     * 禁止pull消费者消费
+     *
+     * @param wrapper pull消费者wrapper
+     * @param topics 禁止消费的topic
+     */
+    public static void disablePullConsumption(DefaultLitePullConsumerWrapper wrapper, Set<String> topics) {
+        Set<String> subscribedTopic = wrapper.getSubscribedTopics();
+        if (subscribedTopic.stream().anyMatch(topics::contains)) {
+            suspendPullConsumer(wrapper);
+            return;
+        }
+        resumePullConsumer(wrapper);
+    }
+
+    private static void suspendPullConsumer(DefaultLitePullConsumerWrapper wrapper) {
+        switch (wrapper.getSubscriptionType()) {
+            case SUBSCRIBE:
+                suspendSubscriptiveConsumer(wrapper);
+                break;
+            case ASSIGN:
+                suspendAssignedConsumer(wrapper);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static void suspendSubscriptiveConsumer(DefaultLitePullConsumerWrapper wrapper) {
+        if (wrapper.isProhibition()) {
+            LOGGER.log(Level.INFO, "Consumer has prohibited consumption, consumer instance name : {0}, "
+                            + "consumer group : {1}, topic : {2}",
+                    new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(), wrapper.getSubscribedTopics()});
+            return;
+        }
+
+        // 退出消费者前主动提交消费的offset，退出消费者组后立刻触发一次重平衡，重新分配队列
+        wrapper.getPullConsumerImpl().persistConsumerOffset();
+        wrapper.getClientFactory().unregisterConsumer(wrapper.getConsumerGroup());
+        doRebalance(wrapper);
+        wrapper.setProhibition(true);
+    }
+
+    private static void suspendAssignedConsumer(DefaultLitePullConsumerWrapper wrapper) {
+        DefaultLitePullConsumerImpl pullConsumerImpl = wrapper.getPullConsumerImpl();
+        if (wrapper.getAssignedMessageQueue() == null) {
+            Optional<AssignedMessageQueue> assignedMessageQueueOptional = RocketmqWrapperUtils
+                    .getAssignedMessageQueue(pullConsumerImpl);
+            if (assignedMessageQueueOptional.isPresent()) {
+                wrapper.setAssignedMessageQueue(assignedMessageQueueOptional.get());
+            }
+        }
+        AssignedMessageQueue assignedMessageQueue = wrapper.getAssignedMessageQueue();
+        assignedMessageQueue.updateAssignedMessageQueue(new ArrayList<>());
+        if (wrapper.getPullConsumer().isRunning()) {
+            ReflectUtils.invokeMethod(pullConsumerImpl, "updateAssignPullTask",
+                    new Class[]{Collection.class}, new Object[]{new ArrayList<>()});
+        }
+        LOGGER.log(Level.INFO, "Success to prohibit consumption, consumer instance name : {0}, consumer group : {1}, "
+                        + "message queue : {2}",
+                new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(),
+                        wrapper.getMessageQueues()});
+    }
+
+    private static void doRebalance(DefaultLitePullConsumerWrapper wrapper) {
+        initExecutor();
+
+        // 退出消费者组后立刻清理消费者目前消费的消息队列
+        messageQueueChanged(wrapper);
+
+        // 延时五秒后，确认是否退出消费者组，并在此清理消费者目前消费的消息队列，确保禁消费成功
+        executor.submit(() -> doDelayRebalance(wrapper));
+    }
+
+    private static void doDelayRebalance(DefaultLitePullConsumerWrapper wrapper) {
+        // 获取消费者的相关参数
+        RebalanceImpl rebalance = wrapper.getRebalanceImpl();
+        String instanceName = wrapper.getInstanceName();
+        String consumerGroup = wrapper.getConsumerGroup();
+        Set<String> subscribedTopics = wrapper.getSubscribedTopics();
+        MQClientInstance clientFactory = wrapper.getClientFactory();
+        String clientId = clientFactory.getClientId();
+
+        // 每间隔一秒，判断消费者是否退出消费者组，如果退出清空消费者消费的消息队列，最大重试次数为五次
+        int retryCount = 0;
+        boolean isConsumerGroupExited = false;
+        while ((retryCount < MAXIMUM_RETRY) && !isConsumerGroupExited) {
+            try {
+                Thread.sleep(DELAY_TIME);
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.SEVERE, "An InterruptedException occurs on the thread, "
+                        + "details: {0}", e.getMessage());
+            }
+            for (String topic : subscribedTopics) {
+                List<String> consumerIdList = clientFactory.findConsumerIdList(topic, consumerGroup);
+                if (consumerIdList != null && consumerIdList.contains(clientId)) {
+                    retryCount++;
+                    break;
+                }
+
+                messageQueueChanged(rebalance, topic);
+                if (!isConsumerGroupExited) {
+                    isConsumerGroupExited = true;
+                }
+            }
+        }
+        if (isConsumerGroupExited) {
+            LOGGER.log(Level.INFO, "Success to prohibit consumption, consumer instance name : {0}, "
+                            + "consumer group : {1}, topic : {2}",
+                    new Object[]{instanceName, consumerGroup, subscribedTopics});
+        } else {
+            LOGGER.log(Level.SEVERE, "Consumer exiting the {0} consumer group timeout may cause "
+                            + "a failure to reallocate the message queue, "
+                            + "consumer instance name : {0}, consumer group : {1}, topic : {2}. "
+                            + "Please deliver the configuration again.",
+                    new Object[]{instanceName, consumerGroup, subscribedTopics});
+            wrapper.setProhibition(false);
+            wrapper.getClientFactory().registerConsumer(consumerGroup, wrapper.getPullConsumerImpl());
+        }
+    }
+
+    private static void messageQueueChanged(DefaultLitePullConsumerWrapper wrapper) {
+        RebalanceImpl rebalance = wrapper.getRebalanceImpl();
+        ConcurrentMap<String, SubscriptionData> subTable = rebalance.getSubscriptionInner();
+        if (subTable != null) {
+            for (Entry<String, SubscriptionData> entry : subTable.entrySet()) {
+                String topic = entry.getKey();
+                messageQueueChanged(rebalance, topic);
+            }
+        }
+    }
+
+    private static void messageQueueChanged(RebalanceImpl rebalance, String topic) {
+        // 清空消费者的processQunues、assignedMessageQueues和pullTask，从而停止消费
+        ReflectUtils.invokeMethod(rebalance, "updateProcessQueueTableInRebalance",
+                new Class[]{String.class, Set.class, boolean.class},
+                new Object[]{topic, new HashSet<MessageQueue>(), false});
+        Set<MessageQueue> messageQueuesSet = rebalance.getTopicSubscribeInfoTable().get(topic);
+        rebalance.messageQueueChanged(topic, messageQueuesSet, new HashSet<>());
+    }
+
+    private static void resumePullConsumer(DefaultLitePullConsumerWrapper wrapper) {
+        switch (wrapper.getSubscriptionType()) {
+            case SUBSCRIBE:
+                resumeSubscriptiveConsumer(wrapper);
+                break;
+            case ASSIGN:
+                resumeAssignedConsumer(wrapper);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static void resumeSubscriptiveConsumer(DefaultLitePullConsumerWrapper wrapper) {
+        if (!wrapper.isProhibition()) {
+            LOGGER.log(Level.INFO, "Consumer has opened consumption, consumer "
+                            + "instance name : {0}, consumer group : {1}, topic : {2}",
+                    new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(), wrapper.getSubscribedTopics()});
+            return;
+        }
+        String consumerGroup = wrapper.getConsumerGroup();
+        DefaultLitePullConsumerImpl pullConsumerImpl = wrapper.getPullConsumerImpl();
+
+        wrapper.getClientFactory().registerConsumer(consumerGroup, pullConsumerImpl);
+        pullConsumerImpl.doRebalance();
+        wrapper.setProhibition(false);
+        LOGGER.log(Level.INFO, "Success to open consumption, "
+                        + "consumer instance name : {0}, consumer group : {1}, topic : {2}",
+                new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(), wrapper.getSubscribedTopics()});
+    }
+
+    private static void resumeAssignedConsumer(DefaultLitePullConsumerWrapper wrapper) {
+        wrapper.getPullConsumer().assign(wrapper.getMessageQueues());
+        LOGGER.log(Level.INFO, "Success to open consumption, "
+                        + "consumer instance name : {0}, consumer group : {1}, message queue : {2}",
+                new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(),
+                        wrapper.getMessageQueues()});
+    }
+
+    /**
+     * 添加PullConsumer包装类实例
+     *
+     * @param pullConsumer pullConsumer实例
+     */
+    public static void cachePullConsumer(DefaultLitePullConsumer pullConsumer) {
+        Optional<DefaultLitePullConsumerWrapper> pullConsumerWrapperOptional = RocketmqWrapperUtils
+                .wrapPullConsumer(pullConsumer);
+        if (pullConsumerWrapperOptional.isPresent()) {
+            RocketMqConsumerCache.PULL_CONSUMERS_CACHE.put(pullConsumer.hashCode(), pullConsumerWrapperOptional.get());
+            LOGGER.log(Level.INFO, "Success to cache consumer, "
+                            + "consumer instance name : {0}, consumer group : {1}, topic : {2}",
+                    new Object[]{pullConsumer.getInstanceName(), pullConsumer.getConsumerGroup(),
+                            pullConsumerWrapperOptional.get().getSubscribedTopics()});
+            return;
+        }
+        LOGGER.log(Level.SEVERE, "Fail to cache consumer, consumer instance name : {0}, consumer group : {1}",
+                new Object[]{pullConsumer.getInstanceName(), pullConsumer.getConsumerGroup()});
+    }
+
+    /**
+     * 移除PullConsumer包装类实例
+     *
+     * @param pullConsumer pullConsumer实例
+     */
+    public static void removePullConsumer(DefaultLitePullConsumer pullConsumer) {
+        int hashCode = pullConsumer.hashCode();
+        DefaultLitePullConsumerWrapper wrapper = RocketMqConsumerCache.PULL_CONSUMERS_CACHE
+                .get(hashCode);
+        if (wrapper != null) {
+            RocketMqConsumerCache.PULL_CONSUMERS_CACHE.remove(hashCode);
+            LOGGER.log(Level.INFO, "Success to remove consumer, consumer instance name : {0}, consumer group "
+                            + ": {1}, topic : {2}",
+                    new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(),
+                            wrapper.getSubscribedTopics()});
+        }
+    }
+
+    /**
+     * 获取PullConsumer的包装类实例缓存
+     *
+     * @param pullConsumer pull消费者实例
+     * @return PullConsumer包装类实例
+     */
+    public static DefaultLitePullConsumerWrapper getPullConsumerWrapper(
+            Object pullConsumer) {
+        return RocketMqConsumerCache.PULL_CONSUMERS_CACHE.get(pullConsumer.hashCode());
+    }
+
+    /**
+     * 获取PullConsumer缓存
+     *
+     * @return PullConsumer缓存
+     */
+    public static Map<Integer, DefaultLitePullConsumerWrapper> getPullConsumerCache() {
+        return RocketMqConsumerCache.PULL_CONSUMERS_CACHE;
+    }
+
+    private static void initExecutor() {
+        if (executor == null) {
+            synchronized (RocketMqPushConsumerController.class) {
+                if (executor == null) {
+                    executor = new ThreadPoolExecutor(THREAD_SIZE, THREAD_SIZE, THREAD_KEEP_ALIVE_TIME,
+                            TimeUnit.SECONDS, new ArrayBlockingQueue<>(THREAD_QUEUE_CAPACITY));
+                    executor.allowCoreThreadTimeOut(true);
+                }
+            }
+        }
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerController.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerController.java
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.controller;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
+import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.impl.consumer.DefaultMQPushConsumerImpl;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * push消费者控制类
+ *
+ * @author daizhenyu
+ * @since 2023-12-04
+ **/
+public class RocketMqPushConsumerController {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private RocketMqPushConsumerController() {
+    }
+
+    /**
+     * 禁止push消费者消费
+     *
+     * @param wrapper push消费者wrapper
+     * @param topics 禁止消费的topic
+     */
+    public static void disablePushConsumption(DefaultMqPushConsumerWrapper wrapper, Set<String> topics) {
+        Set<String> subscribedTopic = wrapper.getSubscribedTopics();
+        if (subscribedTopic.stream().anyMatch(topics::contains)) {
+            suspendPushConsumer(wrapper);
+            return;
+        }
+        resumePushConsumer(wrapper);
+    }
+
+    private static void suspendPushConsumer(DefaultMqPushConsumerWrapper wrapper) {
+        if (wrapper.isProhibition()) {
+            LOGGER.log(Level.INFO, "Consumer has prohibited consumption, consumer instance name : {0}, "
+                            + "consumer group : {1}, topic : {2}",
+                    new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(), wrapper.getSubscribedTopics()});
+            return;
+        }
+
+        DefaultMQPushConsumerImpl pushConsumerImpl = wrapper.getPushConsumerImpl();
+        String consumerGroup = wrapper.getConsumerGroup();
+
+        // 退出消费者前主动提交消费的offset，退出消费者组后立刻触发一次重平衡，重新分配队列
+        pushConsumerImpl.persistConsumerOffset();
+        wrapper.getClientFactory().unregisterConsumer(consumerGroup);
+        pushConsumerImpl.doRebalance();
+        wrapper.setProhibition(true);
+
+        LOGGER.log(Level.INFO, "Success to prohibit consumption, consumer instance name : {0}, "
+                        + "consumer group : {1}, topic : {2}",
+                new Object[]{wrapper.getInstanceName(), consumerGroup, wrapper.getSubscribedTopics()});
+    }
+
+    private static void resumePushConsumer(DefaultMqPushConsumerWrapper wrapper) {
+        String instanceName = wrapper.getInstanceName();
+        String consumerGroup = wrapper.getConsumerGroup();
+        Set<String> subscribedTopics = wrapper.getSubscribedTopics();
+        if (!wrapper.isProhibition()) {
+            LOGGER.log(Level.INFO, "Consumer has opened consumption, consumer "
+                            + "instance name : {0}, consumer group : {1}, topic : {2}",
+                    new Object[]{instanceName, consumerGroup, subscribedTopics});
+            return;
+        }
+
+        DefaultMQPushConsumerImpl pushConsumerImpl = wrapper.getPushConsumerImpl();
+        wrapper.getClientFactory().registerConsumer(consumerGroup, pushConsumerImpl);
+        pushConsumerImpl.doRebalance();
+        wrapper.setProhibition(false);
+        LOGGER.log(Level.INFO, "Success to open consumption, consumer "
+                        + "instance name : {0}, consumer group : {1}, topic : {2}",
+                new Object[]{instanceName, consumerGroup, subscribedTopics});
+    }
+
+    /**
+     * 添加PushConsumer包装类实例
+     *
+     * @param pushConsumer pushConsumer实例
+     */
+    public static void cachePushConsumer(DefaultMQPushConsumer pushConsumer) {
+        Optional<DefaultMqPushConsumerWrapper> pushConsumerWrapperOptional = RocketmqWrapperUtils
+                .wrapPushConsumer(pushConsumer);
+        if (pushConsumerWrapperOptional.isPresent()) {
+            RocketMqConsumerCache.PUSH_CONSUMERS_CACHE.put(pushConsumer.hashCode(), pushConsumerWrapperOptional.get());
+            LOGGER.log(Level.INFO, "Success to cache consumer, "
+                            + "consumer instance name : {0}, consumer group : {1}, topic : {2}",
+                    new Object[]{pushConsumer.getInstanceName(), pushConsumer.getConsumerGroup(),
+                            pushConsumerWrapperOptional.get().getSubscribedTopics()});
+            return;
+        }
+        LOGGER.log(Level.SEVERE, "Fail to cache consumer, consumer instance name : {0}, consumer group : {1}",
+                new Object[]{pushConsumer.getInstanceName(), pushConsumer.getConsumerGroup()});
+    }
+
+    /**
+     * 移除PushConsumer包装类实例
+     *
+     * @param pushConsumer pushConsumer实例
+     */
+    public static void removePushConsumer(DefaultMQPushConsumer pushConsumer) {
+        int hashCode = pushConsumer.hashCode();
+        DefaultMqPushConsumerWrapper wrapper = RocketMqConsumerCache.PUSH_CONSUMERS_CACHE.get(hashCode);
+        if (wrapper != null) {
+            RocketMqConsumerCache.PUSH_CONSUMERS_CACHE.remove(hashCode);
+            LOGGER.log(Level.INFO, "Success to remove consumer, consumer instance name : {0}, consumer group "
+                            + ": {1}, topic : {2}",
+                    new Object[]{wrapper.getInstanceName(), wrapper.getConsumerGroup(),
+                            wrapper.getSubscribedTopics()});
+        }
+    }
+
+    /**
+     * 获取PushConsumer的包装类实例
+     *
+     * @param pushConsumer 消费者实例
+     * @return PushConsumer包装类实例
+     */
+    public static DefaultMqPushConsumerWrapper getPushConsumerWrapper(Object pushConsumer) {
+        return RocketMqConsumerCache.PUSH_CONSUMERS_CACHE.get(pushConsumer.hashCode());
+    }
+
+    /**
+     * 获取PushConsumer缓存
+     *
+     * @return PushConsumer缓存
+     */
+    public static Map<Integer, DefaultMqPushConsumerWrapper> getPushConsumerCache() {
+        return RocketMqConsumerCache.PUSH_CONSUMERS_CACHE;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/AbstractConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/AbstractConsumerWrapper.java
@@ -20,6 +20,7 @@ import org.apache.rocketmq.client.impl.factory.MQClientInstance;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * 消费者包装抽象类
@@ -36,7 +37,7 @@ public abstract class AbstractConsumerWrapper {
     /**
      * 消费者是否已经禁止消费
      */
-    protected boolean pause = false;
+    protected AtomicBoolean prohibition = new AtomicBoolean();
 
     /**
      * nameserver地址
@@ -102,12 +103,17 @@ public abstract class AbstractConsumerWrapper {
      */
     protected abstract void initClientInfo();
 
-    public boolean isPause() {
-        return pause;
+    public boolean isProhibition() {
+        return prohibition.get();
     }
 
-    public void setPause(boolean pause) {
-        this.pause = pause;
+    /**
+     * 设置是否已经禁止消费
+     *
+     * @param prohibition 是否禁止消费
+     */
+    public void setProhibition(boolean prohibition) {
+        this.prohibition.set(prohibition);
     }
 
     public MQClientInstance getClientFactory() {

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultLitePullConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultLitePullConsumerWrapper.java
@@ -20,6 +20,7 @@ import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
 
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.impl.consumer.AssignedMessageQueue;
 import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
 import org.apache.rocketmq.client.impl.consumer.RebalanceImpl;
 import org.apache.rocketmq.client.impl.factory.MQClientInstance;
@@ -40,9 +41,11 @@ public class DefaultLitePullConsumerWrapper extends AbstractConsumerWrapper {
 
     private final RebalanceImpl rebalanceImpl;
 
-    private Collection<MessageQueue> assignedMessageQueues;
+    private Collection<MessageQueue> messageQueues;
 
     private SubscriptionType subscriptionType = SubscriptionType.NONE;
+
+    private AssignedMessageQueue assignedMessageQueue;
 
     /**
      * 有参构造方法
@@ -71,9 +74,9 @@ public class DefaultLitePullConsumerWrapper extends AbstractConsumerWrapper {
         consumerGroup = pullConsumer.getConsumerGroup();
     }
 
-    public void setAssignedMessageQueues(
-            Collection<MessageQueue> assignedMessageQueues) {
-        this.assignedMessageQueues = assignedMessageQueues;
+    public void setMessageQueues(
+            Collection<MessageQueue> messageQueues) {
+        this.messageQueues = messageQueues;
     }
 
     public void setSubscriptionType(SubscriptionType subscriptionType) {
@@ -92,11 +95,19 @@ public class DefaultLitePullConsumerWrapper extends AbstractConsumerWrapper {
         return rebalanceImpl;
     }
 
-    public Collection<MessageQueue> getAssignedMessageQueues() {
-        return assignedMessageQueues;
+    public Collection<MessageQueue> getMessageQueues() {
+        return messageQueues;
     }
 
     public SubscriptionType getSubscriptionType() {
         return subscriptionType;
+    }
+
+    public AssignedMessageQueue getAssignedMessageQueue() {
+        return assignedMessageQueue;
+    }
+
+    public void setAssignedMessageQueue(AssignedMessageQueue assignedMessageQueue) {
+        this.assignedMessageQueue = assignedMessageQueue;
     }
 }

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultMqPushConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultMqPushConsumerWrapper.java
@@ -44,6 +44,7 @@ public class DefaultMqPushConsumerWrapper extends AbstractConsumerWrapper {
         super(clientFactory);
         this.pushConsumer = consumer;
         this.pushConsumerImpl = pushConsumerImpl;
+        initClientInfo();
     }
 
     @Override

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/AbstractPullConsumerInterceptor.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/AbstractPullConsumerInterceptor.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.config.ProhibitionConfigManager;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPullConsumerController;
+import com.huaweicloud.sermant.rocketmq.extension.RocketMqConsumerHandler;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+
+/**
+ * pullconsumer抽象拦截器
+ *
+ * @author daizhenyu
+ * @since 2023-12-04
+ **/
+public abstract class AbstractPullConsumerInterceptor extends AbstractInterceptor {
+    /**
+     * 外部扩展处理器
+     */
+    protected RocketMqConsumerHandler handler;
+
+    /**
+     * 无参构造方法
+     */
+    public AbstractPullConsumerInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 外部扩展处理器
+     */
+    public AbstractPullConsumerInterceptor(RocketMqConsumerHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        return doBefore(context);
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        Object consumerObject = context.getObject();
+        if (consumerObject != null && consumerObject instanceof DefaultLitePullConsumer) {
+            DefaultLitePullConsumerWrapper pullConsumerWrapper = RocketMqPullConsumerController
+                    .getPullConsumerWrapper(consumerObject);
+            return doAfter(context, pullConsumerWrapper);
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) throws Exception {
+        return doOnThrow(context);
+    }
+
+    /**
+     * pullconsumer 执行禁消费操作
+     *
+     * @param pullConsumerWrapper pullconsumer包装类实例
+     */
+    protected void disablePullConsumption(DefaultLitePullConsumerWrapper pullConsumerWrapper) {
+        if (pullConsumerWrapper != null) {
+            RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper,
+                    ProhibitionConfigManager.getRocketMqProhibitionTopics());
+        }
+    }
+
+    /**
+     * 前置方法
+     *
+     * @param context 执行上下文
+     * @return ExecuteContext
+     */
+    protected abstract ExecuteContext doBefore(ExecuteContext context);
+
+    /**
+     * 后置方法
+     *
+     * @param context 执行上下文
+     * @param wrapper 消费者包装类
+     * @return ExecuteContext
+     */
+    protected abstract ExecuteContext doAfter(ExecuteContext context, DefaultLitePullConsumerWrapper wrapper);
+
+    /**
+     * 异常时方法
+     *
+     * @param context 执行上下文
+     * @return ExecuteContext
+     */
+    protected abstract ExecuteContext doOnThrow(ExecuteContext context);
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/AbstractPushConsumerInterceptor.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/AbstractPushConsumerInterceptor.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.config.ProhibitionConfigManager;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPushConsumerController;
+import com.huaweicloud.sermant.rocketmq.extension.RocketMqConsumerHandler;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+
+/**
+ * 抽象拦截器
+ *
+ * @author daizhenyu
+ * @since 2023-12-04
+ **/
+public abstract class AbstractPushConsumerInterceptor extends AbstractInterceptor {
+    /**
+     * 外部扩展处理器
+     */
+    protected RocketMqConsumerHandler handler;
+
+    /**
+     * 无参构造方法
+     */
+    public AbstractPushConsumerInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 外部扩展处理器
+     */
+    public AbstractPushConsumerInterceptor(RocketMqConsumerHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) {
+        return doBefore(context);
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) {
+        Object consumerObject = context.getObject();
+        if (consumerObject != null && consumerObject instanceof DefaultMQPushConsumer) {
+            DefaultMqPushConsumerWrapper pushConsumerWrapper =
+                    RocketMqPushConsumerController.getPushConsumerWrapper(consumerObject);
+            return doAfter(context, pushConsumerWrapper);
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) throws Exception {
+        return doOnThrow(context);
+    }
+
+    /**
+     * pushconsumer 执行禁消费操作
+     *
+     * @param pushConsumerWrapper pushconsumer包装类实例
+     */
+    protected void disablePushConsumption(DefaultMqPushConsumerWrapper pushConsumerWrapper) {
+        if (pushConsumerWrapper != null) {
+            RocketMqPushConsumerController.disablePushConsumption(pushConsumerWrapper,
+                    ProhibitionConfigManager.getRocketMqProhibitionTopics());
+        }
+    }
+
+    /**
+     * 前置方法
+     *
+     * @param context 执行上下文
+     * @return ExecuteContext
+     */
+    protected abstract ExecuteContext doBefore(ExecuteContext context);
+
+    /**
+     * 后置方法
+     *
+     * @param context 执行上下文
+     * @param wrapper 消费者包装类
+     * @return ExecuteContext
+     */
+    protected abstract ExecuteContext doAfter(ExecuteContext context, DefaultMqPushConsumerWrapper wrapper);
+
+    /**
+     * 异常时方法
+     *
+     * @param context 执行上下文
+     * @return ExecuteContext
+     */
+    protected abstract ExecuteContext doOnThrow(ExecuteContext context);
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerSubscribeInterceptor.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerSubscribeInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.PullConsumerLocalInfoUtils;
+import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
+import com.huaweicloud.sermant.rocketmq.extension.RocketMqConsumerHandler;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+
+/**
+ * RocketMq pullConsumer订阅拦截器
+ *
+ * @author daizhenyu
+ * @since 2023-12-15
+ **/
+public class RocketMqPullConsumerSubscribeInterceptor extends AbstractPullConsumerInterceptor {
+    /**
+     * 无参构造方法
+     */
+    public RocketMqPullConsumerSubscribeInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 处理器
+     */
+    public RocketMqPullConsumerSubscribeInterceptor(RocketMqConsumerHandler handler) {
+        super(handler);
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        if (handler != null) {
+            handler.doBefore(context);
+        }
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doAfter(ExecuteContext context, DefaultLitePullConsumerWrapper wrapper) {
+        if (wrapper == null) {
+            PullConsumerLocalInfoUtils.setSubscriptionType(SubscriptionType.SUBSCRIBE);
+        } else {
+            wrapper.setSubscriptionType(SubscriptionType.SUBSCRIBE);
+        }
+
+        if (handler != null) {
+            handler.doAfter(context);
+            return context;
+        }
+
+        // 增加topic订阅后，消费者订阅信息发生变化，需根据禁消费的topic配置对消费者开启或禁止消费
+        disablePullConsumption(wrapper);
+        return context;
+    }
+
+    @Override
+    protected ExecuteContext doOnThrow(ExecuteContext context) {
+        if (handler != null) {
+            handler.doOnThrow(context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/utils/PullConsumerLocalInfoUtils.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/utils/PullConsumerLocalInfoUtils.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.utils;
+
+import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
+
+import org.apache.rocketmq.common.message.MessageQueue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * pull消费者的线程变量
+ *
+ * @author daizhenyu
+ * @since 2023-12-20
+ **/
+public class PullConsumerLocalInfoUtils {
+    private static ThreadLocal<SubscriptionType> subscriptionTypeThreadLocal =
+            new ThreadLocal<>();
+
+    private static ThreadLocal<Collection<MessageQueue>> messageQueueThreadLocal =
+            new ThreadLocal<>();
+
+    private PullConsumerLocalInfoUtils() {
+    }
+
+    /**
+     * 获取消费者的订阅类型
+     *
+     * @return 订阅类型
+     */
+    public static SubscriptionType getSubscriptionType() {
+        SubscriptionType subscriptionType = subscriptionTypeThreadLocal.get();
+        if (subscriptionType == null) {
+            subscriptionType = SubscriptionType.NONE;
+            subscriptionTypeThreadLocal.set(subscriptionType);
+        }
+        return subscriptionType;
+    }
+
+    /**
+     * 设置消费者的订阅类型
+     *
+     * @param subscriptionType 订阅类型
+     */
+    public static void setSubscriptionType(SubscriptionType subscriptionType) {
+        subscriptionTypeThreadLocal.set(subscriptionType);
+    }
+
+    /**
+     * 移除消费者的订阅类型
+     */
+    public static void removeSubscriptionType() {
+        subscriptionTypeThreadLocal.remove();
+    }
+
+    /**
+     * 获取消费者assign的消费队列
+     *
+     * @return 消费者assign的消费队列
+     */
+    public static Collection<MessageQueue> getMessageQueue() {
+        Collection<MessageQueue> messageQueues = messageQueueThreadLocal.get();
+        if (messageQueues == null) {
+            messageQueues = new ArrayList<>();
+            messageQueueThreadLocal.set(messageQueues);
+        }
+        return messageQueues;
+    }
+
+    /**
+     * 设置消费者assign的消费队列
+     *
+     * @param messageQueues 消费者assign的消费队列
+     */
+    public static void setMessageQueue(Collection<MessageQueue> messageQueues) {
+        messageQueueThreadLocal.set(messageQueues);
+    }
+
+    /**
+     * 移除消费者assign的消费队列
+     */
+    public static void removeMessageQueue() {
+        messageQueueThreadLocal.remove();
+    }
+}


### PR DESCRIPTION
【Fix issue】#1379

[Modification content] Added consumer controller and pull consumer interceptor

[Use case description] Add integration tests later

[Self-test situation] 1. Local static check passed

[Scope of Influence] Usage documents will be added in the future