### PR TITLE
Host microservices bug fix: unable to get provider while instantiating interceptor. 

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/classloader/PluginClassLoader.java
@@ -170,7 +170,7 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     /**
-     * 设置局部临时类加载器
+     * 设置局部类加载器
      *
      * @param loader 类加载器
      */
@@ -179,11 +179,9 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     /**
-     * 清楚局部临时类加载器
-     *
-     * @return 被移除的类加载器
+     * 清除局部类加载器
      */
-    public ClassLoader removeTmpLoader() {
-        return localLoader.remove(Thread.currentThread().getId());
+    public void removeLocalLoader() {
+        localLoader.remove(Thread.currentThread().getId());
     }
 }

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtils.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtils.java
@@ -116,7 +116,7 @@ public class RocketmqWrapperUtils {
         }
 
         // 移除插件类加载器的局部类加载器
-        ((PluginClassLoader) RocketmqWrapperUtils.class.getClassLoader()).removeTmpLoader();
+        ((PluginClassLoader) RocketmqWrapperUtils.class.getClassLoader()).removeLocalLoader();
         return Optional.empty();
     }
 

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -7,4 +7,5 @@
     <!-- AgentLoader测试脚本不进行UncommentedMain检查  -->
     <suppress files="sermant-integration-tests/scripts/AgentLoader.java" checks="UncommentedMain"/>
     <suppress files="com.huaweicloud.sermant.premain.AgentLauncher.java" checks="IllegalCatch" />
+    <suppress files="com.huaweicloud.sermant.core.plugin.agent.collector.PluginCollector.java" checks="IllegalCatch" />
 </suppressions>


### PR DESCRIPTION
【Fix issue】#1390

[Modification content] 1. Change removeTmpLoader of PluginClassLoader to removeLocalLoader 2. When creating an interceptor in PluginCollector, set the local class loader as the host class loader

[Use case description] Not involved

[Self-test situation] 1. The local static check has passed 2. Verify that the interceptor was successfully created in the Spring scenario

[Scope of influence] Not involved