### PR TITLE
UT for MongoDB database write prohibition plugin and controller module.

### DIFF
--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/pom.xml
@@ -22,6 +22,16 @@
             <artifactId>sermant-agentcore-core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManagerTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManagerTest.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.config;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashSet;
+
+/**
+ * 数据库禁写配置管理类单元测试
+ *
+ * @author daizhenyu
+ * @since 2024-01-23
+ **/
+public class DatabaseWriteProhibitionManagerTest {
+    private static DatabaseWriteProhibitionConfig globalConfig;
+
+    private static DatabaseWriteProhibitionConfig localConfig;
+
+    @BeforeClass
+    public static void setUp() {
+        globalConfig = new DatabaseWriteProhibitionConfig();
+        HashSet<String> globalDatabases = new HashSet<>();
+        globalDatabases.add("database-test-1");
+        globalConfig.setDatabases(globalDatabases);
+        localConfig = new DatabaseWriteProhibitionConfig();
+        HashSet<String> localDatabases = new HashSet<>();
+        localDatabases.add("database-test-2");
+        localConfig.setDatabases(localDatabases);
+    }
+
+    /**
+     * 测试Global和Local配置都开启的情况
+     */
+    @Test
+    public void testGetProhibitionDatabasesWithGlobalAndLocalConfigEnabled() {
+        globalConfig.setEnableDatabaseWriteProhibition(true);
+        localConfig.setEnableDatabaseWriteProhibition(true);
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
+
+        Assert.assertEquals(globalConfig.getDatabases(), DatabaseWriteProhibitionManager.getProhibitionDatabases());
+    }
+
+    /**
+     * 测试Global配置开启的情况
+     */
+    @Test
+    public void testGetProhibitionDatabasesWithJustGlobalConfigEnabled() {
+        globalConfig.setEnableDatabaseWriteProhibition(true);
+        localConfig.setEnableDatabaseWriteProhibition(false);
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
+
+        Assert.assertEquals(globalConfig.getDatabases(), DatabaseWriteProhibitionManager.getProhibitionDatabases());
+    }
+
+    /**
+     * 测试Local配置开启的情况
+     */
+    @Test
+    public void testGetProhibitionDatabasesWithJustLocalConfigEnabled() {
+        globalConfig.setEnableDatabaseWriteProhibition(false);
+        localConfig.setEnableDatabaseWriteProhibition(true);
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
+
+        Assert.assertEquals(localConfig.getDatabases(), DatabaseWriteProhibitionManager.getProhibitionDatabases());
+    }
+
+    /**
+     * 测试Global和Local配置都关闭的情况
+     */
+    @Test
+    public void testGetProhibitionDatabasesWithBothConfigsDisabled() {
+        globalConfig.setEnableDatabaseWriteProhibition(false);
+        localConfig.setEnableDatabaseWriteProhibition(false);
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
+
+        Assert.assertTrue(DatabaseWriteProhibitionManager.getProhibitionDatabases().isEmpty());
+    }
+
+    /**
+     * 测试更新配置不为null的情况
+     */
+    @Test
+    public void testUpdateConfigWithNonNullConfig() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
+        Assert.assertEquals(globalConfig, DatabaseWriteProhibitionManager.getGlobalConfig());
+        Assert.assertEquals(localConfig, DatabaseWriteProhibitionManager.getLocalConfig());
+    }
+
+    /**
+     * 测试更新配置为null的情况
+     */
+    @Test
+    public void testUpdateConfigWithNullConfig() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(null);
+        DatabaseWriteProhibitionManager.updateLocalConfig(null);
+
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getDatabases().size());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableDatabaseWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableDatabaseWriteProhibition());
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/controller/DatabaseControllerTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/controller/DatabaseControllerTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.controller;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+
+/**
+ * 数据库控制器单元测试
+ *
+ * @author daizhenyu
+ * @since 2024-01-23
+ **/
+public class DatabaseControllerTest {
+    private ExecuteContext context;
+
+    private String database;
+
+    @Before
+    public void setUp() {
+        context = ExecuteContext.forMemberMethod(new Object(), Mockito.mock(Method.class), null, null, null);
+        database = "database-test";
+    }
+
+    @Test
+    public void testDisableDatabaseWriteOperation() {
+        DatabaseController.disableDatabaseWriteOperation(database, context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.clearAllCaches();
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/pom.xml
@@ -37,6 +37,16 @@
             <artifactId>database-controller</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptorTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.internal.operation.MixedBulkWriteOperation;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * ExecuteCommand方法拦截器单元测试
+ *
+ * @author daizhenyu
+ * @since 2024-01-23
+ **/
+public class ExecuteCommandInterceptorTest {
+    private static DatabaseWriteProhibitionConfig globalConfig = new DatabaseWriteProhibitionConfig();
+
+    private static MongoNamespace namespace = new MongoNamespace("database-test",
+            "collection-test");
+
+    private static MixedBulkWriteOperation operationMock;
+
+    private static ExecuteContext context;
+
+    private static Method methodMock;
+
+    private static Object[] argument;
+
+    private ExecuteCommandInterceptor interceptor = new ExecuteCommandInterceptor();
+
+    @BeforeClass
+    public static void setUp() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        operationMock = Mockito.mock(MixedBulkWriteOperation.class);
+        methodMock = Mockito.mock(Method.class);
+        Mockito.when(operationMock.getNamespace()).thenReturn(namespace);
+        argument = new Object[] {"database-test"};
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+    }
+
+    @Test
+    public void testDoBefore() {
+        // 数据库禁写开关关闭
+        globalConfig.setEnableDatabaseWriteProhibition(false);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        interceptor.doBefore(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        // 数据库禁写开关关闭，禁写数据库set包含被拦截的数据库
+        Set<String> databases = new HashSet<>();
+        databases.add("database-test");
+        globalConfig.setDatabases(databases);
+        Assert.assertNull(context.getThrowableOut());
+
+        //数据库禁写开关打开，禁写数据库集合包含被拦截的数据库
+        globalConfig.setEnableDatabaseWriteProhibition(true);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        interceptor.doBefore(context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+
+        //数据库禁写开关打开，禁写数据库集合不包含被拦截的数据库
+        globalConfig.setDatabases(new HashSet<>());
+        interceptor.doBefore(context);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        Assert.assertNull(context.getThrowableOut());
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptorTest.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.internal.operation.MixedBulkWriteOperation;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * ExecuteCommand方法拦截器单元测试
+ *
+ * @author daizhenyu
+ * @since 2024-01-23
+ **/
+public class ExecuteRetryableCommandInterceptorTest {
+    private static DatabaseWriteProhibitionConfig globalConfig = new DatabaseWriteProhibitionConfig();
+
+    private static MongoNamespace namespace = new MongoNamespace("database-test",
+            "collection-test");
+
+    private static MixedBulkWriteOperation operationMock;
+
+    private static ExecuteContext context;
+
+    private static Method methodMock;
+
+    private static Object[] argument;
+
+    private ExecuteRetryableCommandInterceptor interceptor = new ExecuteRetryableCommandInterceptor();
+
+    @BeforeClass
+    public static void setUp() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        operationMock = Mockito.mock(MixedBulkWriteOperation.class);
+        methodMock = Mockito.mock(Method.class);
+        Mockito.when(operationMock.getNamespace()).thenReturn(namespace);
+        argument = new Object[] {"first-param", "database-test"};
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+    }
+
+    @Test
+    public void testDoBefore() {
+        // 数据库禁写开关关闭
+        globalConfig.setEnableDatabaseWriteProhibition(false);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        interceptor.doBefore(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        // 数据库禁写开关关闭，禁写数据库set包含被拦截的数据库
+        Set<String> databases = new HashSet<>();
+        databases.add("database-test");
+        globalConfig.setDatabases(databases);
+        Assert.assertNull(context.getThrowableOut());
+
+        //数据库禁写开关打开，禁写数据库集合包含被拦截的数据库
+        globalConfig.setEnableDatabaseWriteProhibition(true);
+        globalConfig.setDatabases(databases);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        interceptor.doBefore(context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+
+        //数据库禁写开关打开，禁写数据库集合不包含被拦截的数据库
+        globalConfig.setDatabases(new HashSet<>());
+        interceptor.doBefore(context);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        Assert.assertNull(context.getThrowableOut());
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptorTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.internal.operation.MixedBulkWriteOperation;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * MixedBulkWriteOperation类写操作拦截器单元测试
+ *
+ * @author daizhenyu
+ * @since 2024-01-23
+ **/
+public class MixedBulkWriteOperationInterceptorTest {
+    private static DatabaseWriteProhibitionConfig globalConfig = new DatabaseWriteProhibitionConfig();
+
+    private static MongoNamespace namespace = new MongoNamespace("database-test",
+            "collection-test");
+
+    private static MixedBulkWriteOperation operationMock;
+
+    private static ExecuteContext context;
+
+    private static Method methodMock;
+
+    private MixedBulkWriteOperationInterceptor interceptor = new MixedBulkWriteOperationInterceptor();
+
+    @BeforeClass
+    public static void setUp() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
+        operationMock = Mockito.mock(MixedBulkWriteOperation.class);
+        methodMock = Mockito.mock(Method.class);
+        Mockito.when(operationMock.getNamespace()).thenReturn(namespace);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+    }
+
+    @Test
+    public void testDoBefore() {
+        // 数据库禁写开关关闭
+        globalConfig.setEnableDatabaseWriteProhibition(false);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
+        interceptor.doBefore(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        // 数据库禁写开关关闭，禁写数据库set包含被拦截的数据库
+        Set<String> databases = new HashSet<>();
+        databases.add("database-test");
+        globalConfig.setDatabases(databases);
+        Assert.assertNull(context.getThrowableOut());
+
+        //数据库禁写开关打开，禁写数据库集合包含被拦截的数据库
+        globalConfig.setEnableDatabaseWriteProhibition(true);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
+        interceptor.doBefore(context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+
+        //数据库禁写开关打开，禁写数据库集合不包含被拦截的数据库
+        globalConfig.setDatabases(new HashSet<>());
+        interceptor.doBefore(context);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
+        Assert.assertNull(context.getThrowableOut());
+    }
+}


### PR DESCRIPTION
【Fix issue】#1422

[Modification] Added unit tests for the controller module and mongodb module

[Use case description] Unit test

[Self-test situation] 1. Local static check passed; 2. Except for declarer, helper and interface, the code UT coverage rate is 80%

[Scope of influence] None