### PR TITLE
UT for rocketmq plugin.

### DIFF
--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/pom.xml
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/pom.xml
@@ -40,5 +40,15 @@
             <artifactId>commons-collections4</artifactId>
             <version>${collections4.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/constant/SubscriptionType.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/constant/SubscriptionType.java
@@ -45,19 +45,4 @@ public enum SubscriptionType {
     public String getSubscriptionTypeName() {
         return this.subscriptionName;
     }
-
-    /**
-     * 用于根据订阅方式名称获取订阅枚举对象
-     *
-     * @param name 订阅方式名称
-     * @return SubscriptionType
-     */
-    public static SubscriptionType getSubscriptionTypeByName(String name) {
-        for (SubscriptionType value : values()) {
-            if (value.getSubscriptionTypeName().equals(name)) {
-                return value;
-            }
-        }
-        return NONE;
-    }
 }

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/AbstractConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/AbstractConsumerWrapper.java
@@ -98,11 +98,6 @@ public abstract class AbstractConsumerWrapper {
         this.clientFactory = clientFactory;
     }
 
-    /**
-     * 初始化消费者实例的信息
-     */
-    protected abstract void initClientInfo();
-
     public boolean isProhibition() {
         return prohibition.get();
     }
@@ -182,6 +177,10 @@ public abstract class AbstractConsumerWrapper {
 
     public void setSubscribedTopics(Set<String> subscribedTopics) {
         this.subscribedTopics = subscribedTopics;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
     }
 
     /**

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultLitePullConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultLitePullConsumerWrapper.java
@@ -62,11 +62,10 @@ public class DefaultLitePullConsumerWrapper extends AbstractConsumerWrapper {
         this.pullConsumer = pullConsumer;
         this.pullConsumerImpl = pullConsumerImpl;
         this.rebalanceImpl = rebalanceImpl;
-        initClientInfo();
+        initPullClientInfo();
     }
 
-    @Override
-    protected void initClientInfo() {
+    private void initPullClientInfo() {
         ClientConfig clientConfig = clientFactory.getClientConfig();
         nameServerAddress = clientConfig.getClientIP();
         clientIp = clientConfig.getClientIP();

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultMqPushConsumerWrapper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/wrapper/DefaultMqPushConsumerWrapper.java
@@ -44,11 +44,10 @@ public class DefaultMqPushConsumerWrapper extends AbstractConsumerWrapper {
         super(clientFactory);
         this.pushConsumer = consumer;
         this.pushConsumerImpl = pushConsumerImpl;
-        initClientInfo();
+        initPushClientInfo();
     }
 
-    @Override
-    protected void initClientInfo() {
+    private void initPushClientInfo() {
         ClientConfig clientConfig = clientFactory.getClientConfig();
         nameServerAddress = clientConfig.getClientIP();
         clientIp = clientConfig.getClientIP();

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerControllerTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerControllerTest.java
@@ -1,0 +1,201 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.controller;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
+import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.impl.consumer.AssignedMessageQueue;
+import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
+import org.apache.rocketmq.client.impl.consumer.RebalanceImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * RocketMqPullConsumerController的单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-12-26
+ **/
+public class RocketMqPullConsumerControllerTest {
+    private static DefaultLitePullConsumer pullConsumer;
+
+    private static DefaultLitePullConsumerWrapper pullConsumerWrapper;
+
+    private static AssignedMessageQueue assignedMessageQueue;
+
+    private static Set<String> prohibitionTopics;
+
+    private static Set<String> subscribedTopics;
+
+    @BeforeClass
+    public static void setUp() throws MQClientException {
+        MockedStatic<ConfigManager> configManagerMockedStatic = Mockito.mockStatic(ConfigManager.class);
+        configManagerMockedStatic.when(() -> ConfigManager.getConfig(ServiceMeta.class)).thenReturn(new ServiceMeta());
+
+        pullConsumer = Mockito.mock(DefaultLitePullConsumer.class);
+        DefaultLitePullConsumerImpl pullConsumerImpl = Mockito.mock(DefaultLitePullConsumerImpl.class);
+        RebalanceImpl rebalance = Mockito.mock(RebalanceImpl.class);
+        MQClientInstance instance = Mockito.mock(MQClientInstance.class);
+        assignedMessageQueue = Mockito.mock(AssignedMessageQueue.class);
+        Mockito.when(instance.getClientConfig()).thenReturn(createClientConfig());
+        Mockito.when(rebalance.getSubscriptionInner()).thenReturn(new ConcurrentHashMap<>());
+
+        pullConsumerWrapper = new DefaultLitePullConsumerWrapper(pullConsumer, pullConsumerImpl, rebalance, instance);
+        pullConsumerWrapper.setConsumerGroup("test-group");
+
+        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketmqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPullConsumer(pullConsumer))
+                .thenReturn(Optional.of(pullConsumerWrapper));
+
+        prohibitionTopics = new HashSet<>();
+        prohibitionTopics.add("test-topic-1");
+    }
+
+    /**
+     * 消费者订阅topic为空
+     */
+    @Test
+    public void testDisablePullConsumptionNoTopic() {
+        pullConsumerWrapper.setProhibition(true);
+        pullConsumerWrapper.setSubscribedTopics(new HashSet<>());
+        pullConsumerWrapper.setSubscriptionType(SubscriptionType.SUBSCRIBE);
+        RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper, prohibitionTopics);
+        Assert.assertFalse(pullConsumerWrapper.isProhibition());
+    }
+
+    /**
+     * 消费者订阅topic和禁消费的topic存在交集
+     */
+    @Test
+    public void testDisablePullConsumptionWithSubTractTopics() {
+        subscribedTopics = new HashSet<>();
+        subscribedTopics.add("test-topic-1");
+        subscribedTopics.add("test-topic-2");
+        pullConsumerWrapper.setSubscribedTopics(subscribedTopics);
+        pullConsumerWrapper.setProhibition(false);
+        pullConsumerWrapper.setSubscriptionType(SubscriptionType.SUBSCRIBE);
+        RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper, prohibitionTopics);
+        Assert.assertTrue(pullConsumerWrapper.isProhibition());
+
+        // 禁消费后，再次下发禁消费
+        MQClientInstance clientFactory = pullConsumerWrapper.getClientFactory();
+        Mockito.reset(clientFactory);
+        RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper, prohibitionTopics);
+        Mockito.verify(clientFactory, Mockito.times(0))
+                .unregisterConsumer("test-group");
+    }
+
+    /**
+     * 消费者订阅topic和禁消费的topic不存在交集
+     */
+    @Test
+    public void testDisablePullConsumptionWithNoSubTractTopics() {
+        subscribedTopics = new HashSet<>();
+        subscribedTopics.add("test-topic-2");
+        subscribedTopics.add("test-topic-3");
+        pullConsumerWrapper.setSubscribedTopics(subscribedTopics);
+        pullConsumerWrapper.setProhibition(true);
+        pullConsumerWrapper.setSubscriptionType(SubscriptionType.SUBSCRIBE);
+        RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper, prohibitionTopics);
+        Assert.assertFalse(pullConsumerWrapper.isProhibition());
+
+        // 恢复消费后，再次下发禁消费配置
+        MQClientInstance clientFactory = pullConsumerWrapper.getClientFactory();
+        Mockito.reset(clientFactory);
+        RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper, prohibitionTopics);
+        Mockito.verify(clientFactory, Mockito.times(0))
+                .registerConsumer(Mockito.any(), Mockito.any());
+    }
+
+    /**
+     * 消费者指定队列消费，队列的topic和禁消费的topic存在交集
+     */
+    @Test
+    public void testDisablePullConsumptionWithAssignSubTractTopics() {
+        subscribedTopics = new HashSet<>();
+        subscribedTopics.add("test-topic-1");
+        subscribedTopics.add("test-topic-2");
+        pullConsumerWrapper.setSubscribedTopics(subscribedTopics);
+        pullConsumerWrapper.setSubscriptionType(SubscriptionType.ASSIGN);
+        pullConsumerWrapper.setAssignedMessageQueue(assignedMessageQueue);
+        RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper, prohibitionTopics);
+        Mockito.verify(assignedMessageQueue, Mockito.times(1)).updateAssignedMessageQueue(
+                Mockito.any());
+    }
+
+    /**
+     * 消费者指定队列消费，队列的topic和禁消费的topic不存在交集的情况
+     */
+    @Test
+    public void testDisablePullConsumptionWithAssignNoSubTractTopics() {
+        subscribedTopics = new HashSet<>();
+        subscribedTopics.add("test-topic-2");
+        Collection<MessageQueue> messageQueues = new ArrayList<>();
+        MessageQueue messageQueue = new MessageQueue("test-topic-2", "broker-1", 1);
+        messageQueues.add(messageQueue);
+        pullConsumerWrapper.setMessageQueues(messageQueues);
+        pullConsumerWrapper.setSubscribedTopics(subscribedTopics);
+        pullConsumerWrapper.setSubscriptionType(SubscriptionType.ASSIGN);
+        pullConsumerWrapper.setAssignedMessageQueue(assignedMessageQueue);
+        RocketMqPullConsumerController.disablePullConsumption(pullConsumerWrapper, prohibitionTopics);
+        Mockito.verify(pullConsumer, Mockito.times(1)).assign(
+                Mockito.any());
+    }
+
+    @Test
+    public void testCacheAndRemovePullConsumer() {
+        RocketMqPullConsumerController.cachePullConsumer(pullConsumer);
+        Assert.assertEquals(RocketMqConsumerCache.PULL_CONSUMERS_CACHE.size(), 1);
+        RocketMqPullConsumerController.removePullConsumer(pullConsumer);
+        Assert.assertEquals(RocketMqConsumerCache.PULL_CONSUMERS_CACHE.size(), 0);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+    }
+
+    private static ClientConfig createClientConfig() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClientIP("test-ip");
+        clientConfig.setInstanceName("test-consumer");
+        clientConfig.setNamesrvAddr("test-add");
+        return clientConfig;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerControllerTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerControllerTest.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.rocketmq.controller;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
+import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.impl.consumer.DefaultMQPushConsumerImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * RocketMqPushConsumerController单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-12-27
+ **/
+public class RocketMqPushConsumerControllerTest {
+    private static DefaultMQPushConsumer pushConsumer;
+
+    private static DefaultMqPushConsumerWrapper pushConsumerWrapper;
+
+    private static Set<String> prohibitionTopics;
+
+    private static Set<String> subscribedTopics;
+
+    @BeforeClass
+    public static void setUp() throws MQClientException {
+        MockedStatic<ConfigManager> configManagerMockedStatic = Mockito.mockStatic(ConfigManager.class);
+        configManagerMockedStatic.when(() -> ConfigManager.getConfig(ServiceMeta.class)).thenReturn(new ServiceMeta());
+
+        pushConsumer = Mockito.mock(DefaultMQPushConsumer.class);
+        DefaultMQPushConsumerImpl pushConsumerImpl = Mockito.mock(DefaultMQPushConsumerImpl.class);
+        MQClientInstance instance = Mockito.mock(MQClientInstance.class);
+        Mockito.when(instance.getClientConfig()).thenReturn(createClientConfig());
+
+        pushConsumerWrapper = new DefaultMqPushConsumerWrapper(pushConsumer, pushConsumerImpl, instance);
+        pushConsumerWrapper.setConsumerGroup("test-group");
+
+        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketmqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPushConsumer(pushConsumer))
+                .thenReturn(Optional.of(pushConsumerWrapper));
+
+        prohibitionTopics = new HashSet<>();
+        prohibitionTopics.add("test-topic-1");
+    }
+
+    /**
+     * 消费者订阅topic为空
+     */
+    @Test
+    public void testDisablePushConsumptionNoTopic() {
+        pushConsumerWrapper.setProhibition(true);
+        RocketMqPushConsumerController.disablePushConsumption(pushConsumerWrapper, prohibitionTopics);
+        Assert.assertFalse(pushConsumerWrapper.isProhibition());
+    }
+
+    /**
+     * 消费者订阅topic和禁消费的topic存在交集
+     */
+    @Test
+    public void testDisablePullConsumptionWithSubTractTopics() {
+        subscribedTopics = new HashSet<>();
+        subscribedTopics.add("test-topic-1");
+        subscribedTopics.add("test-topic-2");
+        pushConsumerWrapper.setSubscribedTopics(subscribedTopics);
+        pushConsumerWrapper.setProhibition(false);
+        RocketMqPushConsumerController.disablePushConsumption(pushConsumerWrapper, prohibitionTopics);
+        Assert.assertTrue(pushConsumerWrapper.isProhibition());
+
+        // 禁消费后，再次下发禁消费
+        MQClientInstance clientFactory = pushConsumerWrapper.getClientFactory();
+        Mockito.reset(clientFactory);
+        RocketMqPushConsumerController.disablePushConsumption(pushConsumerWrapper, prohibitionTopics);
+        Mockito.verify(clientFactory, Mockito.times(0))
+                .unregisterConsumer("test-group");
+    }
+
+    /**
+     * 消费者订阅topic和禁消费的topic不存在交集
+     */
+    @Test
+    public void testDisablePullConsumptionWithNoSubTractTopics() {
+        subscribedTopics = new HashSet<>();
+        subscribedTopics.add("test-topic-2");
+        subscribedTopics.add("test-topic-3");
+        pushConsumerWrapper.setSubscribedTopics(subscribedTopics);
+        pushConsumerWrapper.setProhibition(true);
+        RocketMqPushConsumerController.disablePushConsumption(pushConsumerWrapper, prohibitionTopics);
+        Assert.assertFalse(pushConsumerWrapper.isProhibition());
+
+        // 恢复消费后，再次下发禁消费配置
+        MQClientInstance clientFactory = pushConsumerWrapper.getClientFactory();
+        Mockito.reset(clientFactory);
+        RocketMqPushConsumerController.disablePushConsumption(pushConsumerWrapper, prohibitionTopics);
+        Mockito.verify(clientFactory, Mockito.times(0))
+                .registerConsumer(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void testCacheAndRemovePushConsumer() {
+        RocketMqPushConsumerController.cachePushConsumer(pushConsumer);
+        Assert.assertEquals(RocketMqConsumerCache.PUSH_CONSUMERS_CACHE.size(), 1);
+        RocketMqPushConsumerController.removePushConsumer(pushConsumer);
+        Assert.assertEquals(RocketMqConsumerCache.PUSH_CONSUMERS_CACHE.size(), 0);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+    }
+
+    private static ClientConfig createClientConfig() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClientIP("test-ip");
+        clientConfig.setInstanceName("test-consumer");
+        clientConfig.setNamesrvAddr("test-add");
+        return clientConfig;
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtilsTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtilsTest.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.utils;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
+
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.impl.consumer.DefaultMQPushConsumerImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * @author daizhenyu
+ * @since 2023-12-26
+ **/
+public class RocketmqWrapperUtilsTest {
+    private static DefaultLitePullConsumer pullConsumer;
+
+    private static DefaultMQPushConsumer pushConsumer;
+
+    private static Collection<MessageQueue> messageQueues;
+
+    private static MessageQueue messageQueue;
+
+    @BeforeClass
+    public static void setUp() throws MQClientException {
+        MockedStatic<ConfigManager> configManagerMockedStatic = Mockito.mockStatic(ConfigManager.class);
+        configManagerMockedStatic.when(() -> ConfigManager.getConfig(ServiceMeta.class)).thenReturn(new ServiceMeta());
+
+        pullConsumer = new DefaultLitePullConsumer("test-group");
+        pullConsumer.start();
+
+        pushConsumer = Mockito.mock(DefaultMQPushConsumer.class);
+        DefaultMQPushConsumerImpl pushConsumerImpl = Mockito.mock(DefaultMQPushConsumerImpl.class);
+        MQClientInstance mqClientInstance = Mockito.mock(MQClientInstance.class);
+        Mockito.when(pushConsumer.getDefaultMQPushConsumerImpl()).thenReturn(pushConsumerImpl);
+        Mockito.when(pushConsumerImpl.getmQClientFactory()).thenReturn(mqClientInstance);
+        Mockito.when(mqClientInstance.getClientConfig()).thenReturn(createClientConfig());
+
+        messageQueues = new ArrayList<>();
+        messageQueue = new MessageQueue("test-topic", "broker-1", 1);
+        messageQueues.add(messageQueue);
+    }
+
+    @Test
+    public void testWrapPullConsumer() {
+        Optional<DefaultLitePullConsumerWrapper> pullConsumerWrapperOptional = RocketmqWrapperUtils
+                .wrapPullConsumer(pullConsumer);
+        Assert.assertTrue(pullConsumerWrapperOptional.isPresent());
+        Assert.assertEquals(pullConsumerWrapperOptional.get().getPullConsumer(), pullConsumer);
+    }
+
+    @Test
+    public void testWrapPushConsumer() {
+        Optional<DefaultMqPushConsumerWrapper> pushConsumerWrapperOptional = RocketmqWrapperUtils
+                .wrapPushConsumer(pushConsumer);
+        Assert.assertTrue(pushConsumerWrapperOptional.isPresent());
+        Assert.assertEquals(pushConsumerWrapperOptional.get().getPushConsumer(), pushConsumer);
+    }
+
+    private static ClientConfig createClientConfig() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClientIP("test-ip");
+        clientConfig.setInstanceName("test-consumer");
+        clientConfig.setNamesrvAddr("test-add");
+        return clientConfig;
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/pom.xml
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePullConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePullConsumerInterceptorTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
+import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.impl.consumer.DefaultLitePullConsumerImpl;
+import org.apache.rocketmq.client.impl.consumer.RebalanceImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.junit.Before;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+/**
+ * interceptor单元测试基类
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class BasePullConsumerInterceptorTest {
+    protected DefaultLitePullConsumer pullConsumer;
+
+    protected DefaultLitePullConsumerWrapper pullConsumerWrapper;
+
+    @Before
+    public void before() throws MQClientException {
+        pullConsumer = new DefaultLitePullConsumer("test-group");
+        pullConsumerWrapper = createPullConsumerWrapper();
+        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketmqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPullConsumer(pullConsumer))
+                .thenReturn(Optional.of(pullConsumerWrapper));
+    }
+
+    private ClientConfig createClientConfig() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClientIP("test-ip");
+        clientConfig.setInstanceName("test-consumer");
+        clientConfig.setNamesrvAddr("test-add");
+        return clientConfig;
+    }
+
+    protected DefaultLitePullConsumerWrapper createPullConsumerWrapper() {
+        DefaultLitePullConsumerImpl pullConsumerImpl = Mockito.mock(DefaultLitePullConsumerImpl.class);
+        RebalanceImpl rebalanceImpl = Mockito.mock(RebalanceImpl.class);
+        MQClientInstance clientInstance = Mockito.mock(MQClientInstance.class);
+        Mockito.when(clientInstance.getClientConfig()).thenReturn(createClientConfig());
+        return new DefaultLitePullConsumerWrapper(pullConsumer, pullConsumerImpl,
+                rebalanceImpl, clientInstance);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePushConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePushConsumerInterceptorTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
+import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+
+import org.apache.rocketmq.client.ClientConfig;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.impl.consumer.DefaultMQPushConsumerImpl;
+import org.apache.rocketmq.client.impl.factory.MQClientInstance;
+import org.junit.Before;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+/**
+ * interceptor单元测试基类
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class BasePushConsumerInterceptorTest {
+    protected DefaultMQPushConsumer pushConsumer;
+
+    protected DefaultMqPushConsumerWrapper pushConsumerWrapper;
+
+    @Before
+    public void before() {
+        pushConsumer = new DefaultMQPushConsumer("test-group");
+        pushConsumerWrapper = createPushConsumerWrapper();
+        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketmqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPushConsumer(pushConsumer))
+                .thenReturn(Optional.of(pushConsumerWrapper));
+    }
+
+    private ClientConfig createClientConfig() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setClientIP("test-ip");
+        clientConfig.setInstanceName("test-consumer");
+        clientConfig.setNamesrvAddr("test-add");
+        return clientConfig;
+    }
+
+    protected DefaultMqPushConsumerWrapper createPushConsumerWrapper() {
+        DefaultMQPushConsumerImpl pushConsumerImpl = pushConsumer.getDefaultMQPushConsumerImpl();
+        MQClientInstance clientInstance = Mockito.mock(MQClientInstance.class);
+        Mockito.when(clientInstance.getClientConfig()).thenReturn(createClientConfig());
+        return new DefaultMqPushConsumerWrapper(pushConsumer, pushConsumerImpl, clientInstance);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerAssignInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerAssignInterceptorTest.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.PullConsumerLocalInfoUtils;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPullConsumerController;
+import com.huaweicloud.sermant.utils.InvokeUtils;
+
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * pullconsumer assign方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPullConsumerAssignInterceptorTest extends BasePullConsumerInterceptorTest {
+    private RocketMqPullConsumerAssignInterceptor interceptor = new RocketMqPullConsumerAssignInterceptor();
+
+    private Collection<MessageQueue> messageQueues;
+
+    private Set<String> topics;
+
+    @Before
+    public void setUp() {
+        MockedStatic<InvokeUtils> invokeUtilsMockedStatic = Mockito.mockStatic(InvokeUtils.class);
+        invokeUtilsMockedStatic
+                .when(() -> InvokeUtils.isRocketMqInvokeBySermant(Thread.currentThread().getStackTrace()))
+                .thenReturn(false);
+        messageQueues = new ArrayList<>();
+        MessageQueue messageQueue = new MessageQueue("test-topic", "broker-1", 1);
+        messageQueues.add(messageQueue);
+        topics = new HashSet<>();
+        topics.add("test-topic");
+    }
+
+    @Test
+    public void testAfter() {
+        ExecuteContext context = ExecuteContext.forMemberMethod(pullConsumer, null, new Object[]{messageQueues},
+                null, null);
+
+        // wrapper为null
+        interceptor.after(context);
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getSubscriptionType().name(), "ASSIGN");
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getMessageQueue(), messageQueues);
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+        PullConsumerLocalInfoUtils.removeMessageQueue();
+
+        // wrapper为null messagequeue为null
+        context = ExecuteContext.forMemberMethod(pullConsumer, null, new Object[]{null},
+                null, null);
+        interceptor.after(context);
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getSubscriptionType().name(), "NONE");
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+
+        // wrapper不为null
+        context = ExecuteContext.forMemberMethod(pullConsumer, null, new Object[]{messageQueues},
+                null, null);
+        RocketMqPullConsumerController.cachePullConsumer(pullConsumer);
+        interceptor.after(context);
+        Assert.assertEquals(pullConsumerWrapper.getSubscriptionType().name(), "ASSIGN");
+        Assert.assertEquals(pullConsumerWrapper.getMessageQueues(), messageQueues);
+        Assert.assertEquals(pullConsumerWrapper.getSubscribedTopics(), topics);
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPullConsumerController.removePullConsumer(pullConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerShutdownInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerShutdownInterceptorTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPullConsumerController;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * pullconsumer shutdown方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPullConsumerShutdownInterceptorTest extends BasePullConsumerInterceptorTest {
+    private RocketMqPullConsumerShutdownInterceptor interceptor = new RocketMqPullConsumerShutdownInterceptor();
+
+    private ExecuteContext context;
+
+    @Before
+    public void setUp() {
+        RocketMqPullConsumerController.cachePullConsumer(pullConsumer);
+        context = ExecuteContext.forMemberMethod(pullConsumer, null, null,
+                null, null);
+    }
+
+    @Test
+    public void testAfter() {
+        interceptor.after(context);
+        Assert.assertEquals(RocketMqPullConsumerController.getPullConsumerCache().size(), 0);
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPullConsumerController.removePullConsumer(pullConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerStartInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerStartInterceptorTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.PullConsumerLocalInfoUtils;
+import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPullConsumerController;
+
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.heartbeat.SubscriptionData;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * pullConsumer start方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPullConsumerStartInterceptorTest extends BasePullConsumerInterceptorTest {
+    private RocketMqPullConsumerStartInterceptor interceptor = new RocketMqPullConsumerStartInterceptor();
+
+    private ExecuteContext context;
+
+    private Collection<MessageQueue> messageQueues;
+
+    @Before
+    public void setUp() {
+        context = ExecuteContext.forMemberMethod(pullConsumer, null, null,
+                null, null);
+
+        messageQueues = new ArrayList<>();
+        MessageQueue messageQueue = new MessageQueue();
+        messageQueues.add(messageQueue);
+
+        ConcurrentHashMap<String, SubscriptionData> topics = new ConcurrentHashMap<>();
+        topics.put("test-topic", new SubscriptionData());
+        Mockito.when(pullConsumerWrapper.getRebalanceImpl().getSubscriptionInner()).thenReturn(topics);
+    }
+
+    @Test
+    public void testAfter() {
+        // 订阅方式为assign
+        PullConsumerLocalInfoUtils.setSubscriptionType(SubscriptionType.ASSIGN);
+        PullConsumerLocalInfoUtils.setMessageQueue(messageQueues);
+        interceptor.after(context);
+        Assert.assertEquals(pullConsumerWrapper.getSubscriptionType().name(), "ASSIGN");
+        Assert.assertEquals(pullConsumerWrapper.getMessageQueues(), messageQueues);
+        PullConsumerLocalInfoUtils.removeMessageQueue();
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+
+        // 订阅方式为SUBSCRIBE
+        PullConsumerLocalInfoUtils.setSubscriptionType(SubscriptionType.SUBSCRIBE);
+        interceptor.after(context);
+        Assert.assertTrue(pullConsumerWrapper.getSubscribedTopics().contains("test-topic"));
+        Assert.assertEquals(pullConsumerWrapper.getSubscriptionType().name(), "SUBSCRIBE");
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPullConsumerController.removePullConsumer(pullConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerSubscribeInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerSubscribeInterceptorTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.PullConsumerLocalInfoUtils;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPullConsumerController;
+
+import org.apache.rocketmq.common.protocol.heartbeat.SubscriptionData;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * pullConsumer subscribe方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPullConsumerSubscribeInterceptorTest extends BasePullConsumerInterceptorTest {
+    private RocketMqPullConsumerSubscribeInterceptor interceptor = new RocketMqPullConsumerSubscribeInterceptor();
+
+    private ConcurrentMap<String, SubscriptionData> subscription;
+
+    private ExecuteContext context;
+
+    @Before
+    public void setUp() {
+        subscription = new ConcurrentHashMap<String, SubscriptionData>();
+        context = ExecuteContext.forMemberMethod(pullConsumer, null, null,
+                null, null);
+    }
+
+    @Test
+    public void testAfter() {
+        // wrapper为null
+        interceptor.after(context);
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getSubscriptionType().name(), "SUBSCRIBE");
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+
+        // wrapper不为null
+        pullConsumerWrapper.setSubscribedTopics(subscription.keySet());
+        subscription.put("test-topic", new SubscriptionData());
+        RocketMqPullConsumerController.cachePullConsumer(pullConsumer);
+        interceptor.after(context);
+        Assert.assertEquals(pullConsumerWrapper.getSubscriptionType().name(), "SUBSCRIBE");
+        Assert.assertEquals(pullConsumerWrapper.getSubscribedTopics(), subscription.keySet());
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPullConsumerController.removePullConsumer(pullConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerUnsubscribeInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPullConsumerUnsubscribeInterceptorTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPullConsumerController;
+
+import org.apache.rocketmq.common.protocol.heartbeat.SubscriptionData;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * pullConsumer unsubscribe方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPullConsumerUnsubscribeInterceptorTest extends BasePullConsumerInterceptorTest {
+    private RocketMqPullConsumerUnsubscribeInterceptor interceptor = new RocketMqPullConsumerUnsubscribeInterceptor();
+
+    private ConcurrentMap<String, SubscriptionData> subscription;
+
+    private ExecuteContext context;
+
+    @Before
+    public void setUp() {
+        subscription = new ConcurrentHashMap<String, SubscriptionData>();
+        subscription.put("test-topic", new SubscriptionData());
+        pullConsumerWrapper.setSubscribedTopics(subscription.keySet());
+        RocketMqPullConsumerController.cachePullConsumer(pullConsumer);
+        context = ExecuteContext.forMemberMethod(pullConsumer, null, null,
+                null, null);
+    }
+
+    @Test
+    public void testAfter() {
+        subscription.remove("test-topic");
+        interceptor.after(context);
+        Assert.assertEquals(pullConsumerWrapper.getSubscribedTopics().size(), 0);
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPullConsumerController.removePullConsumer(pullConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerShutdownInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerShutdownInterceptorTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPushConsumerController;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * pushconsumer shutdown方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPushConsumerShutdownInterceptorTest extends BasePushConsumerInterceptorTest {
+    private RocketMqPushConsumerShutdownInterceptor interceptor = new RocketMqPushConsumerShutdownInterceptor();
+
+    private ExecuteContext context;
+
+    @Before
+    public void setUp() {
+        RocketMqPushConsumerController.cachePushConsumer(pushConsumer);
+        context = ExecuteContext.forMemberMethod(pushConsumer, null, null,
+                null, null);
+    }
+
+    @Test
+    public void testAfter() {
+        interceptor.after(context);
+        Assert.assertNull(RocketMqConsumerCache.PUSH_CONSUMERS_CACHE
+                .get(pushConsumer.hashCode()));
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPushConsumerController.removePushConsumer(pushConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerStartInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerStartInterceptorTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPushConsumerController;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * pushConsumer start方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPushConsumerStartInterceptorTest extends BasePushConsumerInterceptorTest {
+    private RocketMqPushConsumerStartInterceptor interceptor = new RocketMqPushConsumerStartInterceptor();
+
+    private ExecuteContext context;
+
+    @Before
+    public void setUp() throws MQClientException {
+        context = ExecuteContext.forMemberMethod(pushConsumer, null, null,
+                null, null);
+        pushConsumer.subscribe("test-topic", "*");
+    }
+
+    @Test
+    public void testAfter() {
+        interceptor.after(context);
+        Assert.assertTrue(pushConsumerWrapper.getSubscribedTopics().contains("test-topic"));
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPushConsumerController.removePushConsumer(pushConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerSubscribeInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerSubscribeInterceptorTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPushConsumerController;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * pushConsumer subscribe方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPushConsumerSubscribeInterceptorTest extends BasePushConsumerInterceptorTest {
+    private RocketMqPushConsumerSubscribeInterceptor interceptor = new RocketMqPushConsumerSubscribeInterceptor();
+
+    private ExecuteContext context;
+
+    @Before
+    public void setUp() {
+        context = ExecuteContext.forMemberMethod(pushConsumer, null, null,
+                null, null);
+        pushConsumerWrapper
+                .setSubscribedTopics(pushConsumer.getDefaultMQPushConsumerImpl().getSubscriptionInner().keySet());
+        RocketMqPushConsumerController.cachePushConsumer(pushConsumer);
+    }
+
+    @Test
+    public void testAfter() throws MQClientException {
+        pushConsumer.subscribe("test-topic", "*");
+        interceptor.after(context);
+        Assert.assertTrue(pushConsumerWrapper.getSubscribedTopics().contains("test-topic"));
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPushConsumerController.removePushConsumer(pushConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerUnsubscribeInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/RocketMqPushConsumerUnsubscribeInterceptorTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.rocketmq.controller.RocketMqPushConsumerController;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * pushConsumer unsubscribe方法拦截器UT
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class RocketMqPushConsumerUnsubscribeInterceptorTest extends BasePushConsumerInterceptorTest {
+    private RocketMqPushConsumerUnsubscribeInterceptor interceptor = new RocketMqPushConsumerUnsubscribeInterceptor();
+
+    private ExecuteContext context;
+
+    @Before
+    public void setUp() throws MQClientException {
+        context = ExecuteContext.forMemberMethod(pushConsumer, null, null,
+                null, null);
+        pushConsumer.subscribe("test-topic", "*");
+        pushConsumerWrapper
+                .setSubscribedTopics(pushConsumer.getDefaultMQPushConsumerImpl().getSubscriptionInner().keySet());
+        RocketMqPushConsumerController.cachePushConsumer(pushConsumer);
+    }
+
+    @Test
+    public void testAfter() {
+        pushConsumer.unsubscribe("test-topic");
+        interceptor.after(context);
+        Assert.assertFalse(pushConsumerWrapper.getSubscribedTopics().contains("test-topic"));
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+        RocketMqPushConsumerController.removePushConsumer(pushConsumer);
+    }
+}

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/utils/PullConsumerLocalInfoUtilsTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/utils/PullConsumerLocalInfoUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2023-2023 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mq.prohibition.rocketmq.utils;
+
+import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
+
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * PullConsumerLocalInfoUtils工具类单元测试
+ *
+ * @author daizhenyu
+ * @since 2023-12-25
+ **/
+public class PullConsumerLocalInfoUtilsTest {
+    @Test
+    public void testSubscriptionTypeThreadLocal() {
+        PullConsumerLocalInfoUtils.setSubscriptionType(SubscriptionType.ASSIGN);
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getSubscriptionType().name(), "ASSIGN");
+
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getSubscriptionType().name(), "NONE");
+
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+    }
+
+    @Test
+    public void testMessageQueueThreadLocal() {
+        Collection<MessageQueue> messageQueues = new ArrayList<>();
+        MessageQueue messageQueue = new MessageQueue();
+        messageQueues.add(messageQueue);
+
+        PullConsumerLocalInfoUtils.setMessageQueue(messageQueues);
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getMessageQueue().size(), 1);
+
+        PullConsumerLocalInfoUtils.removeMessageQueue();
+        Assert.assertEquals(PullConsumerLocalInfoUtils.getMessageQueue().size(), 0);
+
+        PullConsumerLocalInfoUtils.removeSubscriptionType();
+    }
+}


### PR DESCRIPTION
【Fix issue】#1379

【Modified content】
1. Added unit tests for rocketmq consumption plug-in interceptor, controller and tool classes
2. Modify the codecheck problem of prohibited consumption plug-ins
[Use case description] Unit test

[Self-test situation] 1. The local static check passed; 2. Unit testing was conducted on the interceptor, controller and tool classes of the rocketmq consumption ban plug-in. The UT class coverage was 100% and the number of lines was covered 67%.

[Scope of influence] None