### PR TITLE
Modify the compatibility of label routing when upgrading from 1.0-1.3

### DIFF
--- a/sermant-plugins/sermant-router/config/config.yaml
+++ b/sermant-plugins/sermant-router/config/config.yaml
@@ -7,10 +7,14 @@ router.plugin:
   request-tags: []
   # 需要解析的请求头的tag
   parse-header-tag: ''
+  # 是否初始化dubbo区域路由，兼容性开关，开启后，会在dubbo的配置缓存中初始化一条以zone匹配的同标签路由
+  enabled-dubbo-zone-router: false
+  # 是否初始化spring cloud区域路由，兼容性开关，开启后，会在spring cloud的配置缓存中初始化一条以zone匹配的同标签路由
+  enabled-spring-zone-router: false
 transmit.plugin:
   # 是否在直接new Thread时传递标签
   enabled-thread: true
   # 是否在非定时线程池中传递标签
   enabled-thread-pool: true
   # 是否在定时线程池的schedule/scheduleAtFixedRate/scheduleWithFixedDelay方法中传递标签
-  enabled-scheduler: true
+  enabled-scheduler: false

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/config/RouterConfig.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/config/RouterConfig.java
@@ -47,6 +47,18 @@ public class RouterConfig implements PluginConfig {
     private String zone;
 
     /**
+     * 是否初始化dubbo区域路由，兼容性开关，开启后，会在dubbo的配置缓存中初始化一条以zone匹配的同标签路由
+     */
+    @ConfigFieldKey("enabled-dubbo-zone-router")
+    private boolean enabledDubboZoneRouter;
+
+    /**
+     * 是否初始化spring cloud区域路由，兼容性开关，开启后，会在spring cloud的配置缓存中初始化一条以zone匹配的同标签路由
+     */
+    @ConfigFieldKey("enabled-spring-zone-router")
+    private boolean enabledSpringZoneRouter;
+
+    /**
      * 是否适配注册插件
      */
     @ConfigFieldKey("enabled-registry-plugin-adaptation")
@@ -102,6 +114,22 @@ public class RouterConfig implements PluginConfig {
 
     public void setZone(String zone) {
         this.zone = zone;
+    }
+
+    public boolean isEnabledDubboZoneRouter() {
+        return enabledDubboZoneRouter;
+    }
+
+    public void setEnabledDubboZoneRouter(boolean enabledDubboZoneRouter) {
+        this.enabledDubboZoneRouter = enabledDubboZoneRouter;
+    }
+
+    public boolean isEnabledSpringZoneRouter() {
+        return enabledSpringZoneRouter;
+    }
+
+    public void setEnabledSpringZoneRouter(boolean enabledSpringZoneRouter) {
+        this.enabledSpringZoneRouter = enabledSpringZoneRouter;
     }
 
     public boolean isEnabledRegistryPluginAdaptation() {

--- a/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/constants/RouterConstant.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/com/huaweicloud/sermant/router/common/constants/RouterConstant.java
@@ -47,12 +47,12 @@ public class RouterConstant {
     public static final String IS_METHOD_SUFFIX = "()";
 
     /**
-     * 标签路由key前缀
+     * 流量路由key前缀
      */
     public static final String ROUTER_KEY_PREFIX = "servicecomb.routeRule";
 
     /**
-     * 标签路由全局规则key
+     * 流量路由全局规则key
      */
     public static final String GLOBAL_ROUTER_KEY = "servicecomb.globalRouteRule";
 
@@ -155,6 +155,38 @@ public class RouterConstant {
      * zone
      */
     public static final String ZONE = "zone";
+
+    /**
+     * 标签路由key前缀
+     */
+    public static final String TAG_KEY_PREFIX = "servicecomb.tagRule";
+
+    /**
+     * 标签路由全局规则key
+     */
+    public static final String GLOBAL_TAG_KEY = "servicecomb.globalTagRule";
+
+    /**
+     * 泳道key前缀
+     */
+    public static final String LANE_KEY_PREFIX = "servicecomb.laneRule";
+
+    /**
+     * 泳道全局规则key
+     */
+    public static final String GLOBAL_LANE_KEY = "servicecomb.globalLaneRule";
+
+    /**
+     * 全量服务级兼容的key
+     */
+    public static final List<String> COMPATIBILITY_KEY_LIST = Arrays.asList(ROUTER_KEY_PREFIX, TAG_KEY_PREFIX,
+            LANE_KEY_PREFIX);
+
+    /**
+     * 全局级兼容的key
+     */
+    public static final List<String> GLOBAL_COMPATIBILITY_KEY_LIST = Arrays.asList(GLOBAL_ROUTER_KEY, GLOBAL_TAG_KEY,
+            GLOBAL_LANE_KEY);
 
     private RouterConstant() {
     }

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/entity/RouterConfiguration.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/entity/RouterConfiguration.java
@@ -103,6 +103,20 @@ public class RouterConfiguration {
     }
 
     /**
+     * 按类型更新服务粒度的路由规则
+     *
+     * @param serviceName 服务名
+     * @param entireRule 规则
+     */
+    public void updateServiceRule(String serviceName, EntireRule entireRule) {
+        Map<String, List<Rule>> ruleList = rules.computeIfAbsent(entireRule.getKind(),
+                key -> new ConcurrentHashMap<>());
+        ruleList.put(serviceName, entireRule.getRules());
+        LOGGER.info(String.format(Locale.ROOT, "Rule for %s has been updated: %s ", serviceName,
+                JSONObject.toJSONString(entireRule)));
+    }
+
+    /**
      * 移除服务的路由规则
      *
      * @param serviceName 服务名
@@ -124,6 +138,20 @@ public class RouterConfiguration {
     }
 
     /**
+     * 移除服务的路由规则
+     *
+     * @param serviceName 服务名
+     * @param kind 规则类型
+     */
+    public void removeServiceRule(String serviceName, String kind) {
+        Map<String, List<Rule>> ruleList = rules.get(kind);
+        if (!CollectionUtils.isEmpty(ruleList)) {
+            ruleList.remove(serviceName);
+        }
+        LOGGER.info(String.format(Locale.ROOT, "%s rules for %s have been removed! ", kind, serviceName));
+    }
+
+    /**
      * 重置路由规则
      *
      * @param map 路由规则
@@ -140,6 +168,29 @@ public class RouterConfiguration {
     }
 
     /**
+     * 重置路由规则
+     *
+     * @param kind 规则类型
+     * @param map 路由规则
+     */
+    public void resetRouteRule(String kind, Map<String, EntireRule> map) {
+        if (map == null) {
+            return;
+        }
+        if (map.isEmpty()) {
+            rules.remove(kind);
+        } else {
+            for (Map.Entry<String, EntireRule> ruleEntry : map.entrySet()) {
+                EntireRule entireRule = ruleEntry.getValue();
+                Map<String, List<Rule>> serviceRuleMap = rules.compute(kind, (key, value) -> new ConcurrentHashMap<>());
+                serviceRuleMap.put(ruleEntry.getKey(), entireRule.getRules());
+            }
+        }
+        LOGGER.info(String.format(Locale.ROOT, "Service rules have been updated: %s",
+                JSONObject.toJSONString(map)));
+    }
+
+    /**
      * 重置全局路由规则
      *
      * @param list 路由规则
@@ -151,6 +202,25 @@ public class RouterConfiguration {
         }
         LOGGER.info(String.format(Locale.ROOT, "Global rules have been updated: %s",
                 JSONObject.toJSONString(list)));
+    }
+
+    /**
+     * 重置全局路由规则
+     *
+     * @param entireRule 路由规则
+     */
+    public void resetGlobalRule(EntireRule entireRule) {
+        List<Rule> ruleList = entireRule.getRules();
+        if (ruleList == null) {
+            return;
+        }
+        if (ruleList.isEmpty()) {
+            globalRules.remove(entireRule.getKind());
+        } else {
+            globalRules.put(entireRule.getKind(), ruleList);
+        }
+        LOGGER.info(String.format(Locale.ROOT, "Global rules have been updated: %s",
+                JSONObject.toJSONString(entireRule)));
     }
 
     /**

--- a/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/utils/RuleUtils.java
+++ b/sermant-plugins/sermant-router/router-config-common/src/main/java/com/huaweicloud/sermant/router/config/utils/RuleUtils.java
@@ -258,59 +258,71 @@ public class RuleUtils {
                 entireIterator.remove();
                 continue;
             }
-
-            Iterator<Rule> ruleIterator = entireRule.getRules().iterator();
-            while (ruleIterator.hasNext()) {
-                Rule rule = ruleIterator.next();
-                List<Route> routes = rule.getRoute();
-
-                // 去掉没有配置路由的规则
-                if (CollectionUtils.isEmpty(routes)) {
-                    LOGGER.warning("Routes are empty, rule will be removed.");
-                    ruleIterator.remove();
-                    continue;
-                }
-
-                // 去掉无效的路由和修复同标签规则的路由
-                removeInvalidRoute(routes, kind, isReplaceDash, isAppendPrefix);
-
-                List<Route> fallback = rule.getFallback();
-                if (!CollectionUtils.isEmpty(fallback)) {
-                    // 去掉无效的fallback路由和修复同标签规则的fallback路由
-                    removeInvalidRoute(fallback, kind, isReplaceDash, isAppendPrefix);
-                }
-
-                // 去掉全是无效路由的规则
-                if (CollectionUtils.isEmpty(routes)) {
-                    LOGGER.warning("Routes are invalid, rule will be removed.");
-                    ruleIterator.remove();
-                    continue;
-                }
-
-                if (RouterConstant.FLOW_MATCH_KIND.equals(kind)) {
-                    // 去掉无效的规则
-                    removeInvalidMatch(rule.getMatch());
-
-                    // 无attachments规则，将headers规则更新到attachments规则
-                    setAttachmentsByHeaders(rule.getMatch());
-                    continue;
-                }
-
-                if (RouterConstant.TAG_MATCH_KIND.equals(kind)) {
-                    // 去掉无效的规则
-                    removeInvalidTagMatch(rule.getMatch(), isAppendPrefix);
-                    continue;
-                }
-
-                if (RouterConstant.LANE_MATCH_KIND.equals(kind)) {
-                    // 去掉无效的规则
-                    removeInvalidLaneMatch(rule.getMatch());
-                }
-            }
+            removeInvalidRules(entireRule.getKind(), entireRule.getRules(), isReplaceDash, isAppendPrefix);
 
             // 去掉全是无效规则的配置
             if (CollectionUtils.isEmpty(entireRule.getRules())) {
                 entireIterator.remove();
+            }
+        }
+    }
+
+    /**
+     * 去掉无效的规则
+     *
+     * @param kind 规则类型
+     * @param rules 规则
+     * @param isReplaceDash 是否需要把"-"替换成"."
+     * @param isAppendPrefix 元数据的key值是否需要加上前缀
+     */
+    public static void removeInvalidRules(String kind, List<Rule> rules, boolean isReplaceDash,
+            boolean isAppendPrefix) {
+        Iterator<Rule> ruleIterator = rules.iterator();
+        while (ruleIterator.hasNext()) {
+            Rule rule = ruleIterator.next();
+            List<Route> routes = rule.getRoute();
+
+            // 去掉没有配置路由的规则
+            if (CollectionUtils.isEmpty(routes)) {
+                LOGGER.warning("Routes are empty, rule will be removed.");
+                ruleIterator.remove();
+                continue;
+            }
+
+            // 去掉无效的路由和修复同标签规则的路由
+            removeInvalidRoute(routes, kind, isReplaceDash, isAppendPrefix);
+
+            List<Route> fallback = rule.getFallback();
+            if (!CollectionUtils.isEmpty(fallback)) {
+                // 去掉无效的fallback路由和修复同标签规则的fallback路由
+                removeInvalidRoute(fallback, kind, isReplaceDash, isAppendPrefix);
+            }
+
+            // 去掉全是无效路由的规则
+            if (CollectionUtils.isEmpty(routes)) {
+                LOGGER.warning("Routes are invalid, rule will be removed.");
+                ruleIterator.remove();
+                continue;
+            }
+
+            if (RouterConstant.FLOW_MATCH_KIND.equals(kind)) {
+                // 去掉无效的规则
+                removeInvalidMatch(rule.getMatch());
+
+                // 无attachments规则，将headers规则更新到attachments规则
+                setAttachmentsByHeaders(rule.getMatch());
+                continue;
+            }
+
+            if (RouterConstant.TAG_MATCH_KIND.equals(kind)) {
+                // 去掉无效的规则
+                removeInvalidTagMatch(rule.getMatch(), isAppendPrefix);
+                continue;
+            }
+
+            if (RouterConstant.LANE_MATCH_KIND.equals(kind)) {
+                // 去掉无效的规则
+                removeInvalidLaneMatch(rule.getMatch());
             }
         }
     }

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/AbstractConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/AbstractConfigHandler.java
@@ -16,7 +16,7 @@
 
 package com.huaweicloud.sermant.router.config.handler;
 
-import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
 import com.huaweicloud.sermant.router.config.common.SafeConstructor;
 
 import org.yaml.snakeyaml.Yaml;
@@ -27,7 +27,7 @@ import org.yaml.snakeyaml.Yaml;
  * @author provenceee
  * @since 2022-08-09
  */
-public abstract class AbstractConfigHandler {
+public abstract class AbstractConfigHandler implements AbstractHandler {
     /**
      * yaml
      */
@@ -41,18 +41,14 @@ public abstract class AbstractConfigHandler {
     }
 
     /**
-     * 路由配置处理
-     *
-     * @param event 配置监听事件
-     * @param cacheName 缓存名
-     */
-    public abstract void handle(DynamicConfigEvent event, String cacheName);
-
-    /**
      * 是否需要处理
      *
      * @param key 配置key
+     * @param content 配置内容
      * @return 是否需要处理
      */
-    public abstract boolean shouldHandle(String key);
+    @Override
+    public boolean shouldHandle(String key, String content) {
+        return RouterConstant.MATCH_KIND_LIST.stream().anyMatch(content::contains);
+    }
 }

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/AbstractHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/AbstractHandler.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+
+/**
+ * 处理器接口
+ *
+ * @author provenceee
+ * @since 2024-01-16
+ */
+public interface AbstractHandler {
+    /**
+     * 配置处理
+     *
+     * @param event 配置监听事件
+     * @param cacheName 缓存名
+     */
+    void handle(DynamicConfigEvent event, String cacheName);
+
+    /**
+     * 是否需要处理
+     *
+     * @param key 配置key
+     * @param content 配置内容
+     * @return 是否需要处理
+     */
+    boolean shouldHandle(String key, String content);
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/GlobalConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/GlobalConfigHandler.java
@@ -69,8 +69,8 @@ public class GlobalConfigHandler extends AbstractConfigHandler {
     }
 
     @Override
-    public boolean shouldHandle(String key) {
-        return RouterConstant.GLOBAL_ROUTER_KEY.equals(key);
+    public boolean shouldHandle(String key, String content) {
+        return super.shouldHandle(key, content) && RouterConstant.GLOBAL_ROUTER_KEY.equals(key);
     }
 
     private List<Map<String, Object>> getRule(DynamicConfigEvent event) {

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandler.java
@@ -77,8 +77,8 @@ public class RouterConfigHandler extends AbstractConfigHandler {
     }
 
     @Override
-    public boolean shouldHandle(String key) {
-        return RouterConstant.ROUTER_KEY_PREFIX.equals(key);
+    public boolean shouldHandle(String key, String content) {
+        return super.shouldHandle(key, content) && RouterConstant.ROUTER_KEY_PREFIX.equals(key);
     }
 
     private Map<String, List<Object>> getRouteRuleMap(DynamicConfigEvent event) {

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/ServiceConfigHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/ServiceConfigHandler.java
@@ -73,8 +73,8 @@ public class ServiceConfigHandler extends AbstractConfigHandler {
     }
 
     @Override
-    public boolean shouldHandle(String key) {
-        return key.startsWith(RouterConstant.ROUTER_KEY_PREFIX + POINT);
+    public boolean shouldHandle(String key, String content) {
+        return super.shouldHandle(key, content) && key.startsWith(RouterConstant.ROUTER_KEY_PREFIX + POINT);
     }
 
     private List<Map<String, Object>> getRule(DynamicConfigEvent event, String serviceName) {

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/AbstractKindHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/AbstractKindHandler.java
@@ -1,0 +1,232 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.core.utils.StringUtils;
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.common.event.RouterEventCollector;
+import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
+import com.huaweicloud.sermant.router.config.cache.ConfigCache;
+import com.huaweicloud.sermant.router.config.common.SafeConstructor;
+import com.huaweicloud.sermant.router.config.entity.EntireRule;
+import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
+import com.huaweicloud.sermant.router.config.entity.Rule;
+import com.huaweicloud.sermant.router.config.handler.AbstractHandler;
+import com.huaweicloud.sermant.router.config.utils.RuleUtils;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * 配置类型处理器（兼容1.0.x版本使用）
+ *
+ * @author provenceee
+ * @since 2024-01-11
+ */
+public abstract class AbstractKindHandler implements AbstractHandler {
+    /**
+     * yaml
+     */
+    protected final Yaml yaml;
+
+    private final String prefix;
+
+    private final String kind;
+
+    /**
+     * 构造方法
+     *
+     * @param prefix 服务级key的前缀，用来截取服务名
+     * @param kind 配置类型
+     */
+    public AbstractKindHandler(String prefix, String kind) {
+        this.yaml = new Yaml(new SafeConstructor(null));
+        this.prefix = prefix;
+        this.kind = kind;
+    }
+
+    /**
+     * 路由配置类型处理
+     *
+     * @param event 配置监听事件
+     * @param cacheName 缓存名
+     */
+    @Override
+    public void handle(DynamicConfigEvent event, String cacheName) {
+        if (RouterConstant.GLOBAL_COMPATIBILITY_KEY_LIST.contains(event.getKey())) {
+            handleGlobalRules(event, cacheName);
+        } else if (RouterConstant.COMPATIBILITY_KEY_LIST.contains(event.getKey())) {
+            handleRouterRules(event, cacheName);
+        } else {
+            handleServiceRules(event, cacheName);
+        }
+    }
+
+    /**
+     * 是否需要兼容性处理
+     *
+     * @param key 配置key
+     * @param content 配置内容
+     * @return 是否需要处理
+     */
+    @Override
+    public boolean shouldHandle(String key, String content) {
+        return RouterConstant.MATCH_KIND_LIST.stream().noneMatch(content::contains);
+    }
+
+    /**
+     * 解析全局配置
+     *
+     * @param event 事件
+     * @param cacheName 缓存key
+     */
+    private void handleGlobalRules(DynamicConfigEvent event, String cacheName) {
+        RouterConfiguration configuration = ConfigCache.getLabel(cacheName);
+        if (event.getEventType() == DynamicConfigEventType.DELETE) {
+            configuration.resetGlobalRule(getEntireRule(Collections.emptyList()));
+            RuleUtils.initMatchKeys(configuration);
+            RouterEventCollector.getInstance()
+                    .collectGlobalRouteRuleEvent(JSON.toJSONString(configuration.getGlobalRule()));
+            return;
+        }
+
+        List<Rule> list = JSONArray.parseArray(JSONObject.toJSONString(getGlobalRules(event)), Rule.class);
+        RuleUtils.removeInvalidRules(kind, list, RouterConstant.DUBBO_CACHE_NAME.equals(cacheName),
+                RouterConstant.DUBBO_CACHE_NAME.equals(cacheName));
+        if (!CollectionUtils.isEmpty(list)) {
+            list.sort((o1, o2) -> o2.getPrecedence() - o1.getPrecedence());
+        }
+        configuration.resetGlobalRule(getEntireRule(list));
+        RuleUtils.initMatchKeys(configuration);
+        RouterEventCollector.getInstance()
+                .collectGlobalRouteRuleEvent(JSON.toJSONString(configuration.getGlobalRule()));
+    }
+
+    /**
+     * 解析服务级配置（全集）
+     *
+     * @param event 事件
+     * @param cacheName 缓存key
+     */
+    private void handleRouterRules(DynamicConfigEvent event, String cacheName) {
+        RouterConfiguration configuration = ConfigCache.getLabel(cacheName);
+        if (event.getEventType() == DynamicConfigEventType.DELETE) {
+            configuration.resetRouteRule(kind, Collections.emptyMap());
+            RuleUtils.initKeys(configuration);
+            RouterEventCollector.getInstance()
+                    .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
+            return;
+        }
+        Map<String, String> routeRuleMap = getRouteRuleMap(event);
+        Map<String, EntireRule> routeRule = new HashMap<>();
+        for (Entry<String, String> entry : routeRuleMap.entrySet()) {
+            List<Map<String, String>> routeRuleList = yaml.load(entry.getValue());
+            if (CollectionUtils.isEmpty(routeRuleList)) {
+                continue;
+            }
+            List<Rule> list = JSONArray.parseArray(JSONObject.toJSONString(routeRuleList), Rule.class);
+            RuleUtils.removeInvalidRules(kind, list, RouterConstant.DUBBO_CACHE_NAME.equals(cacheName),
+                    RouterConstant.DUBBO_CACHE_NAME.equals(cacheName));
+            if (!CollectionUtils.isEmpty(list)) {
+                list.sort((o1, o2) -> o2.getPrecedence() - o1.getPrecedence());
+                routeRule.put(entry.getKey(), getEntireRule(list));
+            }
+        }
+        configuration.resetRouteRule(kind, routeRule);
+        RuleUtils.initKeys(configuration);
+        RouterEventCollector.getInstance()
+                .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
+    }
+
+    /**
+     * 解析服务级配置
+     *
+     * @param event 事件
+     * @param cacheName 缓存key
+     */
+    private void handleServiceRules(DynamicConfigEvent event, String cacheName) {
+        RouterConfiguration configuration = ConfigCache.getLabel(cacheName);
+        String serviceName = event.getKey().substring(prefix.length() + 1);
+        if (event.getEventType() == DynamicConfigEventType.DELETE) {
+            configuration.removeServiceRule(serviceName, kind);
+            RuleUtils.initKeys(configuration);
+            RouterEventCollector.getInstance()
+                    .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
+            return;
+        }
+        List<Rule> list = JSONArray.parseArray(JSONObject.toJSONString(getServiceRules(event, serviceName)),
+                Rule.class);
+        RuleUtils.removeInvalidRules(kind, list, RouterConstant.DUBBO_CACHE_NAME.equals(cacheName),
+                RouterConstant.DUBBO_CACHE_NAME.equals(cacheName));
+        if (CollectionUtils.isEmpty(list)) {
+            configuration.removeServiceRule(serviceName, kind);
+        } else {
+            list.sort((o1, o2) -> o2.getPrecedence() - o1.getPrecedence());
+            configuration.updateServiceRule(serviceName, getEntireRule(list));
+        }
+        RuleUtils.initKeys(configuration);
+        RouterEventCollector.getInstance()
+                .collectServiceRouteRuleEvent(JSON.toJSONString(configuration.getRouteRule()));
+    }
+
+    private EntireRule getEntireRule(List<Rule> rules) {
+        EntireRule entireRule = new EntireRule();
+        entireRule.setKind(kind);
+        entireRule.setRules(rules == null ? Collections.emptyList() : rules);
+        return entireRule;
+    }
+
+    private List<Map<String, Object>> getGlobalRules(DynamicConfigEvent event) {
+        String content = event.getContent();
+        if (StringUtils.isBlank(content)) {
+            return Collections.emptyList();
+        }
+        Map<String, List<Map<String, Object>>> map = yaml.load(content);
+        return map.get(RouterConstant.GLOBAL_ROUTER_KEY);
+    }
+
+    private List<Map<String, Object>> getServiceRules(DynamicConfigEvent event, String serviceName) {
+        String content = event.getContent();
+        if (StringUtils.isBlank(content)) {
+            return Collections.emptyList();
+        }
+        Map<String, List<Map<String, Object>>> map = yaml.load(content);
+        return map.get(prefix + RouterConstant.POINT + serviceName);
+    }
+
+    private Map<String, String> getRouteRuleMap(DynamicConfigEvent event) {
+        String content = event.getContent();
+        Map<String, String> routeRuleMap = yaml.load(content);
+        if (CollectionUtils.isEmpty(routeRuleMap)) {
+            return Collections.emptyMap();
+        }
+        return routeRuleMap;
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/FlowKindHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/FlowKindHandler.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 流量配置处理器（兼容1.0.x版本使用）
+ *
+ * @author provenceee
+ * @since 2024-01-11
+ */
+public class FlowKindHandler extends AbstractKindHandler {
+    private final Set<String> keys;
+
+    /**
+     * 构造方法
+     */
+    public FlowKindHandler() {
+        super(RouterConstant.ROUTER_KEY_PREFIX, RouterConstant.FLOW_MATCH_KIND);
+        this.keys = new HashSet<>();
+        this.keys.add(RouterConstant.GLOBAL_ROUTER_KEY);
+        this.keys.add(RouterConstant.ROUTER_KEY_PREFIX);
+    }
+
+    @Override
+    public boolean shouldHandle(String key, String content) {
+        return super.shouldHandle(key, content)
+                && (keys.contains(key) || key.startsWith(RouterConstant.ROUTER_KEY_PREFIX + RouterConstant.POINT));
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/LaneKindHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/LaneKindHandler.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 泳道配置处理器（兼容1.0.x版本使用）
+ *
+ * @author provenceee
+ * @since 2024-01-11
+ */
+public class LaneKindHandler extends AbstractKindHandler {
+    private final Set<String> keys;
+
+    /**
+     * 构造方法
+     */
+    public LaneKindHandler() {
+        super(RouterConstant.LANE_KEY_PREFIX, RouterConstant.LANE_MATCH_KIND);
+        this.keys = new HashSet<>();
+        this.keys.add(RouterConstant.GLOBAL_LANE_KEY);
+        this.keys.add(RouterConstant.LANE_KEY_PREFIX);
+    }
+
+    @Override
+    public boolean shouldHandle(String key, String content) {
+        return super.shouldHandle(key, content)
+                && (keys.contains(key) || key.startsWith(RouterConstant.LANE_KEY_PREFIX + RouterConstant.POINT));
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/TagKindHandler.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/handler/kind/TagKindHandler.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 标签配置处理器（兼容1.0.x版本使用）
+ *
+ * @author provenceee
+ * @since 2024-01-11
+ */
+public class TagKindHandler extends AbstractKindHandler {
+    private final Set<String> keys;
+
+    /**
+     * 构造方法
+     */
+    public TagKindHandler() {
+        super(RouterConstant.TAG_KEY_PREFIX, RouterConstant.TAG_MATCH_KIND);
+        this.keys = new HashSet<>();
+        this.keys.add(RouterConstant.GLOBAL_TAG_KEY);
+        this.keys.add(RouterConstant.TAG_KEY_PREFIX);
+    }
+
+    @Override
+    public boolean shouldHandle(String key, String content) {
+        return super.shouldHandle(key, content)
+                && (keys.contains(key) || key.startsWith(RouterConstant.TAG_KEY_PREFIX + RouterConstant.POINT));
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/listener/RouterConfigListener.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/main/java/com/huaweicloud/sermant/router/config/listener/RouterConfigListener.java
@@ -19,12 +19,15 @@ package com.huaweicloud.sermant.router.config.listener;
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
 import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
-import com.huaweicloud.sermant.router.config.handler.AbstractConfigHandler;
+import com.huaweicloud.sermant.router.config.handler.AbstractHandler;
 import com.huaweicloud.sermant.router.config.handler.GlobalConfigHandler;
 import com.huaweicloud.sermant.router.config.handler.RouterConfigHandler;
 import com.huaweicloud.sermant.router.config.handler.ServiceConfigHandler;
+import com.huaweicloud.sermant.router.config.handler.kind.FlowKindHandler;
+import com.huaweicloud.sermant.router.config.handler.kind.LaneKindHandler;
+import com.huaweicloud.sermant.router.config.handler.kind.TagKindHandler;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -40,7 +43,7 @@ public class RouterConfigListener implements DynamicConfigListener {
 
     private final String cacheName;
 
-    private final Set<AbstractConfigHandler> handlers;
+    private final Set<AbstractHandler> handlers;
 
     /**
      * 构造方法
@@ -49,7 +52,10 @@ public class RouterConfigListener implements DynamicConfigListener {
      */
     public RouterConfigListener(String cacheName) {
         this.cacheName = cacheName;
-        this.handlers = new HashSet<>();
+        this.handlers = new LinkedHashSet<>();
+        this.handlers.add(new FlowKindHandler());
+        this.handlers.add(new LaneKindHandler());
+        this.handlers.add(new TagKindHandler());
         this.handlers.add(new GlobalConfigHandler());
         this.handlers.add(new RouterConfigHandler());
         this.handlers.add(new ServiceConfigHandler());
@@ -59,7 +65,7 @@ public class RouterConfigListener implements DynamicConfigListener {
     public void process(DynamicConfigEvent event) {
         String key = event.getKey();
         handlers.forEach(handler -> {
-            if (handler.shouldHandle(key)) {
+            if (handler.shouldHandle(key, event.getContent())) {
                 handler.handle(event, cacheName);
             }
         });

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/GlobalConfigHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/GlobalConfigHandlerTest.java
@@ -16,6 +16,8 @@
 
 package com.huaweicloud.sermant.router.config.handler;
 
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,6 +39,6 @@ public class GlobalConfigHandlerTest {
      */
     @Test
     public void testShouldHandle() {
-        Assert.assertTrue(handler.shouldHandle("servicecomb.globalRouteRule"));
+        Assert.assertTrue(handler.shouldHandle("servicecomb.globalRouteRule", RouterConstant.FLOW_MATCH_KIND));
     }
 }

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/RouterConfigHandlerTest.java
@@ -16,6 +16,8 @@
 
 package com.huaweicloud.sermant.router.config.handler;
 
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,7 +39,7 @@ public class RouterConfigHandlerTest {
      */
     @Test
     public void testShouldHandle() {
-        Assert.assertTrue(handler.shouldHandle("servicecomb.routeRule"));
-        Assert.assertFalse(handler.shouldHandle("servicecomb.routeRule.foo"));
+        Assert.assertTrue(handler.shouldHandle("servicecomb.routeRule", RouterConstant.FLOW_MATCH_KIND));
+        Assert.assertFalse(handler.shouldHandle("servicecomb.routeRule.foo", RouterConstant.FLOW_MATCH_KIND));
     }
 }

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/ServiceConfigHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/ServiceConfigHandlerTest.java
@@ -16,6 +16,8 @@
 
 package com.huaweicloud.sermant.router.config.handler;
 
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,7 +39,7 @@ public class ServiceConfigHandlerTest {
      */
     @Test
     public void testShouldHandle() {
-        Assert.assertTrue(handler.shouldHandle("servicecomb.routeRule.foo"));
-        Assert.assertFalse(handler.shouldHandle("servicecomb.routeRule"));
+        Assert.assertTrue(handler.shouldHandle("servicecomb.routeRule.foo", RouterConstant.FLOW_MATCH_KIND));
+        Assert.assertFalse(handler.shouldHandle("servicecomb.routeRule", RouterConstant.FLOW_MATCH_KIND));
     }
 }

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/AbstractKindHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/AbstractKindHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.event.config.EventConfig;
+import com.huaweicloud.sermant.core.plugin.config.PluginConfigManager;
+import com.huaweicloud.sermant.router.common.config.RouterConfig;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * 测试抽象类
+ *
+ * @author provenceee
+ * @since 2024-01-16
+ */
+public abstract class AbstractKindHandlerTest {
+    private static MockedStatic<ConfigManager> mockConfigManager;
+
+    private static MockedStatic<PluginConfigManager> mockPluginConfigManager;
+
+    /**
+     * 初始化
+     */
+    @BeforeClass
+    public static void init() {
+        EventConfig config = new EventConfig();
+        mockConfigManager = Mockito.mockStatic(ConfigManager.class);
+        mockConfigManager.when(() -> ConfigManager.getConfig(EventConfig.class)).thenReturn(config);
+
+        RouterConfig routerConfig = new RouterConfig();
+        routerConfig.setZone("foo");
+        mockPluginConfigManager = Mockito.mockStatic(PluginConfigManager.class);
+        mockPluginConfigManager.when(() -> PluginConfigManager.getPluginConfig(RouterConfig.class))
+                .thenReturn(routerConfig);
+    }
+
+    /**
+     * 清除mock
+     */
+    @AfterClass
+    public static void clear() {
+        mockConfigManager.close();
+        mockPluginConfigManager.close();
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/FlowKindHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/FlowKindHandlerTest.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
+import com.huaweicloud.sermant.router.config.cache.ConfigCache;
+import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * 测试流量配置处理器
+ *
+ * @author provenceee
+ * @since 2024-01-11
+ */
+public class FlowKindHandlerTest extends AbstractKindHandlerTest {
+    private final AbstractKindHandler handler;
+
+    private final String content;
+
+    private final String cacheName;
+
+    public FlowKindHandlerTest() {
+        this.handler = new FlowKindHandler();
+        this.content = "servicecomb.globalRouteRule:\n"
+                + "    - precedence: 2\n"
+                + "      match:\n"
+                + "        attachments:\n"
+                + "          id:\n"
+                + "            exact: '1'\n"
+                + "            caseInsensitive: false\n"
+                + "      route:\n"
+                + "        - weight: 20\n"
+                + "          tags:\n"
+                + "            version: 1.0.0\n"
+                + "        - weight: 80\n"
+                + "          tags:\n"
+                + "            version: 1.0.1\n"
+                + "    - precedence: 1\n"
+                + "      route:\n"
+                + "        - weight: 20\n"
+                + "          tags:\n"
+                + "            group: red\n"
+                + "        - weight: 80\n"
+                + "          tags:\n"
+                + "            group: green";
+        this.cacheName = "flowKindHandlerTest";
+    }
+
+    /**
+     * 测试shouldHandle方法
+     */
+    @Test
+    public void testShouldHandle() {
+        Assert.assertTrue(handler.shouldHandle(RouterConstant.GLOBAL_ROUTER_KEY, ""));
+        Assert.assertFalse(handler.shouldHandle(RouterConstant.GLOBAL_ROUTER_KEY, RouterConstant.FLOW_MATCH_KIND));
+    }
+
+    /**
+     * 测试shouldHandle方法
+     */
+    @Test
+    public void testHandle() {
+        // 初始化
+        RouterConfiguration configuration = ConfigCache.getLabel(cacheName);
+        Assert.assertTrue(CollectionUtils.isEmpty(configuration.getGlobalRule().get(RouterConstant.FLOW_MATCH_KIND)));
+
+        // 测试存在配置
+        DynamicConfigEvent event = new DynamicConfigEvent(RouterConstant.GLOBAL_ROUTER_KEY, "test", content,
+                DynamicConfigEventType.CREATE);
+        handler.handle(event, cacheName);
+        Assert.assertFalse(CollectionUtils.isEmpty(configuration.getGlobalRule().get(RouterConstant.FLOW_MATCH_KIND)));
+
+        // 测试删除配置
+        event = new DynamicConfigEvent(RouterConstant.GLOBAL_ROUTER_KEY, "test", content,
+                DynamicConfigEventType.DELETE);
+        handler.handle(event, cacheName);
+        Assert.assertTrue(CollectionUtils.isEmpty(configuration.getGlobalRule().get(RouterConstant.FLOW_MATCH_KIND)));
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/LaneKindHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/LaneKindHandlerTest.java
@@ -1,0 +1,112 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
+import com.huaweicloud.sermant.router.config.cache.ConfigCache;
+import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * 测试泳道配置处理器
+ *
+ * @author provenceee
+ * @since 2024-01-11
+ */
+public class LaneKindHandlerTest extends AbstractKindHandlerTest {
+    private final AbstractKindHandler handler;
+
+    private final String content;
+
+    private final String cacheName;
+
+    public LaneKindHandlerTest() {
+        this.handler = new LaneKindHandler();
+        this.content = "foo: |\n"
+                + "  - precedence: 2\n"
+                + "    match:\n"
+                + "      method: getFoo\n"
+                + "      path: \"com.huaweicloud.bar\"\n"
+                + "      protocol: dubbo\n"
+                + "      attachments:\n"
+                + "        id:\n"
+                + "          exact: '1'\n"
+                + "          caseInsensitive: false\n"
+                + "      args:\n"
+                + "        args0:\n"
+                + "          type: .name\n"
+                + "          exact: 'foo'\n"
+                + "    route:\n"
+                + "      - tag-inject:\n"
+                + "          x-sermant-flag2: gray2\n"
+                + "        weight: 100\n"
+                + "  - precedence: 1\n"
+                + "    match:\n"
+                + "      method: get\n"
+                + "      path: \"/foo\"\n"
+                + "      protocol: http\n"
+                + "      headers:\n"
+                + "        id:\n"
+                + "          exact: '1'\n"
+                + "      parameters:\n"
+                + "        name:\n"
+                + "          exact: 'foo'\n"
+                + "    route:\n"
+                + "      - tag-inject:\n"
+                + "          x-sermant-flag1: gray1\n"
+                + "        weight: 60";
+        this.cacheName = "LaneKindHandlerTest";
+    }
+
+    /**
+     * 测试shouldHandle方法
+     */
+    @Test
+    public void testShouldHandle() {
+        Assert.assertTrue(handler.shouldHandle(RouterConstant.LANE_KEY_PREFIX, ""));
+        Assert.assertFalse(handler.shouldHandle(RouterConstant.LANE_KEY_PREFIX, RouterConstant.LANE_MATCH_KIND));
+    }
+
+    /**
+     * 测试shouldHandle方法
+     */
+    @Test
+    public void testHandle() {
+        // 初始化
+        RouterConfiguration configuration = ConfigCache.getLabel(cacheName);
+        Assert.assertTrue(CollectionUtils.isEmpty(configuration.getRouteRule().get(RouterConstant.LANE_MATCH_KIND)));
+
+        // 测试存在配置
+        DynamicConfigEvent event = new DynamicConfigEvent(RouterConstant.LANE_KEY_PREFIX, "test", content,
+                DynamicConfigEventType.CREATE);
+        handler.handle(event, cacheName);
+        Assert.assertFalse(CollectionUtils.isEmpty(configuration.getRouteRule().get(RouterConstant.LANE_MATCH_KIND)));
+
+        // 测试删除配置
+        event = new DynamicConfigEvent(RouterConstant.LANE_KEY_PREFIX, "test", content,
+                DynamicConfigEventType.DELETE);
+        handler.handle(event, cacheName);
+        Assert.assertTrue(CollectionUtils.isEmpty(configuration.getRouteRule().get(RouterConstant.LANE_MATCH_KIND)));
+    }
+}

--- a/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/TagKindHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-config-service/src/test/java/com/huaweicloud/sermant/router/config/handler/kind/TagKindHandlerTest.java
@@ -1,0 +1,103 @@
+/*
+ *
+ *  * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.huaweicloud.sermant.router.config.handler.kind;
+
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.router.common.constants.RouterConstant;
+import com.huaweicloud.sermant.router.common.utils.CollectionUtils;
+import com.huaweicloud.sermant.router.config.cache.ConfigCache;
+import com.huaweicloud.sermant.router.config.entity.RouterConfiguration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * 测试标签配置处理器
+ *
+ * @author provenceee
+ * @since 2024-01-11
+ */
+public class TagKindHandlerTest extends AbstractKindHandlerTest {
+    private final AbstractKindHandler handler;
+
+    private final String content;
+
+    private final String cacheName;
+
+    public TagKindHandlerTest() {
+        this.handler = new TagKindHandler();
+        this.content = "servicecomb.tagRule.foo:\n"
+                + "    - precedence: 1\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          zone:\n"
+                + "            exact: 'hangzhou'\n"
+                + "            caseInsensitive: false\n"
+                + "      route:\n"
+                + "        - tags:\n"
+                + "            zone: CONSUMER_TAG\n"
+                + "    - precedence: 2\n"
+                + "      match:\n"
+                + "        tags:\n"
+                + "          version:\n"
+                + "            exact: '1.0.0'\n"
+                + "            caseInsensitive: false\n"
+                + "      route:\n"
+                + "        - weight: 20\n"
+                + "          tags:\n"
+                + "            group: red\n"
+                + "        - weight: 80\n"
+                + "          tags:\n"
+                + "            group: green";
+        this.cacheName = "TagKindHandlerTest";
+    }
+
+    /**
+     * 测试shouldHandle方法
+     */
+    @Test
+    public void testShouldHandle() {
+        Assert.assertTrue(handler.shouldHandle(RouterConstant.TAG_KEY_PREFIX + ".foo", ""));
+        Assert.assertFalse(
+                handler.shouldHandle(RouterConstant.TAG_KEY_PREFIX + ".foo", RouterConstant.TAG_MATCH_KIND));
+    }
+
+    /**
+     * 测试shouldHandle方法
+     */
+    @Test
+    public void testHandle() {
+        // 初始化
+        RouterConfiguration configuration = ConfigCache.getLabel(cacheName);
+        Assert.assertTrue(CollectionUtils.isEmpty(configuration.getRouteRule().get(RouterConstant.TAG_MATCH_KIND)));
+
+        // 测试存在配置
+        DynamicConfigEvent event = new DynamicConfigEvent(RouterConstant.TAG_KEY_PREFIX + ".foo", "test", content,
+                DynamicConfigEventType.CREATE);
+        handler.handle(event, cacheName);
+        Assert.assertFalse(CollectionUtils.isEmpty(configuration.getRouteRule().get(RouterConstant.TAG_MATCH_KIND)));
+
+        // 测试删除配置
+        event = new DynamicConfigEvent(RouterConstant.TAG_KEY_PREFIX + ".foo", "test", content,
+                DynamicConfigEventType.DELETE);
+        handler.handle(event, cacheName);
+        Assert.assertTrue(CollectionUtils.isEmpty(configuration.getRouteRule().get(RouterConstant.TAG_MATCH_KIND)));
+    }
+}

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HystrixActionDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/HystrixActionDeclarer.java
@@ -56,6 +56,7 @@ public class HystrixActionDeclarer extends AbstractDeclarer {
 
     @Override
     public boolean isEnabled() {
+        // 不开启线程池异步路由时，才需要开启这个
         return !PluginConfigManager.getPluginConfig(TransmitConfig.class).isEnabledThreadPool();
     }
 }

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/ServiceInstanceListSupplierDeclarer.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/declarer/ServiceInstanceListSupplierDeclarer.java
@@ -50,6 +50,7 @@ public class ServiceInstanceListSupplierDeclarer extends AbstractDeclarer {
 
     @Override
     public boolean isEnabled() {
+        // 不开启线程池异步路由时，才需要开启这个
         return !PluginConfigManager.getPluginConfig(TransmitConfig.class).isEnabledThreadPool();
     }
 }

--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/FeignClientInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/com/huaweicloud/sermant/router/spring/interceptor/FeignClientInterceptor.java
@@ -164,6 +164,7 @@ public class FeignClientInterceptor extends AbstractInterceptor {
 
     private boolean canLoadHystrix() {
         if (PluginConfigManager.getPluginConfig(TransmitConfig.class).isEnabledThreadPool()) {
+            // 开启线程池异步路由时，透传标签不需要依赖HystrixRequestContext，所以直接返回false
             return false;
         }
         try {


### PR DESCRIPTION
【Fix issue】 #1406

[Modification content] Modified the incompatibility issue introduced by label routing when upgrading from 1.0-1.3. For specific modification points, please view the issue

[Self-test situation] Local self-test passed, ut test passed

[Scope of influence] No impact