### PR TITLE
MongoDB database write prohibition plug-in and controller module.

### DIFF
--- a/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
+++ b/sermant-agentcore/sermant-agentcore-config/config/plugins.yaml
@@ -17,6 +17,7 @@ plugins:
   - service-removal
   - service-visibility
   - tag-transmission
+  - database-write-prohibition
 # dynamicPlugins用于配置支持动态安装的插件, agentmain启动时生效, 允许卸载:
 #  1. active类型插件将会主动启用
 #  2. passive类型插件需通过指令或接口调用启用

--- a/sermant-plugins/pom.xml
+++ b/sermant-plugins/pom.xml
@@ -42,6 +42,7 @@
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
                 <module>sermant-tag-transmission</module>
+                <module>sermant-database-write-prohibition</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -74,6 +75,7 @@
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
                 <module>sermant-tag-transmission</module>
+                <module>sermant-database-write-prohibition</module>
             </modules>
             <build>
                 <pluginManagement>
@@ -106,6 +108,7 @@
                 <module>sermant-service-removal</module>
                 <module>sermant-spring-beans-deal</module>
                 <module>sermant-tag-transmission</module>
+                <module>sermant-database-write-prohibition</module>
             </modules>
         </profile>
     </profiles>

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-database-write-prohibition</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>database-controller</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionConfig.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionConfig.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.config;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 数据库禁写插件配置类
+ *
+ * @author daizhenyu
+ * @since 2024-01-15
+ **/
+public class DatabaseWriteProhibitionConfig {
+    /**
+     * 是否开启禁写
+     */
+    private boolean enableDatabaseWriteProhibition = false;
+
+    /**
+     * 需要禁写的数据库
+     */
+    private Set<String> databases = new HashSet<>();
+
+    public boolean isEnableDatabaseWriteProhibition() {
+        return enableDatabaseWriteProhibition;
+    }
+
+    public void setEnableDatabaseWriteProhibition(boolean enableDatabaseWriteProhibition) {
+        this.enableDatabaseWriteProhibition = enableDatabaseWriteProhibition;
+    }
+
+    /**
+     * 获取禁消费的数据库列表
+     *
+     * @return 数据库列表
+     */
+    public Set<String> getDatabases() {
+        return databases;
+    }
+
+    public void setDatabases(Set<String> databases) {
+        this.databases = databases;
+    }
+
+    @Override
+    public String toString() {
+        return "enableDatabaseWriteProhibition=" + enableDatabaseWriteProhibition + ", databases=" + databases;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManager.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManager.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.database.config;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * 数据库禁写配置管理类
+ *
+ * @author daizhenyu
+ * @since 2024-01-22
+ */
+public class DatabaseWriteProhibitionManager {
+    private static DatabaseWriteProhibitionConfig globalConfig = new DatabaseWriteProhibitionConfig();
+
+    private static DatabaseWriteProhibitionConfig localConfig = new DatabaseWriteProhibitionConfig();
+
+    private DatabaseWriteProhibitionManager() {
+    }
+
+    /**
+     * 获取要禁止消费的数据库集合
+     *
+     * @return 禁止消费的数据库集合
+     */
+    public static Set<String> getProhibitionDatabases() {
+        if (globalConfig.isEnableDatabaseWriteProhibition()) {
+            return globalConfig.getDatabases();
+        }
+        if (localConfig.isEnableDatabaseWriteProhibition()) {
+            return localConfig.getDatabases();
+        }
+        return Collections.EMPTY_SET;
+    }
+
+    /**
+     * 获取全局配置
+     *
+     * @return 全局配置
+     */
+    public static DatabaseWriteProhibitionConfig getGlobalConfig() {
+        return globalConfig;
+    }
+
+    /**
+     * 获取局部配置
+     *
+     * @return 局部配置
+     */
+    public static DatabaseWriteProhibitionConfig getLocalConfig() {
+        return localConfig;
+    }
+
+    /**
+     * 更新全局配置
+     *
+     * @param config 禁止消费配置
+     */
+    public static void updateGlobalConfig(DatabaseWriteProhibitionConfig config) {
+        if (config == null) {
+            globalConfig = new DatabaseWriteProhibitionConfig();
+            return;
+        }
+        globalConfig = config;
+    }
+
+    /**
+     * 更新局部配置
+     *
+     * @param config 禁止消费配置
+     */
+    public static void updateLocalConfig(DatabaseWriteProhibitionConfig config) {
+        if (config == null) {
+            localConfig = new DatabaseWriteProhibitionConfig();
+            return;
+        }
+        localConfig = config;
+    }
+
+    /**
+     * 打印配置信息
+     *
+     * @return 配置信息
+     */
+    public static String printConfig() {
+        return "Global WriteProhibitionConfig: " + globalConfig.toString() + "; Local WriteProhibitionConfig: "
+                + localConfig.toString();
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/controller/DatabaseController.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/controller/DatabaseController.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.controller;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
+import java.sql.SQLException;
+
+/**
+ * 数据库控制器
+ *
+ * @author daizhenyu
+ * @since 2024-01-15
+ **/
+public class DatabaseController {
+    private static Object result = new Object();
+
+    private DatabaseController() {
+    }
+
+    /**
+     * 获取需要禁写的数据库清单
+     *
+     * @param database 数据库名称
+     * @param context 拦截点上下文对象
+     * @return
+     */
+    public static void disableDatabaseWriteOperation(String database, ExecuteContext context) {
+        context.setThrowableOut(new SQLException("Database prohibit to write, database: " + database));
+        context.skip(result);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/handler/DatabaseHandler.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/handler/DatabaseHandler.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.handler;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
+/**
+ * 数据库禁写处理接口
+ *
+ * @author daizhenyu
+ * @since 2024-01-15
+ **/
+public interface DatabaseHandler {
+    /**
+     * 拦截点前置处理
+     *
+     * @param context 上下文信息
+     */
+    void doBefore(ExecuteContext context);
+
+    /**
+     * 拦截点后置处理
+     *
+     * @param context 上下文信息
+     */
+    void doAfter(ExecuteContext context);
+
+    /**
+     * 拦截点异常处理
+     *
+     * @param context 上下文信息
+     */
+    void doOnThrow(ExecuteContext context);
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/interceptor/AbstractDatabaseInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/interceptor/AbstractDatabaseInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.interceptor;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+
+/**
+ * mongodb抽象interceptor
+ *
+ * @author daizhenyu
+ * @since 2024-01-22
+ **/
+public abstract class AbstractDatabaseInterceptor extends AbstractInterceptor {
+    protected DatabaseHandler handler;
+
+    @Override
+    public ExecuteContext before(ExecuteContext context) throws Exception {
+        if (handler != null) {
+            handler.doBefore(context);
+            return context;
+        }
+        return doBefore(context);
+    }
+
+    @Override
+    public ExecuteContext after(ExecuteContext context) throws Exception {
+        if (handler != null) {
+            handler.doAfter(context);
+            return context;
+        }
+        return context;
+    }
+
+    @Override
+    public ExecuteContext onThrow(ExecuteContext context) throws Exception {
+        if (handler != null) {
+            handler.doOnThrow(context);
+            return context;
+        }
+        return context;
+    }
+
+    /**
+     * 方法执行前
+     *
+     * @param context 上下文
+     * @return ExecuteContext 上下文
+     */
+    protected abstract ExecuteContext doBefore(ExecuteContext context);
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-database-write-prohibition</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>mongodb-3.x-4.x-plugin</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>plugin</package.plugin.type>
+        <mongodb.version>4.3.4</mongodb.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>${mongodb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>database-controller</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/declarers/CommandOperationHelperDeclarer.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/declarers/CommandOperationHelperDeclarer.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.mongodb.utils.MongoDbEnhancementHelper;
+
+/**
+ * mongodb写操作增强声明器
+ *
+ * @author daizhenyu
+ * @since 2024-01-16
+ **/
+public class CommandOperationHelperDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return MongoDbEnhancementHelper.getCommandOperationHelperClassMatcher();
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return MongoDbEnhancementHelper.getCommandOperationHelperInterceptDeclarers();
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/declarers/MixedBulkWriteOperationDeclarer.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/declarers/MixedBulkWriteOperationDeclarer.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.mongodb.utils.MongoDbEnhancementHelper;
+
+/**
+ * MixedBulkWriteOperation类增强声明器
+ *
+ * @author daizhenyu
+ * @since 2024-01-16
+ **/
+public class MixedBulkWriteOperationDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return MongoDbEnhancementHelper.getMixedBulkWriteOperationClassMatcher();
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return MongoDbEnhancementHelper.getMixedBulkWriteOperationInterceptDeclarers();
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptor.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.interceptor.AbstractDatabaseInterceptor;
+
+/**
+ * 执行同步和异步write操作的拦截器
+ *
+ * @author daizhenyu
+ * @since 2024-01-18
+ **/
+public class ExecuteCommandInterceptor extends AbstractDatabaseInterceptor {
+    /**
+     * 无参构造方法
+     */
+    public ExecuteCommandInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public ExecuteCommandInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        String database = (String) context.getArguments()[0];
+        if (DatabaseWriteProhibitionManager.getProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptor.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.interceptor.AbstractDatabaseInterceptor;
+
+/**
+ * 执行重试write操作的拦截器
+ *
+ * @author daizhenyu
+ * @since 2024-01-18
+ **/
+public class ExecuteRetryableCommandInterceptor extends AbstractDatabaseInterceptor {
+    /**
+     * 无参构造方法
+     */
+    public ExecuteRetryableCommandInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public ExecuteRetryableCommandInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        String database = (String) context.getArguments()[1];
+        if (DatabaseWriteProhibitionManager.getProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptor.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.interceptor.AbstractDatabaseInterceptor;
+
+import com.mongodb.internal.operation.MixedBulkWriteOperation;
+
+/**
+ * MixedBulkWriteOperation类拦截声明器
+ *
+ * @author daizhenyu
+ * @since 2024-01-16
+ **/
+public class MixedBulkWriteOperationInterceptor extends AbstractDatabaseInterceptor {
+    /**
+     * 无参构造方法
+     */
+    public MixedBulkWriteOperationInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public MixedBulkWriteOperationInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        String database = ((MixedBulkWriteOperation) context.getObject()).getNamespace().getDatabaseName();
+        if (DatabaseWriteProhibitionManager.getProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/utils/MongoDbEnhancementHelper.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/utils/MongoDbEnhancementHelper.java
@@ -1,0 +1,295 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.utils;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.mongodb.interceptors.ExecuteCommandInterceptor;
+import com.huaweicloud.sermant.mongodb.interceptors.ExecuteRetryableCommandInterceptor;
+import com.huaweicloud.sermant.mongodb.interceptors.MixedBulkWriteOperationInterceptor;
+
+import com.mongodb.ReadPreference;
+import com.mongodb.internal.binding.ConnectionSource;
+import com.mongodb.internal.connection.Connection;
+
+import org.bson.BsonDocument;
+import org.bson.FieldNameValidator;
+import org.bson.codecs.Decoder;
+
+/**
+ * mongo拦截点辅助类
+ *
+ * @author daizhenyu
+ * @since 2024-01-16
+ **/
+public class MongoDbEnhancementHelper {
+    private static final String MIXED_BULK_WRITE_CLASS = "com.mongodb.internal.operation.MixedBulkWriteOperation";
+
+    private static final String COMMAND_OPERATION_CLASS = "com.mongodb.internal.operation.CommandOperationHelper";
+
+    private static final String EXECUTE_METHOD_NAME = "execute";
+
+    private static final String EXECUTE_ASYNC_METHOD_NAME = "executeAsync";
+
+    private static final String EXECUTE_COMMAND_ASYNC_METHOD_NAME = "executeCommandAsync";
+
+    private static final String EXECUTE_COMMAND_METHOD_NAME = "executeCommand";
+
+    private static final String EXECUTE_WRITE_COMMAND_METHOD_NAME = "executeWriteCommand";
+
+    private static final String EXECUTE_RETRYABLE_COMMAND_METHOD_NAME = "executeRetryableCommand";
+
+    private static final int METHOD_PARAM_COUNT = 9;
+
+    private static final Class[] EXECUTE_COMMAND_PARAMS_TYPE = {
+            String.class,
+            BsonDocument.class,
+            FieldNameValidator.class,
+            Decoder.class,
+            ConnectionSource.class,
+            Connection.class,
+            ReadPreference.class
+    };
+
+    private static final String[] EXECUTE_RETRY_COMMAND_PARAMS_TYPE = {
+            "com.mongodb.internal.binding.WriteBinding",
+            "java.lang.String",
+            "com.mongodb.ReadPreference",
+            "org.bson.FieldNameValidator",
+            "org.bson.codecs.Decoder",
+            "com.mongodb.internal.operation.CommandOperationHelper.CommandCreator",
+            "com.mongodb.internal.operation.CommandOperationHelper.CommandWriteTransformer",
+            "com.mongodb.Function"
+    };
+
+    private static final String[] EXECUTE_RETRY_COMMAND_ASYNC_PARAMS_TYPE = {
+            "com.mongodb.internal.binding.AsyncWriteBinding",
+            "java.lang.String",
+            "com.mongodb.ReadPreference",
+            "org.bson.FieldNameValidator",
+            "org.bson.codecs.Decoder",
+            "com.mongodb.internal.operation.CommandOperationHelper.CommandCreator",
+            "com.mongodb.internal.operation.CommandOperationHelper.CommandWriteTransformerAsync",
+            "com.mongodb.Function",
+            "com.mongodb.internal.async.SingleResultCallback"
+    };
+
+    private MongoDbEnhancementHelper() {
+    }
+
+    /**
+     * 获取CommandOperationHelper类的ClassMatcher
+     *
+     * @return ClassMatcher 类匹配器
+     */
+    public static ClassMatcher getCommandOperationHelperClassMatcher() {
+        return ClassMatcher.nameEquals(COMMAND_OPERATION_CLASS);
+    }
+
+    /**
+     * 获取MixedBulkWriteOperation类的ClassMatcher
+     *
+     * @return ClassMatcher 类匹配器
+     */
+    public static ClassMatcher getMixedBulkWriteOperationClassMatcher() {
+        return ClassMatcher.nameEquals(MIXED_BULK_WRITE_CLASS);
+    }
+
+    /**
+     * 获取MixedBulkWriteOperation写操作无参拦截器数组
+     *
+     * @return InterceptDeclarer[] MixedBulkWriteOperation写操作无参拦截器数组
+     */
+    public static InterceptDeclarer[] getMixedBulkWriteOperationInterceptDeclarers() {
+        MixedBulkWriteOperationInterceptor mixedBulkWriteOperationInterceptor =
+                new MixedBulkWriteOperationInterceptor();
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(getExecuteMethodMatcher(), mixedBulkWriteOperationInterceptor),
+                InterceptDeclarer.build(getExecuteAsyncMethodMatcher(), mixedBulkWriteOperationInterceptor)
+        };
+    }
+
+    /**
+     * 获取MixedBulkWriteOperation execute方法无参拦截器
+     *
+     * @return InterceptDeclarer MixedBulkWriteOperation execute方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteMethodMatcher(),
+                new MixedBulkWriteOperationInterceptor());
+    }
+
+    /**
+     * 获取MixedBulkWriteOperation execute方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer MixedBulkWriteOperation execute方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteMethodMatcher(),
+                new MixedBulkWriteOperationInterceptor(handler));
+    }
+
+    /**
+     * 获取MixedBulkWriteOperation executeAsync方法无参拦截器
+     *
+     * @return InterceptDeclarer MixedBulkWriteOperation executeAsync方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteAsyncInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteAsyncMethodMatcher(),
+                new MixedBulkWriteOperationInterceptor());
+    }
+
+    /**
+     * 获取MixedBulkWriteOperation executeAsync方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer MixedBulkWriteOperation executeAsync方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteAsyncInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteAsyncMethodMatcher(),
+                new MixedBulkWriteOperationInterceptor(handler));
+    }
+
+    /**
+     * 获取CommandOperationHelper写操作无参拦截器
+     *
+     * @return InterceptDeclarer[] CommandOperationHelper写操作无参拦截器
+     */
+    public static InterceptDeclarer[] getCommandOperationHelperInterceptDeclarers() {
+        ExecuteCommandInterceptor commandInterceptor = new ExecuteCommandInterceptor();
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(getExecuteCommandMethodMatcher(), commandInterceptor),
+                InterceptDeclarer.build(getExecuteCommandAsyncMethodMatcher(), commandInterceptor),
+                InterceptDeclarer.build(getExecuteWriteCommandMethodMatcher(), commandInterceptor),
+                InterceptDeclarer.build(getExecuteRetryableCommandMethodMatcher(),
+                        new ExecuteRetryableCommandInterceptor())
+        };
+    }
+
+    /**
+     * 获取CommandOperationHelper executeCommand方法无参拦截器
+     *
+     * @return InterceptDeclarer CommandOperationHelper executeCommand方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteCommandInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteCommandMethodMatcher(), new ExecuteCommandInterceptor());
+    }
+
+    /**
+     * 获取CommandOperationHelper executeCommand方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer CommandOperationHelper executeCommand方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteCommandInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteCommandMethodMatcher(), new ExecuteCommandInterceptor(handler));
+    }
+
+    /**
+     * 获取CommandOperationHelper executeWriteCommand方法无参拦截器
+     *
+     * @return InterceptDeclarer CommandOperationHelper executeWriteCommand方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteWriteCommandInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteWriteCommandMethodMatcher(), new ExecuteCommandInterceptor());
+    }
+
+    /**
+     * 获取CommandOperationHelper executeWriteCommand方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer CommandOperationHelper executeWriteCommand方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteWriteCommandInterceptDeclarer(
+            DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteWriteCommandMethodMatcher(), new ExecuteCommandInterceptor(handler));
+    }
+
+    /**
+     * 获取CommandOperationHelper executeCommandAsync方法无参拦截器
+     *
+     * @return InterceptDeclarer CommandOperationHelper executeCommandAsync方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteCommandAsyncInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteCommandAsyncMethodMatcher(), new ExecuteCommandInterceptor());
+    }
+
+    /**
+     * 获取CommandOperationHelper executeCommandAsync方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer CommandOperationHelper executeCommandAsync方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteCommandAsyncInterceptDeclarer(
+            DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteCommandAsyncMethodMatcher(), new ExecuteCommandInterceptor(handler));
+    }
+
+    /**
+     * 获取CommandOperationHelper executeRetryableCommand方法无参拦截器
+     *
+     * @return InterceptDeclarer CommandOperationHelper executeRetryableCommand方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteRetryableCommandInterceptDeclarer() {
+        return InterceptDeclarer
+                .build(getExecuteRetryableCommandMethodMatcher(), new ExecuteRetryableCommandInterceptor());
+    }
+
+    /**
+     * 获取CommandOperationHelper executeRetryableCommand方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer CommandOperationHelper executeRetryableCommand方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteRetryableCommandInterceptDeclarer(
+            DatabaseHandler handler) {
+        return InterceptDeclarer
+                .build(getExecuteRetryableCommandMethodMatcher(), new ExecuteRetryableCommandInterceptor(handler));
+    }
+
+    private static MethodMatcher getExecuteMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_METHOD_NAME);
+    }
+
+    private static MethodMatcher getExecuteAsyncMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_ASYNC_METHOD_NAME);
+    }
+
+    private static MethodMatcher getExecuteCommandMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_COMMAND_METHOD_NAME)
+                .and(MethodMatcher.paramTypesEqual(EXECUTE_COMMAND_PARAMS_TYPE));
+    }
+
+    private static MethodMatcher getExecuteWriteCommandMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_WRITE_COMMAND_METHOD_NAME)
+                .and(MethodMatcher.paramCountEquals(METHOD_PARAM_COUNT));
+    }
+
+    private static MethodMatcher getExecuteCommandAsyncMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_COMMAND_ASYNC_METHOD_NAME)
+                .and(MethodMatcher.paramCountEquals(METHOD_PARAM_COUNT));
+    }
+
+    private static MethodMatcher getExecuteRetryableCommandMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_RETRYABLE_COMMAND_METHOD_NAME)
+                .and(MethodMatcher.paramTypesEqual(EXECUTE_RETRY_COMMAND_ASYNC_PARAMS_TYPE)
+                        .or(MethodMatcher.paramTypesEqual(EXECUTE_RETRY_COMMAND_PARAMS_TYPE)));
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.huaweicloud.sermant.mongodb.declarers.MixedBulkWriteOperationDeclarer
+com.huaweicloud.sermant.mongodb.declarers.CommandOperationHelperDeclarer

--- a/sermant-plugins/sermant-database-write-prohibition/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-plugins</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sermant-database-write-prohibition</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <sermant.basedir>${pom.basedir}/../../..</sermant.basedir>
+        <package.plugin.name>database-write-prohibition</package.plugin.name>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>agent</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>database-controller</module>
+                <module>mongodb-3.x-4.x-plugin</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>test</id>
+            <modules>
+                <module>database-controller</module>
+                <module>mongodb-3.x-4.x-plugin</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>release</id>
+            <modules>
+                <module>database-controller</module>
+                <module>mongodb-3.x-4.x-plugin</module>
+            </modules>
+        </profile>
+    </profiles>
+
+</project>


### PR DESCRIPTION
【Fix issue】#1422

[Modification content] Added the controller module and mongodb write prohibition module developed by the data layer middleware plug-in

[Use case description] Not involved

[Self-test situation] 1. Local static check passed

[Scope of Influence] Follow-up supplementary plug-in documentation