### PR TITLE
Message queue prohibits consumption plug-in to unify RocketMq name

### DIFF
--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerController.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerController.java
@@ -20,7 +20,7 @@ import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.utils.ReflectUtils;
 import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
-import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+import com.huaweicloud.sermant.utils.RocketMqWrapperUtils;
 
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
 import org.apache.rocketmq.client.impl.consumer.AssignedMessageQueue;
@@ -115,7 +115,7 @@ public class RocketMqPullConsumerController {
     private static void suspendAssignedConsumer(DefaultLitePullConsumerWrapper wrapper) {
         DefaultLitePullConsumerImpl pullConsumerImpl = wrapper.getPullConsumerImpl();
         if (wrapper.getAssignedMessageQueue() == null) {
-            Optional<AssignedMessageQueue> assignedMessageQueueOptional = RocketmqWrapperUtils
+            Optional<AssignedMessageQueue> assignedMessageQueueOptional = RocketMqWrapperUtils
                     .getAssignedMessageQueue(pullConsumerImpl);
             if (assignedMessageQueueOptional.isPresent()) {
                 wrapper.setAssignedMessageQueue(assignedMessageQueueOptional.get());
@@ -255,7 +255,7 @@ public class RocketMqPullConsumerController {
      * @param pullConsumer pullConsumer实例
      */
     public static void cachePullConsumer(DefaultLitePullConsumer pullConsumer) {
-        Optional<DefaultLitePullConsumerWrapper> pullConsumerWrapperOptional = RocketmqWrapperUtils
+        Optional<DefaultLitePullConsumerWrapper> pullConsumerWrapperOptional = RocketMqWrapperUtils
                 .wrapPullConsumer(pullConsumer);
         if (pullConsumerWrapperOptional.isPresent()) {
             RocketMqConsumerCache.PULL_CONSUMERS_CACHE.put(pullConsumer.hashCode(), pullConsumerWrapperOptional.get());

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerController.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerController.java
@@ -19,7 +19,7 @@ package com.huaweicloud.sermant.rocketmq.controller;
 import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
-import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+import com.huaweicloud.sermant.utils.RocketMqWrapperUtils;
 
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.impl.consumer.DefaultMQPushConsumerImpl;
@@ -105,7 +105,7 @@ public class RocketMqPushConsumerController {
      * @param pushConsumer pushConsumer实例
      */
     public static void cachePushConsumer(DefaultMQPushConsumer pushConsumer) {
-        Optional<DefaultMqPushConsumerWrapper> pushConsumerWrapperOptional = RocketmqWrapperUtils
+        Optional<DefaultMqPushConsumerWrapper> pushConsumerWrapperOptional = RocketMqWrapperUtils
                 .wrapPushConsumer(pushConsumer);
         if (pushConsumerWrapperOptional.isPresent()) {
             RocketMqConsumerCache.PUSH_CONSUMERS_CACHE.put(pushConsumer.hashCode(), pushConsumerWrapperOptional.get());

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/utils/RocketMqWrapperUtils.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/main/java/com/huaweicloud/sermant/utils/RocketMqWrapperUtils.java
@@ -40,8 +40,8 @@ import java.util.Optional;
  * @author daizhenyu
  * @since 2023-12-14
  **/
-public class RocketmqWrapperUtils {
-    private RocketmqWrapperUtils() {
+public class RocketMqWrapperUtils {
+    private RocketMqWrapperUtils() {
     }
 
     /**
@@ -105,7 +105,7 @@ public class RocketmqWrapperUtils {
      */
     public static Optional<AssignedMessageQueue> getAssignedMessageQueue(DefaultLitePullConsumerImpl pullConsumerImpl) {
         // 设置插件类加载器的局部类加载器为宿主类加载器
-        ((PluginClassLoader) RocketmqWrapperUtils.class.getClassLoader()).setLocalLoader(
+        ((PluginClassLoader) RocketMqWrapperUtils.class.getClassLoader()).setLocalLoader(
                 pullConsumerImpl.getClass().getClassLoader());
 
         Optional<Object> assignedMessageQueueOptional = ReflectUtils
@@ -116,7 +116,7 @@ public class RocketmqWrapperUtils {
         }
 
         // 移除插件类加载器的局部类加载器
-        ((PluginClassLoader) RocketmqWrapperUtils.class.getClassLoader()).removeLocalLoader();
+        ((PluginClassLoader) RocketMqWrapperUtils.class.getClassLoader()).removeLocalLoader();
         return Optional.empty();
     }
 

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerControllerTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPullConsumerControllerTest.java
@@ -21,7 +21,7 @@ import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
 import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
 import com.huaweicloud.sermant.rocketmq.constant.SubscriptionType;
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
-import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+import com.huaweicloud.sermant.utils.RocketMqWrapperUtils;
 
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
@@ -78,9 +78,9 @@ public class RocketMqPullConsumerControllerTest {
         pullConsumerWrapper = new DefaultLitePullConsumerWrapper(pullConsumer, pullConsumerImpl, rebalance, instance);
         pullConsumerWrapper.setConsumerGroup("test-group");
 
-        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
-                .mockStatic(RocketmqWrapperUtils.class);
-        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPullConsumer(pullConsumer))
+        MockedStatic<RocketMqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketMqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketMqWrapperUtils.wrapPullConsumer(pullConsumer))
                 .thenReturn(Optional.of(pullConsumerWrapper));
 
         prohibitionTopics = new HashSet<>();

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerControllerTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/rocketmq/controller/RocketMqPushConsumerControllerTest.java
@@ -20,7 +20,7 @@ import com.huaweicloud.sermant.core.config.ConfigManager;
 import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
 import com.huaweicloud.sermant.rocketmq.cache.RocketMqConsumerCache;
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
-import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+import com.huaweicloud.sermant.utils.RocketMqWrapperUtils;
 
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
@@ -66,9 +66,9 @@ public class RocketMqPushConsumerControllerTest {
         pushConsumerWrapper = new DefaultMqPushConsumerWrapper(pushConsumer, pushConsumerImpl, instance);
         pushConsumerWrapper.setConsumerGroup("test-group");
 
-        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
-                .mockStatic(RocketmqWrapperUtils.class);
-        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPushConsumer(pushConsumer))
+        MockedStatic<RocketMqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketMqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketMqWrapperUtils.wrapPushConsumer(pushConsumer))
                 .thenReturn(Optional.of(pushConsumerWrapper));
 
         prohibitionTopics = new HashSet<>();

--- a/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtilsTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/consumer-controller/src/test/java/com/huaweicloud/sermant/utils/RocketmqWrapperUtilsTest.java
@@ -74,7 +74,7 @@ public class RocketmqWrapperUtilsTest {
 
     @Test
     public void testWrapPullConsumer() {
-        Optional<DefaultLitePullConsumerWrapper> pullConsumerWrapperOptional = RocketmqWrapperUtils
+        Optional<DefaultLitePullConsumerWrapper> pullConsumerWrapperOptional = RocketMqWrapperUtils
                 .wrapPullConsumer(pullConsumer);
         Assert.assertTrue(pullConsumerWrapperOptional.isPresent());
         Assert.assertEquals(pullConsumerWrapperOptional.get().getPullConsumer(), pullConsumer);
@@ -82,7 +82,7 @@ public class RocketmqWrapperUtilsTest {
 
     @Test
     public void testWrapPushConsumer() {
-        Optional<DefaultMqPushConsumerWrapper> pushConsumerWrapperOptional = RocketmqWrapperUtils
+        Optional<DefaultMqPushConsumerWrapper> pushConsumerWrapperOptional = RocketMqWrapperUtils
                 .wrapPushConsumer(pushConsumer);
         Assert.assertTrue(pushConsumerWrapperOptional.isPresent());
         Assert.assertEquals(pushConsumerWrapperOptional.get().getPushConsumer(), pushConsumer);

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/declarer/RocketMqPullConsumerDeclarer.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/declarer/RocketMqPullConsumerDeclarer.java
@@ -19,7 +19,7 @@ package com.huaweicloud.sermant.mq.prohibition.rocketmq.declarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
-import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.RocketmqEnhancementHelper;
+import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.RocketMqEnhancementHelper;
 
 /**
  * pullConsumer拦截声明器，支持rocketmq4.8+版本
@@ -27,20 +27,20 @@ import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.RocketmqEnhancement
  * @author daizhenyu
  * @since 2023-12-04
  **/
-public class RocketmqPullConsumerDeclarer extends AbstractPluginDeclarer {
+public class RocketMqPullConsumerDeclarer extends AbstractPluginDeclarer {
     @Override
     public ClassMatcher getClassMatcher() {
-        return RocketmqEnhancementHelper.getPullConsumerClassMatcher();
+        return RocketMqEnhancementHelper.getPullConsumerClassMatcher();
     }
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-                RocketmqEnhancementHelper.getPullConsumerStartInterceptDeclarers(),
-                RocketmqEnhancementHelper.getPullConsumerSubscribeInterceptDeclarers(),
-                RocketmqEnhancementHelper.getPullConsumerUnsubscribeInterceptDeclarers(),
-                RocketmqEnhancementHelper.getPullConsumerAssignInterceptDeclarers(),
-                RocketmqEnhancementHelper.getPullConsumerShutdownInterceptDeclarers()
+                RocketMqEnhancementHelper.getPullConsumerStartInterceptDeclarers(),
+                RocketMqEnhancementHelper.getPullConsumerSubscribeInterceptDeclarers(),
+                RocketMqEnhancementHelper.getPullConsumerUnsubscribeInterceptDeclarers(),
+                RocketMqEnhancementHelper.getPullConsumerAssignInterceptDeclarers(),
+                RocketMqEnhancementHelper.getPullConsumerShutdownInterceptDeclarers()
         };
     }
 }

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/declarer/RocketMqPushConsumerDeclarer.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/declarer/RocketMqPushConsumerDeclarer.java
@@ -19,7 +19,7 @@ package com.huaweicloud.sermant.mq.prohibition.rocketmq.declarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
-import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.RocketmqEnhancementHelper;
+import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.RocketMqEnhancementHelper;
 
 /**
  * pushConsumer拦截声明器，支持rocketmq4.8+版本
@@ -27,19 +27,19 @@ import com.huaweicloud.sermant.mq.prohibition.rocketmq.utils.RocketmqEnhancement
  * @author daizhenyu
  * @since 2023-12-04
  **/
-public class RocketmqPushConsumerDeclarer extends AbstractPluginDeclarer {
+public class RocketMqPushConsumerDeclarer extends AbstractPluginDeclarer {
     @Override
     public ClassMatcher getClassMatcher() {
-        return RocketmqEnhancementHelper.getPushConsumerClassMatcher();
+        return RocketMqEnhancementHelper.getPushConsumerClassMatcher();
     }
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
         return new InterceptDeclarer[]{
-                RocketmqEnhancementHelper.getPushConsumerStartInterceptDeclarers(),
-                RocketmqEnhancementHelper.getPushConsumerSubscribeInterceptDeclarers(),
-                RocketmqEnhancementHelper.getPushConsumerUnsubscribeInterceptDeclarers(),
-                RocketmqEnhancementHelper.getPushConsumerShutdownInterceptDeclarers()
+                RocketMqEnhancementHelper.getPushConsumerStartInterceptDeclarers(),
+                RocketMqEnhancementHelper.getPushConsumerSubscribeInterceptDeclarers(),
+                RocketMqEnhancementHelper.getPushConsumerUnsubscribeInterceptDeclarers(),
+                RocketMqEnhancementHelper.getPushConsumerShutdownInterceptDeclarers()
         };
     }
 }

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/utils/RocketMqEnhancementHelper.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/utils/RocketMqEnhancementHelper.java
@@ -36,7 +36,7 @@ import com.huaweicloud.sermant.rocketmq.extension.RocketMqConsumerHandler;
  * @author daizhenyu
  * @since 2023-12-13
  **/
-public class RocketmqEnhancementHelper {
+public class RocketMqEnhancementHelper {
     private static final String ENHANCE_PUSH_CONSUMER_CLASS =
             "org.apache.rocketmq.client.consumer.DefaultMQPushConsumer";
 
@@ -53,7 +53,7 @@ public class RocketmqEnhancementHelper {
 
     private static final String ASSIGN_METHOD_NAME = "assign";
 
-    private RocketmqEnhancementHelper() {
+    private RocketMqEnhancementHelper() {
     }
 
     /**

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-com.huaweicloud.sermant.mq.prohibition.rocketmq.declarer.RocketmqPullConsumerDeclarer
-com.huaweicloud.sermant.mq.prohibition.rocketmq.declarer.RocketmqPushConsumerDeclarer
+com.huaweicloud.sermant.mq.prohibition.rocketmq.declarer.RocketMqPullConsumerDeclarer
+com.huaweicloud.sermant.mq.prohibition.rocketmq.declarer.RocketMqPushConsumerDeclarer

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePullConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePullConsumerInterceptorTest.java
@@ -17,7 +17,7 @@
 package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
 
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultLitePullConsumerWrapper;
-import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+import com.huaweicloud.sermant.utils.RocketMqWrapperUtils;
 
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
@@ -46,9 +46,9 @@ public class BasePullConsumerInterceptorTest {
     public void before() throws MQClientException {
         pullConsumer = new DefaultLitePullConsumer("test-group");
         pullConsumerWrapper = createPullConsumerWrapper();
-        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
-                .mockStatic(RocketmqWrapperUtils.class);
-        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPullConsumer(pullConsumer))
+        MockedStatic<RocketMqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketMqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketMqWrapperUtils.wrapPullConsumer(pullConsumer))
                 .thenReturn(Optional.of(pullConsumerWrapper));
     }
 

--- a/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePushConsumerInterceptorTest.java
+++ b/sermant-plugins/sermant-mq-consume-prohibition/rocketmq-plugin/src/test/java/com/huaweicloud/sermant/mq/prohibition/rocketmq/interceptor/BasePushConsumerInterceptorTest.java
@@ -17,7 +17,7 @@
 package com.huaweicloud.sermant.mq.prohibition.rocketmq.interceptor;
 
 import com.huaweicloud.sermant.rocketmq.wrapper.DefaultMqPushConsumerWrapper;
-import com.huaweicloud.sermant.utils.RocketmqWrapperUtils;
+import com.huaweicloud.sermant.utils.RocketMqWrapperUtils;
 
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
@@ -44,9 +44,9 @@ public class BasePushConsumerInterceptorTest {
     public void before() {
         pushConsumer = new DefaultMQPushConsumer("test-group");
         pushConsumerWrapper = createPushConsumerWrapper();
-        MockedStatic<RocketmqWrapperUtils> wrapperUtilsMockedStatic = Mockito
-                .mockStatic(RocketmqWrapperUtils.class);
-        wrapperUtilsMockedStatic.when(() -> RocketmqWrapperUtils.wrapPushConsumer(pushConsumer))
+        MockedStatic<RocketMqWrapperUtils> wrapperUtilsMockedStatic = Mockito
+                .mockStatic(RocketMqWrapperUtils.class);
+        wrapperUtilsMockedStatic.when(() -> RocketMqWrapperUtils.wrapPushConsumer(pushConsumer))
                 .thenReturn(Optional.of(pushConsumerWrapper));
     }
 


### PR DESCRIPTION
【Fix issue】#1427

[Modification content] The name of the message queue prohibited consumption plug-in Rocketmq is changed to RocketMq

[Use case description] Not required

[Self-test situation] 1. Local static check passed

[Scope of influence] None