### PR TITLE
Fix zone failure of dynamic configuration for consumption prohibition plugin.

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/CommonGroupConfigSubscriber.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/subscribe/CommonGroupConfigSubscriber.java
@@ -135,7 +135,7 @@ public class CommonGroupConfigSubscriber extends AbstractGroupConfigSubscriber {
         final HashMap<String, String> map = new HashMap<>(REQUEST_MAP_SIZE);
         map.put(APP, config.getApplication());
         map.put(ENVIRONMENT, config.getEnvironment());
-        map.put(ZONE, config.getEnvironment());
+        map.put(ZONE, config.getZone());
         final String labelGroup = LabelGroupUtils.createLabelGroup(map);
         listenerCache.put(labelGroup, new IntegratedEventListenerAdapter(configOrderIntegratedProcessor, labelGroup));
         configOrderIntegratedProcessor.addHolder(new ConfigDataHolder(labelGroup, ZONE_ORDER));


### PR DESCRIPTION
【Fix issue】#1409

[Modification content] Fixed the problem of prohibiting dynamic configuration zone failure of consumption plug-ins.

[Use case description] Configure the value of service.meta.zone and confirm that the dynamically configured node group is app=${service.meta.application}&environment=${service.meta.environment}&zone=${service.meta.zone}

[Self-test situation] 1. Local static check passed

【Scope of Impact】Fix the bug and restore the plug-in function to normal