### PR TITLE
Database write prohibition dynamic configuration

### DIFF
--- a/sermant-plugins/sermant-database-write-prohibition/database-config-service/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/database-config-service/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-database-write-prohibition</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>database-config-service</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>service</package.plugin.type>
+        <snakeyaml.version>2.0</snakeyaml.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>database-controller</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-plugins/sermant-database-write-prohibition/database-config-service/src/main/java/com/huaweicloud/sermant/database/dynamicconfig/DatabaseConfigListener.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-config-service/src/main/java/com/huaweicloud/sermant/database/dynamicconfig/DatabaseConfigListener.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.dynamicconfig;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEvent;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigEventType;
+import com.huaweicloud.sermant.core.service.dynamicconfig.common.DynamicConfigListener;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 数据层中间件禁写插件的动态配置监听器
+ *
+ * @author daizhenyu
+ * @since 2024-01-26
+ */
+public class DatabaseConfigListener implements DynamicConfigListener {
+    /**
+     * 全局配置的Key
+     */
+    public static final String GLOBAL_CONFIG_KEY = "sermant.database.write.globalConfig";
+
+    /**
+     * 局部配置的key的前缀
+     */
+    public static final String LOCAL_CONFIG_KEY_PREFIX = "sermant.database.write.";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    private final Yaml yaml;
+
+    /**
+     * 监听器构造方法
+     */
+    public DatabaseConfigListener() {
+        Representer representer = new Representer(new DumperOptions());
+        representer.getPropertyUtils().setSkipMissingProperties(true);
+        this.yaml = new Yaml(representer);
+    }
+
+    @Override
+    public void process(DynamicConfigEvent event) {
+        try {
+            if (event.getEventType() == DynamicConfigEventType.DELETE) {
+                processDeleteEvent(event);
+                return;
+            }
+            processInitOrCreateOrUpdateEvent(event);
+        } catch (YAMLException e) {
+            LOGGER.log(Level.SEVERE, "Fail to convert dynamic database-write-prohibition config, {0}", e.getMessage());
+        }
+    }
+
+    /**
+     * 处理初始化、创建或者更新配置的事件
+     *
+     * @param event 事件
+     */
+    private void processInitOrCreateOrUpdateEvent(DynamicConfigEvent event) {
+        if (GLOBAL_CONFIG_KEY.equals(event.getKey())) {
+            DatabaseWriteProhibitionManager
+                    .updateGlobalConfig(yaml.loadAs(event.getContent(), DatabaseWriteProhibitionConfig.class));
+        }
+        if ((LOCAL_CONFIG_KEY_PREFIX + ConfigManager.getConfig(ServiceMeta.class).getService()).equals(
+                event.getKey())) {
+            DatabaseWriteProhibitionManager
+                    .updateLocalConfig(yaml.loadAs(event.getContent(), DatabaseWriteProhibitionConfig.class));
+        }
+        if (event.getEventType() == DynamicConfigEventType.INIT) {
+            LOGGER.log(Level.INFO, "Init database-write-prohibition config, current config: {0}",
+                    DatabaseWriteProhibitionManager.printConfig());
+            return;
+        }
+        LOGGER.log(Level.INFO, "Update database-write-prohibition config, current config: {0}",
+                DatabaseWriteProhibitionManager.printConfig());
+    }
+
+    /**
+     * 处理删除配置的事件
+     *
+     * @param event 事件
+     */
+    private void processDeleteEvent(DynamicConfigEvent event) {
+        if (GLOBAL_CONFIG_KEY.equals(event.getKey())) {
+            DatabaseWriteProhibitionManager.updateGlobalConfig(new DatabaseWriteProhibitionConfig());
+        }
+        if ((LOCAL_CONFIG_KEY_PREFIX + ConfigManager.getConfig(ServiceMeta.class).getService()).equals(
+                event.getKey())) {
+            DatabaseWriteProhibitionManager.updateLocalConfig(new DatabaseWriteProhibitionConfig());
+        }
+        LOGGER.log(Level.INFO, "Delete database-write-prohibition config, current config: {0}",
+                DatabaseWriteProhibitionManager.printConfig());
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-config-service/src/main/java/com/huaweicloud/sermant/database/dynamicconfig/DatabaseConfigService.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-config-service/src/main/java/com/huaweicloud/sermant/database/dynamicconfig/DatabaseConfigService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.dynamicconfig;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.config.ConfigManager;
+import com.huaweicloud.sermant.core.plugin.config.ServiceMeta;
+import com.huaweicloud.sermant.core.plugin.service.PluginService;
+import com.huaweicloud.sermant.core.plugin.subscribe.CommonGroupConfigSubscriber;
+import com.huaweicloud.sermant.core.plugin.subscribe.ConfigSubscriber;
+
+import java.util.logging.Logger;
+
+/**
+ * 数据层中间件禁写的动态配置服务
+ *
+ * @author daizhenyu
+ * @since 2024-01-27
+ */
+public class DatabaseConfigService implements PluginService {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    public void start() {
+        ConfigSubscriber subscriber = new CommonGroupConfigSubscriber(
+                ConfigManager.getConfig(ServiceMeta.class).getService(),
+                new DatabaseConfigListener(), "database-write-prohibition");
+        subscriber.subscribe();
+        LOGGER.info("Success to subscribe database-write-prohibition config");
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-config-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
+++ b/sermant-plugins/sermant-database-write-prohibition/database-config-service/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.service.PluginService
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.huaweicloud.sermant.database.dynamicconfig.DatabaseConfigService

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionConfig.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionConfig.java
@@ -27,38 +27,118 @@ import java.util.Set;
  **/
 public class DatabaseWriteProhibitionConfig {
     /**
-     * 是否开启禁写
+     * MongoDb是否开启禁写
      */
-    private boolean enableDatabaseWriteProhibition = false;
+    private boolean enableMongoDbWriteProhibition = false;
 
     /**
-     * 需要禁写的数据库
+     * MongoDb需要禁写的数据库
      */
-    private Set<String> databases = new HashSet<>();
-
-    public boolean isEnableDatabaseWriteProhibition() {
-        return enableDatabaseWriteProhibition;
-    }
-
-    public void setEnableDatabaseWriteProhibition(boolean enableDatabaseWriteProhibition) {
-        this.enableDatabaseWriteProhibition = enableDatabaseWriteProhibition;
-    }
+    private Set<String> mongoDbDatabases = new HashSet<>();
 
     /**
-     * 获取禁消费的数据库列表
-     *
-     * @return 数据库列表
+     * Mysql是否开启禁写
      */
-    public Set<String> getDatabases() {
-        return databases;
+    private boolean enableMysqlWriteProhibition = false;
+
+    /**
+     * Mysql需要禁写的数据库
+     */
+    private Set<String> mysqlDatabases = new HashSet<>();
+
+    /**
+     * PostgreSQL是否开启禁写
+     */
+    private boolean enablePostgreSqlWriteProhibition = false;
+
+    /**
+     * PostgreSQL需要禁写的数据库
+     */
+    private Set<String> postgreSqlDatabases = new HashSet<>();
+
+    /**
+     * OpenGauss是否开启禁写
+     */
+    private boolean enableOpenGaussWriteProhibition = false;
+
+    /**
+     * OpenGauss需要禁写的数据库
+     */
+    private Set<String> openGaussDatabases = new HashSet<>();
+
+    public boolean isEnableMongoDbWriteProhibition() {
+        return enableMongoDbWriteProhibition;
     }
 
-    public void setDatabases(Set<String> databases) {
-        this.databases = databases;
+    public void setEnableMongoDbWriteProhibition(boolean enableMongoDbWriteProhibition) {
+        this.enableMongoDbWriteProhibition = enableMongoDbWriteProhibition;
+    }
+
+    public Set<String> getMongoDbDatabases() {
+        return mongoDbDatabases;
+    }
+
+    public void setMongoDbDatabases(Set<String> mongoDbDatabases) {
+        this.mongoDbDatabases = mongoDbDatabases;
+    }
+
+    public boolean isEnableMysqlWriteProhibition() {
+        return enableMysqlWriteProhibition;
+    }
+
+    public void setEnableMysqlWriteProhibition(boolean enableMysqlWriteProhibition) {
+        this.enableMysqlWriteProhibition = enableMysqlWriteProhibition;
+    }
+
+    public Set<String> getMysqlDatabases() {
+        return mysqlDatabases;
+    }
+
+    public void setMysqlDatabases(Set<String> mysqlDatabases) {
+        this.mysqlDatabases = mysqlDatabases;
+    }
+
+    public boolean isEnablePostgreSqlWriteProhibition() {
+        return enablePostgreSqlWriteProhibition;
+    }
+
+    public void setEnablePostgreSqlWriteProhibition(boolean enablePostgreSqlWriteProhibition) {
+        this.enablePostgreSqlWriteProhibition = enablePostgreSqlWriteProhibition;
+    }
+
+    public Set<String> getPostgreSqlDatabases() {
+        return postgreSqlDatabases;
+    }
+
+    public void setPostgreSqlDatabases(Set<String> postgreSqlDatabases) {
+        this.postgreSqlDatabases = postgreSqlDatabases;
+    }
+
+    public boolean isEnableOpenGaussWriteProhibition() {
+        return enableOpenGaussWriteProhibition;
+    }
+
+    public void setEnableOpenGaussWriteProhibition(boolean enableOpenGaussWriteProhibition) {
+        this.enableOpenGaussWriteProhibition = enableOpenGaussWriteProhibition;
+    }
+
+    public Set<String> getOpenGaussDatabases() {
+        return openGaussDatabases;
+    }
+
+    public void setOpenGaussDatabases(Set<String> openGaussDatabases) {
+        this.openGaussDatabases = openGaussDatabases;
     }
 
     @Override
     public String toString() {
-        return "enableDatabaseWriteProhibition=" + enableDatabaseWriteProhibition + ", databases=" + databases;
+        return "enableMongoDbWriteProhibition=" + enableMongoDbWriteProhibition
+                + ", mongoDbDatabases=" + mongoDbDatabases + "; "
+                + "enableMysqlWriteProhibition=" + enableMysqlWriteProhibition
+                + ", mysqlDatabases=" + mysqlDatabases + "; "
+                + "enablePostgreSqlWriteProhibition=" + enablePostgreSqlWriteProhibition
+                + ", postgreSqlDatabases=" + postgreSqlDatabases + ";"
+                + " enableOpenGaussWriteProhibition=" + enableOpenGaussWriteProhibition
+                + ", openGaussDatabases=" + openGaussDatabases;
     }
 }

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManager.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManager.java
@@ -35,16 +35,61 @@ public class DatabaseWriteProhibitionManager {
     }
 
     /**
-     * 获取要禁止消费的数据库集合
+     * 获取MongoDb禁止写入的数据库集合
      *
-     * @return 禁止消费的数据库集合
+     * @return MongoDb禁止写入的数据库集合
      */
-    public static Set<String> getProhibitionDatabases() {
-        if (globalConfig.isEnableDatabaseWriteProhibition()) {
-            return globalConfig.getDatabases();
+    public static Set<String> getMongoDbProhibitionDatabases() {
+        if (globalConfig.isEnableMongoDbWriteProhibition()) {
+            return globalConfig.getMongoDbDatabases();
         }
-        if (localConfig.isEnableDatabaseWriteProhibition()) {
-            return localConfig.getDatabases();
+        if (localConfig.isEnableMongoDbWriteProhibition()) {
+            return localConfig.getMongoDbDatabases();
+        }
+        return Collections.EMPTY_SET;
+    }
+
+    /**
+     * 获取Mysql要禁止写入的数据库集合
+     *
+     * @return Mysql禁止写入的数据库集合
+     */
+    public static Set<String> getMysqlProhibitionDatabases() {
+        if (globalConfig.isEnableMysqlWriteProhibition()) {
+            return globalConfig.getMysqlDatabases();
+        }
+        if (localConfig.isEnableMysqlWriteProhibition()) {
+            return localConfig.getMysqlDatabases();
+        }
+        return Collections.EMPTY_SET;
+    }
+
+    /**
+     * 获取PostgreSQL要禁止写入的数据库集合
+     *
+     * @return PostgreSQL禁止写入的数据库集合
+     */
+    public static Set<String> getPostgreSqlProhibitionDatabases() {
+        if (globalConfig.isEnablePostgreSqlWriteProhibition()) {
+            return globalConfig.getPostgreSqlDatabases();
+        }
+        if (localConfig.isEnablePostgreSqlWriteProhibition()) {
+            return localConfig.getPostgreSqlDatabases();
+        }
+        return Collections.EMPTY_SET;
+    }
+
+    /**
+     * 获取OpenGauss要禁止写入的数据库集合
+     *
+     * @return OpenGauss禁止写入的数据库集合
+     */
+    public static Set<String> getOpenGaussProhibitionDatabases() {
+        if (globalConfig.isEnableOpenGaussWriteProhibition()) {
+            return globalConfig.getOpenGaussDatabases();
+        }
+        if (localConfig.isEnableOpenGaussWriteProhibition()) {
+            return localConfig.getOpenGaussDatabases();
         }
         return Collections.EMPTY_SET;
     }
@@ -70,7 +115,7 @@ public class DatabaseWriteProhibitionManager {
     /**
      * 更新全局配置
      *
-     * @param config 禁止消费配置
+     * @param config 禁止写数据库配置
      */
     public static void updateGlobalConfig(DatabaseWriteProhibitionConfig config) {
         if (config == null) {
@@ -83,7 +128,7 @@ public class DatabaseWriteProhibitionManager {
     /**
      * 更新局部配置
      *
-     * @param config 禁止消费配置
+     * @param config 禁止写数据库配置
      */
     public static void updateLocalConfig(DatabaseWriteProhibitionConfig config) {
         if (config == null) {

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManagerTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManagerTest.java
@@ -36,13 +36,31 @@ public class DatabaseWriteProhibitionManagerTest {
     @BeforeClass
     public static void setUp() {
         globalConfig = new DatabaseWriteProhibitionConfig();
-        HashSet<String> globalDatabases = new HashSet<>();
-        globalDatabases.add("database-test-1");
-        globalConfig.setDatabases(globalDatabases);
+        HashSet<String> globalMongoDbDatabases = new HashSet<>();
+        globalMongoDbDatabases.add("mongodb-test-1");
+        globalConfig.setMongoDbDatabases(globalMongoDbDatabases);
+        HashSet<String> globalMysqlDatabases = new HashSet<>();
+        globalMysqlDatabases.add("mysql-test-1");
+        globalConfig.setMysqlDatabases(globalMysqlDatabases);
+        HashSet<String> globalPostgreSqlDatabases = new HashSet<>();
+        globalPostgreSqlDatabases.add("postgresql-test-1");
+        globalConfig.setPostgreSqlDatabases(globalPostgreSqlDatabases);
+        HashSet<String> globalOpenGaussDatabases = new HashSet<>();
+        globalOpenGaussDatabases.add("mongodb-test-1");
+        globalConfig.setOpenGaussDatabases(globalOpenGaussDatabases);
         localConfig = new DatabaseWriteProhibitionConfig();
-        HashSet<String> localDatabases = new HashSet<>();
-        localDatabases.add("database-test-2");
-        localConfig.setDatabases(localDatabases);
+        HashSet<String> localMongoDbDatabases = new HashSet<>();
+        localMongoDbDatabases.add("mongodb-test-1");
+        localConfig.setMongoDbDatabases(localMongoDbDatabases);
+        HashSet<String> localMysqlDatabases = new HashSet<>();
+        localMysqlDatabases.add("mysql-test-1");
+        globalConfig.setMysqlDatabases(localMysqlDatabases);
+        HashSet<String> localPostgreSqlDatabases = new HashSet<>();
+        localPostgreSqlDatabases.add("postgresql-test-1");
+        globalConfig.setPostgreSqlDatabases(localPostgreSqlDatabases);
+        HashSet<String> localOpenGaussDatabases = new HashSet<>();
+        localOpenGaussDatabases.add("mongodb-test-1");
+        globalConfig.setOpenGaussDatabases(localOpenGaussDatabases);
     }
 
     /**
@@ -50,12 +68,25 @@ public class DatabaseWriteProhibitionManagerTest {
      */
     @Test
     public void testGetProhibitionDatabasesWithGlobalAndLocalConfigEnabled() {
-        globalConfig.setEnableDatabaseWriteProhibition(true);
-        localConfig.setEnableDatabaseWriteProhibition(true);
+        globalConfig.setEnableMongoDbWriteProhibition(true);
+        globalConfig.setEnableMysqlWriteProhibition(true);
+        globalConfig.setEnablePostgreSqlWriteProhibition(true);
+        globalConfig.setEnableOpenGaussWriteProhibition(true);
+        localConfig.setEnableMongoDbWriteProhibition(true);
+        localConfig.setEnableMysqlWriteProhibition(true);
+        localConfig.setEnablePostgreSqlWriteProhibition(true);
+        localConfig.setEnableOpenGaussWriteProhibition(true);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
         DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
 
-        Assert.assertEquals(globalConfig.getDatabases(), DatabaseWriteProhibitionManager.getProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getMongoDbDatabases(),
+                DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getMysqlDatabases(),
+                DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getPostgreSqlDatabases(),
+                DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getOpenGaussDatabases(),
+                DatabaseWriteProhibitionManager.getOpenGaussProhibitionDatabases());
     }
 
     /**
@@ -63,12 +94,25 @@ public class DatabaseWriteProhibitionManagerTest {
      */
     @Test
     public void testGetProhibitionDatabasesWithJustGlobalConfigEnabled() {
-        globalConfig.setEnableDatabaseWriteProhibition(true);
-        localConfig.setEnableDatabaseWriteProhibition(false);
+        globalConfig.setEnableMongoDbWriteProhibition(true);
+        globalConfig.setEnableMysqlWriteProhibition(true);
+        globalConfig.setEnablePostgreSqlWriteProhibition(true);
+        globalConfig.setEnableOpenGaussWriteProhibition(true);
+        localConfig.setEnableMongoDbWriteProhibition(false);
+        localConfig.setEnableMysqlWriteProhibition(false);
+        localConfig.setEnablePostgreSqlWriteProhibition(false);
+        localConfig.setEnableOpenGaussWriteProhibition(false);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
         DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
 
-        Assert.assertEquals(globalConfig.getDatabases(), DatabaseWriteProhibitionManager.getProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getMongoDbDatabases(),
+                DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getMysqlDatabases(),
+                DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getPostgreSqlDatabases(),
+                DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getOpenGaussDatabases(),
+                DatabaseWriteProhibitionManager.getOpenGaussProhibitionDatabases());
     }
 
     /**
@@ -76,12 +120,25 @@ public class DatabaseWriteProhibitionManagerTest {
      */
     @Test
     public void testGetProhibitionDatabasesWithJustLocalConfigEnabled() {
-        globalConfig.setEnableDatabaseWriteProhibition(false);
-        localConfig.setEnableDatabaseWriteProhibition(true);
+        globalConfig.setEnableMongoDbWriteProhibition(false);
+        globalConfig.setEnableMysqlWriteProhibition(false);
+        globalConfig.setEnablePostgreSqlWriteProhibition(false);
+        globalConfig.setEnableOpenGaussWriteProhibition(false);
+        localConfig.setEnableMongoDbWriteProhibition(true);
+        localConfig.setEnableMysqlWriteProhibition(true);
+        localConfig.setEnablePostgreSqlWriteProhibition(true);
+        localConfig.setEnableOpenGaussWriteProhibition(true);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
         DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
 
-        Assert.assertEquals(localConfig.getDatabases(), DatabaseWriteProhibitionManager.getProhibitionDatabases());
+        Assert.assertEquals(localConfig.getMongoDbDatabases(),
+                DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases());
+        Assert.assertEquals(localConfig.getMysqlDatabases(),
+                DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases());
+        Assert.assertEquals(localConfig.getPostgreSqlDatabases(),
+                DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases());
+        Assert.assertEquals(localConfig.getOpenGaussDatabases(),
+                DatabaseWriteProhibitionManager.getOpenGaussProhibitionDatabases());
     }
 
     /**
@@ -89,12 +146,21 @@ public class DatabaseWriteProhibitionManagerTest {
      */
     @Test
     public void testGetProhibitionDatabasesWithBothConfigsDisabled() {
-        globalConfig.setEnableDatabaseWriteProhibition(false);
-        localConfig.setEnableDatabaseWriteProhibition(false);
+        globalConfig.setEnableMongoDbWriteProhibition(false);
+        globalConfig.setEnableMysqlWriteProhibition(false);
+        globalConfig.setEnablePostgreSqlWriteProhibition(false);
+        globalConfig.setEnableOpenGaussWriteProhibition(false);
+        localConfig.setEnableMongoDbWriteProhibition(false);
+        localConfig.setEnableMysqlWriteProhibition(false);
+        localConfig.setEnablePostgreSqlWriteProhibition(false);
+        localConfig.setEnableOpenGaussWriteProhibition(false);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
         DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
 
-        Assert.assertTrue(DatabaseWriteProhibitionManager.getProhibitionDatabases().isEmpty());
+        Assert.assertTrue(DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases().isEmpty());
+        Assert.assertTrue(DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases().isEmpty());
+        Assert.assertTrue(DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases().isEmpty());
+        Assert.assertTrue(DatabaseWriteProhibitionManager.getOpenGaussProhibitionDatabases().isEmpty());
     }
 
     /**
@@ -116,9 +182,21 @@ public class DatabaseWriteProhibitionManagerTest {
         DatabaseWriteProhibitionManager.updateGlobalConfig(null);
         DatabaseWriteProhibitionManager.updateLocalConfig(null);
 
-        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getDatabases().size());
-        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getDatabases().size());
-        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableDatabaseWriteProhibition());
-        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableDatabaseWriteProhibition());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getMongoDbDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getMysqlDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getPostgreSqlDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getOpenGaussDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getMongoDbDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getMysqlDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getPostgreSqlDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getOpenGaussDatabases().size());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableMongoDbWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableMysqlWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnablePostgreSqlWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableOpenGaussWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableMongoDbWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableMysqlWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnablePostgreSqlWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableOpenGaussWriteProhibition());
     }
 }

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/constant/MethodParamTypeName.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/constant/MethodParamTypeName.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.constant;
+
+/**
+ * 方法参数类型的全限定名常量类
+ *
+ * @author daizhenyu
+ * @since 2024-01-27
+ **/
+public class MethodParamTypeName {
+    /**
+     * String类全限定名
+     */
+    public static final String STRING_CLASS_NAME = "java.lang.String";
+
+    /**
+     * WriteBinding类全限定名
+     */
+    public static final String WRITE_BINDING_CLASS_NAME = "com.mongodb.internal.binding.WriteBinding";
+
+    /**
+     * ReadPreference类全限定名
+     */
+    public static final String READ_PREFERENCE_CLASS_NAME = "com.mongodb.ReadPreference";
+
+    /**
+     * FieldNameValidator类全限定名
+     */
+    public static final String FIELD_NAME_VALIDATOR_CLASS_NAME = "org.bson.FieldNameValidator";
+
+    /**
+     * Decoder类全限定名
+     */
+    public static final String DECODER_CLASS_NAME = "org.bson.codecs.Decoder";
+
+    /**
+     * CommandCreator类全限定名
+     */
+    public static final String COMMAND_CREATOR_CLASS_NAME =
+            "com.mongodb.internal.operation.CommandOperationHelper.CommandCreator";
+
+    /**
+     * CommandWriteTransformer类全限定名
+     */
+    public static final String COMMAND_WRITE_TRANSFORMER_CLASS_NAME =
+            "com.mongodb.internal.operation.CommandOperationHelper.CommandWriteTransformer";
+
+    /**
+     * Function类全限定名
+     */
+    public static final String FUNCTION_CLASS_NAME = "com.mongodb.Function";
+
+    /**
+     * BsonDocument类全限定名
+     */
+    public static final String BSON_DOCUMENT_CLASS_NAME = "org.bson.BsonDocument";
+
+    /**
+     * ConnectionSource类全限定名
+     */
+    public static final String CONNECTION_SOURCE_CLASS_NAME = "com.mongodb.internal.binding.ConnectionSource";
+
+    /**
+     * Connection类全限定名
+     */
+    public static final String CONNECTION_CLASS_NAME = "com.mongodb.internal.connection.Connection";
+
+    /**
+     * AsyncWriteBinding类全限定名
+     */
+    public static final String ASYNC_WRITE_BINDING_CLASS_NAME = "com.mongodb.internal.binding.AsyncWriteBinding";
+
+    /**
+     * CommandWriteTransformerAsync类全限定名
+     */
+    public static final String COMMAND_WRITE_TRANSFORMER_ASYNC_CLASS_NAME =
+            "com.mongodb.internal.operation.CommandOperationHelper.CommandWriteTransformerAsync";
+
+    /**
+     * SingleResultCallback类全限定名
+     */
+    public static final String SINGLE_RESULT_CALLBACK_CLASS_NAME = "com.mongodb.internal.async.SingleResultCallback";
+
+    private MethodParamTypeName() {
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptor.java
@@ -47,7 +47,7 @@ public class ExecuteCommandInterceptor extends AbstractDatabaseInterceptor {
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
         String database = (String) context.getArguments()[0];
-        if (DatabaseWriteProhibitionManager.getProhibitionDatabases().contains(database)) {
+        if (DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases().contains(database)) {
             DatabaseController.disableDatabaseWriteOperation(database, context);
         }
         return context;

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptor.java
@@ -47,7 +47,7 @@ public class ExecuteRetryableCommandInterceptor extends AbstractDatabaseIntercep
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
         String database = (String) context.getArguments()[1];
-        if (DatabaseWriteProhibitionManager.getProhibitionDatabases().contains(database)) {
+        if (DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases().contains(database)) {
             DatabaseController.disableDatabaseWriteOperation(database, context);
         }
         return context;

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptor.java
@@ -49,7 +49,7 @@ public class MixedBulkWriteOperationInterceptor extends AbstractDatabaseIntercep
     @Override
     public ExecuteContext doBefore(ExecuteContext context) {
         String database = ((MixedBulkWriteOperation) context.getObject()).getNamespace().getDatabaseName();
-        if (DatabaseWriteProhibitionManager.getProhibitionDatabases().contains(database)) {
+        if (DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases().contains(database)) {
             DatabaseController.disableDatabaseWriteOperation(database, context);
         }
         return context;

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/utils/MongoDbEnhancementHelper.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/utils/MongoDbEnhancementHelper.java
@@ -20,20 +20,13 @@ import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
 import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.mongodb.constant.MethodParamTypeName;
 import com.huaweicloud.sermant.mongodb.interceptors.ExecuteCommandInterceptor;
 import com.huaweicloud.sermant.mongodb.interceptors.ExecuteRetryableCommandInterceptor;
 import com.huaweicloud.sermant.mongodb.interceptors.MixedBulkWriteOperationInterceptor;
 
-import com.mongodb.ReadPreference;
-import com.mongodb.internal.binding.ConnectionSource;
-import com.mongodb.internal.connection.Connection;
-
-import org.bson.BsonDocument;
-import org.bson.FieldNameValidator;
-import org.bson.codecs.Decoder;
-
 /**
- * mongo拦截点辅助类
+ * mongodb拦截点辅助类
  *
  * @author daizhenyu
  * @since 2024-01-16
@@ -57,37 +50,37 @@ public class MongoDbEnhancementHelper {
 
     private static final int METHOD_PARAM_COUNT = 9;
 
-    private static final Class[] EXECUTE_COMMAND_PARAMS_TYPE = {
-            String.class,
-            BsonDocument.class,
-            FieldNameValidator.class,
-            Decoder.class,
-            ConnectionSource.class,
-            Connection.class,
-            ReadPreference.class
+    private static final String[] EXECUTE_COMMAND_PARAMS_TYPE = {
+            MethodParamTypeName.STRING_CLASS_NAME,
+            MethodParamTypeName.BSON_DOCUMENT_CLASS_NAME,
+            MethodParamTypeName.FIELD_NAME_VALIDATOR_CLASS_NAME,
+            MethodParamTypeName.DECODER_CLASS_NAME,
+            MethodParamTypeName.CONNECTION_SOURCE_CLASS_NAME,
+            MethodParamTypeName.CONNECTION_CLASS_NAME,
+            MethodParamTypeName.READ_PREFERENCE_CLASS_NAME
     };
 
     private static final String[] EXECUTE_RETRY_COMMAND_PARAMS_TYPE = {
-            "com.mongodb.internal.binding.WriteBinding",
-            "java.lang.String",
-            "com.mongodb.ReadPreference",
-            "org.bson.FieldNameValidator",
-            "org.bson.codecs.Decoder",
-            "com.mongodb.internal.operation.CommandOperationHelper.CommandCreator",
-            "com.mongodb.internal.operation.CommandOperationHelper.CommandWriteTransformer",
-            "com.mongodb.Function"
+            MethodParamTypeName.WRITE_BINDING_CLASS_NAME,
+            MethodParamTypeName.STRING_CLASS_NAME,
+            MethodParamTypeName.READ_PREFERENCE_CLASS_NAME,
+            MethodParamTypeName.FIELD_NAME_VALIDATOR_CLASS_NAME,
+            MethodParamTypeName.DECODER_CLASS_NAME,
+            MethodParamTypeName.COMMAND_CREATOR_CLASS_NAME,
+            MethodParamTypeName.COMMAND_WRITE_TRANSFORMER_CLASS_NAME,
+            MethodParamTypeName.FUNCTION_CLASS_NAME
     };
 
     private static final String[] EXECUTE_RETRY_COMMAND_ASYNC_PARAMS_TYPE = {
-            "com.mongodb.internal.binding.AsyncWriteBinding",
-            "java.lang.String",
-            "com.mongodb.ReadPreference",
-            "org.bson.FieldNameValidator",
-            "org.bson.codecs.Decoder",
-            "com.mongodb.internal.operation.CommandOperationHelper.CommandCreator",
-            "com.mongodb.internal.operation.CommandOperationHelper.CommandWriteTransformerAsync",
-            "com.mongodb.Function",
-            "com.mongodb.internal.async.SingleResultCallback"
+            MethodParamTypeName.ASYNC_WRITE_BINDING_CLASS_NAME,
+            MethodParamTypeName.STRING_CLASS_NAME,
+            MethodParamTypeName.READ_PREFERENCE_CLASS_NAME,
+            MethodParamTypeName.FIELD_NAME_VALIDATOR_CLASS_NAME,
+            MethodParamTypeName.DECODER_CLASS_NAME,
+            MethodParamTypeName.COMMAND_CREATOR_CLASS_NAME,
+            MethodParamTypeName.COMMAND_WRITE_TRANSFORMER_ASYNC_CLASS_NAME,
+            MethodParamTypeName.FUNCTION_CLASS_NAME,
+            MethodParamTypeName.SINGLE_RESULT_CALLBACK_CLASS_NAME
     };
 
     private MongoDbEnhancementHelper() {

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteCommandInterceptorTest.java
@@ -61,7 +61,7 @@ public class ExecuteCommandInterceptorTest {
         operationMock = Mockito.mock(MixedBulkWriteOperation.class);
         methodMock = Mockito.mock(Method.class);
         Mockito.when(operationMock.getNamespace()).thenReturn(namespace);
-        argument = new Object[] {"database-test"};
+        argument = new Object[]{"database-test"};
     }
 
     @AfterClass
@@ -72,7 +72,7 @@ public class ExecuteCommandInterceptorTest {
     @Test
     public void testDoBefore() {
         // 数据库禁写开关关闭
-        globalConfig.setEnableDatabaseWriteProhibition(false);
+        globalConfig.setEnableMongoDbWriteProhibition(false);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
         interceptor.doBefore(context);
         Assert.assertNull(context.getThrowableOut());
@@ -80,18 +80,18 @@ public class ExecuteCommandInterceptorTest {
         // 数据库禁写开关关闭，禁写数据库set包含被拦截的数据库
         Set<String> databases = new HashSet<>();
         databases.add("database-test");
-        globalConfig.setDatabases(databases);
+        globalConfig.setMongoDbDatabases(databases);
         Assert.assertNull(context.getThrowableOut());
 
         //数据库禁写开关打开，禁写数据库集合包含被拦截的数据库
-        globalConfig.setEnableDatabaseWriteProhibition(true);
+        globalConfig.setEnableMongoDbWriteProhibition(true);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
         interceptor.doBefore(context);
         Assert.assertEquals("Database prohibit to write, database: database-test",
                 context.getThrowableOut().getMessage());
 
         //数据库禁写开关打开，禁写数据库集合不包含被拦截的数据库
-        globalConfig.setDatabases(new HashSet<>());
+        globalConfig.setMongoDbDatabases(new HashSet<>());
         interceptor.doBefore(context);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
         Assert.assertNull(context.getThrowableOut());

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteRetryableCommandInterceptorTest.java
@@ -72,7 +72,7 @@ public class ExecuteRetryableCommandInterceptorTest {
     @Test
     public void testDoBefore() {
         // 数据库禁写开关关闭
-        globalConfig.setEnableDatabaseWriteProhibition(false);
+        globalConfig.setEnableMongoDbWriteProhibition(false);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
         interceptor.doBefore(context);
         Assert.assertNull(context.getThrowableOut());
@@ -80,19 +80,18 @@ public class ExecuteRetryableCommandInterceptorTest {
         // 数据库禁写开关关闭，禁写数据库set包含被拦截的数据库
         Set<String> databases = new HashSet<>();
         databases.add("database-test");
-        globalConfig.setDatabases(databases);
+        globalConfig.setMongoDbDatabases(databases);
         Assert.assertNull(context.getThrowableOut());
 
         //数据库禁写开关打开，禁写数据库集合包含被拦截的数据库
-        globalConfig.setEnableDatabaseWriteProhibition(true);
-        globalConfig.setDatabases(databases);
+        globalConfig.setEnableMongoDbWriteProhibition(true);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
         interceptor.doBefore(context);
         Assert.assertEquals("Database prohibit to write, database: database-test",
                 context.getThrowableOut().getMessage());
 
         //数据库禁写开关打开，禁写数据库集合不包含被拦截的数据库
-        globalConfig.setDatabases(new HashSet<>());
+        globalConfig.setMongoDbDatabases(new HashSet<>());
         interceptor.doBefore(context);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
         Assert.assertNull(context.getThrowableOut());

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptorTest.java
@@ -69,7 +69,7 @@ public class MixedBulkWriteOperationInterceptorTest {
     @Test
     public void testDoBefore() {
         // 数据库禁写开关关闭
-        globalConfig.setEnableDatabaseWriteProhibition(false);
+        globalConfig.setEnableMongoDbWriteProhibition(false);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
         interceptor.doBefore(context);
         Assert.assertNull(context.getThrowableOut());
@@ -77,18 +77,18 @@ public class MixedBulkWriteOperationInterceptorTest {
         // 数据库禁写开关关闭，禁写数据库set包含被拦截的数据库
         Set<String> databases = new HashSet<>();
         databases.add("database-test");
-        globalConfig.setDatabases(databases);
+        globalConfig.setMongoDbDatabases(databases);
         Assert.assertNull(context.getThrowableOut());
 
         //数据库禁写开关打开，禁写数据库集合包含被拦截的数据库
-        globalConfig.setEnableDatabaseWriteProhibition(true);
+        globalConfig.setEnableMongoDbWriteProhibition(true);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
         interceptor.doBefore(context);
         Assert.assertEquals("Database prohibit to write, database: database-test",
                 context.getThrowableOut().getMessage());
 
         //数据库禁写开关打开，禁写数据库集合不包含被拦截的数据库
-        globalConfig.setDatabases(new HashSet<>());
+        globalConfig.setMongoDbDatabases(new HashSet<>());
         interceptor.doBefore(context);
         context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
         Assert.assertNull(context.getThrowableOut());

--- a/sermant-plugins/sermant-database-write-prohibition/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/pom.xml
@@ -27,6 +27,7 @@
             </activation>
             <modules>
                 <module>database-controller</module>
+                <module>database-config-service</module>
                 <module>mongodb-3.x-4.x-plugin</module>
             </modules>
         </profile>
@@ -34,6 +35,7 @@
             <id>test</id>
             <modules>
                 <module>database-controller</module>
+                <module>database-config-service</module>
                 <module>mongodb-3.x-4.x-plugin</module>
             </modules>
         </profile>
@@ -41,6 +43,7 @@
             <id>release</id>
             <modules>
                 <module>database-controller</module>
+                <module>database-config-service</module>
                 <module>mongodb-3.x-4.x-plugin</module>
             </modules>
         </profile>


### PR DESCRIPTION
【Fix issue】#1422

【Modified content】
1. Added dynamic configuration of database write prohibition
2. Modified the configuration class
3. Modify the mongodb interception point method type to Sring array
[Use case description] Not required

[Self-test situation] 1. Local static check passed

[Scope of Impact] You need to add the plug-in user manual after