### PR TITLE
Mysql write prohibition and database instance information acquisition

### DIFF
--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionConfig.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionConfig.java
@@ -39,12 +39,12 @@ public class DatabaseWriteProhibitionConfig {
     /**
      * Mysql是否开启禁写
      */
-    private boolean enableMysqlWriteProhibition = false;
+    private boolean enableMySqlWriteProhibition = false;
 
     /**
      * Mysql需要禁写的数据库
      */
-    private Set<String> mysqlDatabases = new HashSet<>();
+    private Set<String> mySqlDatabases = new HashSet<>();
 
     /**
      * PostgreSQL是否开启禁写
@@ -82,20 +82,20 @@ public class DatabaseWriteProhibitionConfig {
         this.mongoDbDatabases = mongoDbDatabases;
     }
 
-    public boolean isEnableMysqlWriteProhibition() {
-        return enableMysqlWriteProhibition;
+    public boolean isEnableMySqlWriteProhibition() {
+        return enableMySqlWriteProhibition;
     }
 
-    public void setEnableMysqlWriteProhibition(boolean enableMysqlWriteProhibition) {
-        this.enableMysqlWriteProhibition = enableMysqlWriteProhibition;
+    public void setEnableMySqlWriteProhibition(boolean enableMySqlWriteProhibition) {
+        this.enableMySqlWriteProhibition = enableMySqlWriteProhibition;
     }
 
-    public Set<String> getMysqlDatabases() {
-        return mysqlDatabases;
+    public Set<String> getMySqlDatabases() {
+        return mySqlDatabases;
     }
 
-    public void setMysqlDatabases(Set<String> mysqlDatabases) {
-        this.mysqlDatabases = mysqlDatabases;
+    public void setMySqlDatabases(Set<String> mySqlDatabases) {
+        this.mySqlDatabases = mySqlDatabases;
     }
 
     public boolean isEnablePostgreSqlWriteProhibition() {
@@ -134,8 +134,8 @@ public class DatabaseWriteProhibitionConfig {
     public String toString() {
         return "enableMongoDbWriteProhibition=" + enableMongoDbWriteProhibition
                 + ", mongoDbDatabases=" + mongoDbDatabases + "; "
-                + "enableMysqlWriteProhibition=" + enableMysqlWriteProhibition
-                + ", mysqlDatabases=" + mysqlDatabases + "; "
+                + "enableMysqlWriteProhibition=" + enableMySqlWriteProhibition
+                + ", mysqlDatabases=" + mySqlDatabases + "; "
                 + "enablePostgreSqlWriteProhibition=" + enablePostgreSqlWriteProhibition
                 + ", postgreSqlDatabases=" + postgreSqlDatabases + ";"
                 + " enableOpenGaussWriteProhibition=" + enableOpenGaussWriteProhibition

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManager.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManager.java
@@ -54,12 +54,12 @@ public class DatabaseWriteProhibitionManager {
      *
      * @return Mysql禁止写入的数据库集合
      */
-    public static Set<String> getMysqlProhibitionDatabases() {
-        if (globalConfig.isEnableMysqlWriteProhibition()) {
-            return globalConfig.getMysqlDatabases();
+    public static Set<String> getMySqlProhibitionDatabases() {
+        if (globalConfig.isEnableMySqlWriteProhibition()) {
+            return globalConfig.getMySqlDatabases();
         }
-        if (localConfig.isEnableMysqlWriteProhibition()) {
-            return localConfig.getMysqlDatabases();
+        if (localConfig.isEnableMySqlWriteProhibition()) {
+            return localConfig.getMySqlDatabases();
         }
         return Collections.EMPTY_SET;
     }

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/constant/DatabaseType.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/constant/DatabaseType.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.constant;
+
+/**
+ * 数据库类型常量
+ *
+ * @author daizhenyu
+ * @since 2024-02-06
+ **/
+public enum DatabaseType {
+    /**
+     * mongodb
+     */
+    MONGODB("MongoDB"),
+    /**
+     * mysql
+     */
+    MYSQL("MySQL"),
+    /**
+     * postgresql
+     */
+    POSTGRESQL("PostgreSQL"),
+    /**
+     * opengauss
+     */
+    OPENGAUSS("openGauss");
+
+    private String type;
+
+    /**
+     * 构造方法
+     *
+     * @param type 数据库类型
+     */
+    DatabaseType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/controller/DatabaseController.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/controller/DatabaseController.java
@@ -16,9 +16,12 @@
 
 package com.huaweicloud.sermant.database.controller;
 
+import com.huaweicloud.sermant.core.common.LoggerFactory;
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 
 import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * 数据库控制器
@@ -27,6 +30,8 @@ import java.sql.SQLException;
  * @since 2024-01-15
  **/
 public class DatabaseController {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
     private static Object result = new Object();
 
     private DatabaseController() {
@@ -42,5 +47,6 @@ public class DatabaseController {
     public static void disableDatabaseWriteOperation(String database, ExecuteContext context) {
         context.setThrowableOut(new SQLException("Database prohibit to write, database: " + database));
         context.skip(result);
+        LOGGER.log(Level.FINE, "Database prohibit to write, database: {0}", database);
     }
 }

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/entity/DatabaseInfo.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/entity/DatabaseInfo.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.entity;
+
+import com.huaweicloud.sermant.database.constant.DatabaseType;
+
+/**
+ * 数据库示例信息
+ *
+ * @author daizhenyu
+ * @since 2024-02-01
+ **/
+public class DatabaseInfo {
+    private DatabaseType databaseType;
+
+    private String databaseName;
+
+    private String hostAddress;
+
+    private int port;
+
+    /**
+     * 无参构造方法
+     */
+    public DatabaseInfo() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param type 数据库类型
+     */
+    public DatabaseInfo(DatabaseType type) {
+        databaseType = type;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public void setDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+    }
+
+    public String getHostAddress() {
+        return hostAddress;
+    }
+
+    public void setHostAddress(String hostAddress) {
+        this.hostAddress = hostAddress;
+    }
+
+    public DatabaseType getDatabaseType() {
+        return databaseType;
+    }
+
+    public void setDatabaseType(DatabaseType databaseType) {
+        this.databaseType = databaseType;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/interceptor/AbstractDatabaseInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/interceptor/AbstractDatabaseInterceptor.java
@@ -18,19 +18,29 @@ package com.huaweicloud.sermant.database.interceptor;
 
 import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
 import com.huaweicloud.sermant.core.plugin.agent.interceptor.AbstractInterceptor;
+import com.huaweicloud.sermant.database.entity.DatabaseInfo;
 import com.huaweicloud.sermant.database.handler.DatabaseHandler;
 
 /**
- * mongodb抽象interceptor
+ * 数据库抽象interceptor
  *
  * @author daizhenyu
  * @since 2024-01-22
  **/
 public abstract class AbstractDatabaseInterceptor extends AbstractInterceptor {
+    /**
+     * 数据库信息存储的key
+     */
+    protected static final String DATABASE_INFO = "databaseInfo";
+
+    /**
+     * 自定义数据库处理handle
+     */
     protected DatabaseHandler handler;
 
     @Override
     public ExecuteContext before(ExecuteContext context) throws Exception {
+        createAndCacheDatabaseInfo(context);
         if (handler != null) {
             handler.doBefore(context);
             return context;
@@ -63,4 +73,21 @@ public abstract class AbstractDatabaseInterceptor extends AbstractInterceptor {
      * @return ExecuteContext 上下文
      */
     protected abstract ExecuteContext doBefore(ExecuteContext context);
+
+    /**
+     * 创建数据库实例对象并缓存在上下文的本地局部属性集中
+     *
+     * @param context 上下文
+     */
+    protected abstract void createAndCacheDatabaseInfo(ExecuteContext context);
+
+    /**
+     * 从context局部属性集中获取数据库实例信息
+     *
+     * @param context 上下文
+     * @return DatabaseInfo 数据库实例信息
+     */
+    protected DatabaseInfo getDataBaseInfo(ExecuteContext context) {
+        return (DatabaseInfo) context.getLocalFieldValue(DATABASE_INFO);
+    }
 }

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/utils/SqlParserUtils.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/main/java/com/huaweicloud/sermant/database/utils/SqlParserUtils.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.database.utils;
+
+import com.huaweicloud.sermant.core.utils.StringUtils;
+
+import java.util.regex.Pattern;
+
+/**
+ * sql解析工具类
+ *
+ * @author daizhenyu
+ * @since 2024-01-25
+ **/
+public class SqlParserUtils {
+    private static Pattern writePattern =
+            Pattern.compile("INSERT\\b|UPDATE\\b|DELETE\\b|CREATE\\b|ALTER\\b|DROP\\b|TRUNCATE\\b",
+                    Pattern.CASE_INSENSITIVE);
+
+    private SqlParserUtils() {
+    }
+
+    /**
+     * 解析sql并判断是否为写操作
+     *
+     * @param sql sql语句
+     * @return 是否为写操作
+     */
+    public static boolean isWriteOperation(String sql) {
+        if (StringUtils.isEmpty(sql)) {
+            return false;
+        }
+        return writePattern.matcher(sql).find();
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManagerTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/database-controller/src/test/java/com/huaweicloud/sermant/database/config/DatabaseWriteProhibitionManagerTest.java
@@ -41,7 +41,7 @@ public class DatabaseWriteProhibitionManagerTest {
         globalConfig.setMongoDbDatabases(globalMongoDbDatabases);
         HashSet<String> globalMysqlDatabases = new HashSet<>();
         globalMysqlDatabases.add("mysql-test-1");
-        globalConfig.setMysqlDatabases(globalMysqlDatabases);
+        globalConfig.setMySqlDatabases(globalMysqlDatabases);
         HashSet<String> globalPostgreSqlDatabases = new HashSet<>();
         globalPostgreSqlDatabases.add("postgresql-test-1");
         globalConfig.setPostgreSqlDatabases(globalPostgreSqlDatabases);
@@ -54,7 +54,7 @@ public class DatabaseWriteProhibitionManagerTest {
         localConfig.setMongoDbDatabases(localMongoDbDatabases);
         HashSet<String> localMysqlDatabases = new HashSet<>();
         localMysqlDatabases.add("mysql-test-1");
-        globalConfig.setMysqlDatabases(localMysqlDatabases);
+        globalConfig.setMySqlDatabases(localMysqlDatabases);
         HashSet<String> localPostgreSqlDatabases = new HashSet<>();
         localPostgreSqlDatabases.add("postgresql-test-1");
         globalConfig.setPostgreSqlDatabases(localPostgreSqlDatabases);
@@ -69,11 +69,11 @@ public class DatabaseWriteProhibitionManagerTest {
     @Test
     public void testGetProhibitionDatabasesWithGlobalAndLocalConfigEnabled() {
         globalConfig.setEnableMongoDbWriteProhibition(true);
-        globalConfig.setEnableMysqlWriteProhibition(true);
+        globalConfig.setEnableMySqlWriteProhibition(true);
         globalConfig.setEnablePostgreSqlWriteProhibition(true);
         globalConfig.setEnableOpenGaussWriteProhibition(true);
         localConfig.setEnableMongoDbWriteProhibition(true);
-        localConfig.setEnableMysqlWriteProhibition(true);
+        localConfig.setEnableMySqlWriteProhibition(true);
         localConfig.setEnablePostgreSqlWriteProhibition(true);
         localConfig.setEnableOpenGaussWriteProhibition(true);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
@@ -81,8 +81,8 @@ public class DatabaseWriteProhibitionManagerTest {
 
         Assert.assertEquals(globalConfig.getMongoDbDatabases(),
                 DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases());
-        Assert.assertEquals(globalConfig.getMysqlDatabases(),
-                DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getMySqlDatabases(),
+                DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases());
         Assert.assertEquals(globalConfig.getPostgreSqlDatabases(),
                 DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases());
         Assert.assertEquals(globalConfig.getOpenGaussDatabases(),
@@ -95,11 +95,11 @@ public class DatabaseWriteProhibitionManagerTest {
     @Test
     public void testGetProhibitionDatabasesWithJustGlobalConfigEnabled() {
         globalConfig.setEnableMongoDbWriteProhibition(true);
-        globalConfig.setEnableMysqlWriteProhibition(true);
+        globalConfig.setEnableMySqlWriteProhibition(true);
         globalConfig.setEnablePostgreSqlWriteProhibition(true);
         globalConfig.setEnableOpenGaussWriteProhibition(true);
         localConfig.setEnableMongoDbWriteProhibition(false);
-        localConfig.setEnableMysqlWriteProhibition(false);
+        localConfig.setEnableMySqlWriteProhibition(false);
         localConfig.setEnablePostgreSqlWriteProhibition(false);
         localConfig.setEnableOpenGaussWriteProhibition(false);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
@@ -107,8 +107,8 @@ public class DatabaseWriteProhibitionManagerTest {
 
         Assert.assertEquals(globalConfig.getMongoDbDatabases(),
                 DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases());
-        Assert.assertEquals(globalConfig.getMysqlDatabases(),
-                DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases());
+        Assert.assertEquals(globalConfig.getMySqlDatabases(),
+                DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases());
         Assert.assertEquals(globalConfig.getPostgreSqlDatabases(),
                 DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases());
         Assert.assertEquals(globalConfig.getOpenGaussDatabases(),
@@ -121,11 +121,11 @@ public class DatabaseWriteProhibitionManagerTest {
     @Test
     public void testGetProhibitionDatabasesWithJustLocalConfigEnabled() {
         globalConfig.setEnableMongoDbWriteProhibition(false);
-        globalConfig.setEnableMysqlWriteProhibition(false);
+        globalConfig.setEnableMySqlWriteProhibition(false);
         globalConfig.setEnablePostgreSqlWriteProhibition(false);
         globalConfig.setEnableOpenGaussWriteProhibition(false);
         localConfig.setEnableMongoDbWriteProhibition(true);
-        localConfig.setEnableMysqlWriteProhibition(true);
+        localConfig.setEnableMySqlWriteProhibition(true);
         localConfig.setEnablePostgreSqlWriteProhibition(true);
         localConfig.setEnableOpenGaussWriteProhibition(true);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
@@ -133,8 +133,8 @@ public class DatabaseWriteProhibitionManagerTest {
 
         Assert.assertEquals(localConfig.getMongoDbDatabases(),
                 DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases());
-        Assert.assertEquals(localConfig.getMysqlDatabases(),
-                DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases());
+        Assert.assertEquals(localConfig.getMySqlDatabases(),
+                DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases());
         Assert.assertEquals(localConfig.getPostgreSqlDatabases(),
                 DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases());
         Assert.assertEquals(localConfig.getOpenGaussDatabases(),
@@ -147,18 +147,18 @@ public class DatabaseWriteProhibitionManagerTest {
     @Test
     public void testGetProhibitionDatabasesWithBothConfigsDisabled() {
         globalConfig.setEnableMongoDbWriteProhibition(false);
-        globalConfig.setEnableMysqlWriteProhibition(false);
+        globalConfig.setEnableMySqlWriteProhibition(false);
         globalConfig.setEnablePostgreSqlWriteProhibition(false);
         globalConfig.setEnableOpenGaussWriteProhibition(false);
         localConfig.setEnableMongoDbWriteProhibition(false);
-        localConfig.setEnableMysqlWriteProhibition(false);
+        localConfig.setEnableMySqlWriteProhibition(false);
         localConfig.setEnablePostgreSqlWriteProhibition(false);
         localConfig.setEnableOpenGaussWriteProhibition(false);
         DatabaseWriteProhibitionManager.updateGlobalConfig(globalConfig);
         DatabaseWriteProhibitionManager.updateLocalConfig(localConfig);
 
         Assert.assertTrue(DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases().isEmpty());
-        Assert.assertTrue(DatabaseWriteProhibitionManager.getMysqlProhibitionDatabases().isEmpty());
+        Assert.assertTrue(DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().isEmpty());
         Assert.assertTrue(DatabaseWriteProhibitionManager.getPostgreSqlProhibitionDatabases().isEmpty());
         Assert.assertTrue(DatabaseWriteProhibitionManager.getOpenGaussProhibitionDatabases().isEmpty());
     }
@@ -183,19 +183,19 @@ public class DatabaseWriteProhibitionManagerTest {
         DatabaseWriteProhibitionManager.updateLocalConfig(null);
 
         Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getMongoDbDatabases().size());
-        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getMysqlDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getMySqlDatabases().size());
         Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getPostgreSqlDatabases().size());
         Assert.assertEquals(0, DatabaseWriteProhibitionManager.getGlobalConfig().getOpenGaussDatabases().size());
         Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getMongoDbDatabases().size());
-        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getMysqlDatabases().size());
+        Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getMySqlDatabases().size());
         Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getPostgreSqlDatabases().size());
         Assert.assertEquals(0, DatabaseWriteProhibitionManager.getLocalConfig().getOpenGaussDatabases().size());
         Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableMongoDbWriteProhibition());
-        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableMysqlWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableMySqlWriteProhibition());
         Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnablePostgreSqlWriteProhibition());
         Assert.assertFalse(DatabaseWriteProhibitionManager.getGlobalConfig().isEnableOpenGaussWriteProhibition());
         Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableMongoDbWriteProhibition());
-        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableMysqlWriteProhibition());
+        Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableMySqlWriteProhibition());
         Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnablePostgreSqlWriteProhibition());
         Assert.assertFalse(DatabaseWriteProhibitionManager.getLocalConfig().isEnableOpenGaussWriteProhibition());
     }

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/AbstractMongoDbInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/main/java/com/huaweicloud/sermant/mongodb/interceptors/AbstractMongoDbInterceptor.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.interceptor.AbstractDatabaseInterceptor;
+
+/**
+ * mongodb抽象interceptor
+ *
+ * @author daizhenyu
+ * @since 2024-02-02
+ **/
+public abstract class AbstractMongoDbInterceptor extends AbstractDatabaseInterceptor {
+    @Override
+    public ExecuteContext doBefore(ExecuteContext context) {
+        String database = getDataBaseInfo(context).getDatabaseName();
+        if (DatabaseWriteProhibitionManager.getMongoDbProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ConnectionSourceImpl.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ConnectionSourceImpl.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mongodb.interceptors;
+
+import com.mongodb.ServerApi;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.binding.ConnectionSource;
+import com.mongodb.internal.connection.Connection;
+import com.mongodb.internal.session.SessionContext;
+
+/**
+ * ConnectionSource接口的实现类
+ *
+ * @author daizhenyu
+ * @since 2024-02-05
+ **/
+public class ConnectionSourceImpl implements ConnectionSource {
+    private ServerDescription description;
+
+    /**
+     * 构造方法
+     *
+     * @param description 服务端信息
+     */
+    public ConnectionSourceImpl(ServerDescription description) {
+        this.description = description;
+    }
+    @Override
+    public ServerDescription getServerDescription() {
+        return description;
+    }
+
+    @Override
+    public SessionContext getSessionContext() {
+        return null;
+    }
+
+    @Override
+    public ServerApi getServerApi() {
+        return null;
+    }
+
+    @Override
+    public Connection getConnection() {
+        return null;
+    }
+
+    @Override
+    public int getCount() {
+        return 0;
+    }
+
+    @Override
+    public ConnectionSource retain() {
+        return null;
+    }
+
+    @Override
+    public void release() {
+
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteWriteCommandInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/ExecuteWriteCommandInterceptorTest.java
@@ -43,7 +43,7 @@ import java.util.Set;
  * @author daizhenyu
  * @since 2024-01-23
  **/
-public class ExecuteCommandInterceptorTest {
+public class ExecuteWriteCommandInterceptorTest {
     private static DatabaseWriteProhibitionConfig globalConfig = new DatabaseWriteProhibitionConfig();
 
     private static MongoNamespace namespace = new MongoNamespace("database-test",
@@ -57,7 +57,7 @@ public class ExecuteCommandInterceptorTest {
 
     private static Object[] argument;
 
-    private ExecuteCommandInterceptor interceptor = new ExecuteCommandInterceptor();
+    private ExecuteWriteCommandInterceptor interceptor = new ExecuteWriteCommandInterceptor();
 
     @BeforeClass
     public static void setUp() {
@@ -70,7 +70,7 @@ public class ExecuteCommandInterceptorTest {
         ServerAddress serverAddress = new ServerAddress("127.0.0.1", 8080);
         Mockito.when(connection.getDescription()).thenReturn(description);
         Mockito.when(description.getServerAddress()).thenReturn(serverAddress);
-        argument = new Object[]{"database-test", null, null, null, null, connection};
+        argument = new Object[]{"database-test", null, null, null, connection};
     }
 
     @AfterClass

--- a/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mongodb-3.x-4.x-plugin/src/test/java/com/huaweicloud/sermant/mongodb/interceptors/MixedBulkWriteOperationInterceptorTest.java
@@ -21,7 +21,15 @@ import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
 import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.ServerAddress;
+import com.mongodb.ServerApi;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.binding.ConnectionSource;
+import com.mongodb.internal.binding.SingleServerBinding;
+import com.mongodb.internal.binding.WriteBinding;
+import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.operation.MixedBulkWriteOperation;
+import com.mongodb.internal.session.SessionContext;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -51,6 +59,8 @@ public class MixedBulkWriteOperationInterceptorTest {
 
     private static Method methodMock;
 
+    private static Object[] argument;
+
     private MixedBulkWriteOperationInterceptor interceptor = new MixedBulkWriteOperationInterceptor();
 
     @BeforeClass
@@ -59,6 +69,12 @@ public class MixedBulkWriteOperationInterceptorTest {
         operationMock = Mockito.mock(MixedBulkWriteOperation.class);
         methodMock = Mockito.mock(Method.class);
         Mockito.when(operationMock.getNamespace()).thenReturn(namespace);
+        WriteBinding binding = Mockito.mock(SingleServerBinding.class);
+        ServerDescription description = Mockito.mock(ServerDescription.class);
+        ServerAddress serverAddress = new ServerAddress("127.0.0.1", 8080);
+        Mockito.when(binding.getWriteConnectionSource()).thenReturn(new ConnectionSourceImpl(description));
+        Mockito.when(description.getAddress()).thenReturn(serverAddress);
+        argument = new Object[]{binding};
     }
 
     @AfterClass
@@ -67,30 +83,31 @@ public class MixedBulkWriteOperationInterceptorTest {
     }
 
     @Test
-    public void testDoBefore() {
+    public void testDoBefore() throws Exception {
         // 数据库禁写开关关闭
         globalConfig.setEnableMongoDbWriteProhibition(false);
-        context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
-        interceptor.doBefore(context);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        interceptor.before(context);
         Assert.assertNull(context.getThrowableOut());
 
         // 数据库禁写开关关闭，禁写数据库set包含被拦截的数据库
         Set<String> databases = new HashSet<>();
         databases.add("database-test");
         globalConfig.setMongoDbDatabases(databases);
+        interceptor.before(context);
         Assert.assertNull(context.getThrowableOut());
 
         //数据库禁写开关打开，禁写数据库集合包含被拦截的数据库
         globalConfig.setEnableMongoDbWriteProhibition(true);
-        context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
-        interceptor.doBefore(context);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        interceptor.before(context);
         Assert.assertEquals("Database prohibit to write, database: database-test",
                 context.getThrowableOut().getMessage());
 
         //数据库禁写开关打开，禁写数据库集合不包含被拦截的数据库
         globalConfig.setMongoDbDatabases(new HashSet<>());
-        interceptor.doBefore(context);
-        context = ExecuteContext.forMemberMethod(operationMock, methodMock, null, null, null);
+        context = ExecuteContext.forMemberMethod(operationMock, methodMock, argument, null, null);
+        interceptor.before(context);
         Assert.assertNull(context.getThrowableOut());
     }
 }

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-database-write-prohibition</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>mysql-mariadb-2.x-plugin</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>plugin</package.plugin.type>
+        <mariadb.version>2.6.0</mariadb.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>${mariadb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>database-controller</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/declarers/QueryProtocolDeclarer.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/declarers/QueryProtocolDeclarer.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv2.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.mariadbv2.utils.MariadbV2EnhancementHelper;
+
+/**
+ * AbstractQueryProtocol类增强声明器
+ *
+ * @author daizhenyu
+ * @since 2024-01-26
+ **/
+public class QueryProtocolDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return MariadbV2EnhancementHelper.getQueryProtocolClassMatcher();
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return MariadbV2EnhancementHelper.getQueryProtocolInterceptDeclarers();
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/AbstractMariadbV2Interceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/AbstractMariadbV2Interceptor.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv2.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.constant.DatabaseType;
+import com.huaweicloud.sermant.database.entity.DatabaseInfo;
+import com.huaweicloud.sermant.database.interceptor.AbstractDatabaseInterceptor;
+
+import org.mariadb.jdbc.HostAddress;
+import org.mariadb.jdbc.internal.protocol.Protocol;
+
+/**
+ * mariadb2.x抽象interceptor
+ *
+ * @author daizhenyu
+ * @since 2024-02-02
+ **/
+public abstract class AbstractMariadbV2Interceptor extends AbstractDatabaseInterceptor {
+    @Override
+    protected void createAndCacheDatabaseInfo(ExecuteContext context) {
+        DatabaseInfo info = new DatabaseInfo(DatabaseType.MYSQL);
+        context.setLocalFieldValue(DATABASE_INFO, info);
+        Protocol protocol = (Protocol) context.getObject();
+        info.setDatabaseName(protocol.getDatabase());
+        HostAddress hostAddress = protocol.getHostAddress();
+        if (hostAddress != null) {
+            info.setHostAddress(hostAddress.host);
+            info.setPort(hostAddress.port);
+        }
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/ExecuteBatchStmtInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/ExecuteBatchStmtInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv2.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.utils.SqlParserUtils;
+
+import java.util.List;
+
+/**
+ * executeBatchStmt方法拦截器
+ *
+ * @author daizhenyu
+ * @since 2024-01-26
+ **/
+public class ExecuteBatchStmtInterceptor extends AbstractMariadbV2Interceptor {
+    private static final int PARAM_INDEX = 2;
+
+    /**
+     * 无参构造方法
+     */
+    public ExecuteBatchStmtInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public ExecuteBatchStmtInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        String database = getDataBaseInfo(context).getDatabaseName();
+        if (!DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().contains(database)) {
+            return context;
+        }
+        List<String> sqlList = (List) context.getArguments()[PARAM_INDEX];
+        for (String sql : sqlList) {
+            if (SqlParserUtils.isWriteOperation(sql)) {
+                DatabaseController.disableDatabaseWriteOperation(database, context);
+                return context;
+            }
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/ExecuteInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/ExecuteInterceptor.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv2.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.utils.SqlParserUtils;
+
+import org.mariadb.jdbc.internal.util.dao.ClientPrepareResult;
+
+/**
+ * executeQuery、executeBatchClient方法拦截器
+ *
+ * @author daizhenyu
+ * @since 2024-01-26
+ **/
+public class ExecuteInterceptor extends AbstractMariadbV2Interceptor {
+    private static final int PARAM_INDEX = 2;
+
+    /**
+     * 无参构造方法
+     */
+    public ExecuteInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public ExecuteInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        String database = getDataBaseInfo(context).getDatabaseName();
+        Object argument = context.getArguments()[PARAM_INDEX];
+        String sql = null;
+        if (argument instanceof ClientPrepareResult) {
+            sql = ((ClientPrepareResult) argument).getSql();
+        } else {
+            sql = (String) argument;
+        }
+        if (SqlParserUtils.isWriteOperation(sql)
+                && DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/ExecuteServerInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/ExecuteServerInterceptor.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv2.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.utils.SqlParserUtils;
+
+import org.mariadb.jdbc.internal.util.dao.ServerPrepareResult;
+
+/**
+ * executePreparedQuery、executeBatchServer方法拦截器
+ *
+ * @author daizhenyu
+ * @since 2024-01-26
+ **/
+public class ExecuteServerInterceptor extends AbstractMariadbV2Interceptor {
+    /**
+     * 无参构造方法
+     */
+    public ExecuteServerInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public ExecuteServerInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        String database = getDataBaseInfo(context).getDatabaseName();
+        String sql = ((ServerPrepareResult) context.getArguments()[1]).getSql();
+        if (SqlParserUtils.isWriteOperation(sql)
+                && DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/PrepareInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/interceptors/PrepareInterceptor.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv2.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.utils.SqlParserUtils;
+
+/**
+ * prepare方法拦截器
+ *
+ * @author daizhenyu
+ * @since 2024-01-27
+ **/
+public class PrepareInterceptor extends AbstractMariadbV2Interceptor {
+    /**
+     * 无参构造方法
+     */
+    public PrepareInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public PrepareInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        String database = getDataBaseInfo(context).getDatabaseName();
+        String sql = (String) context.getArguments()[0];
+        if (SqlParserUtils.isWriteOperation(sql)
+                && DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/utils/MariadbV2EnhancementHelper.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv2/utils/MariadbV2EnhancementHelper.java
@@ -1,0 +1,237 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv2.utils;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.mariadbv2.interceptors.ExecuteBatchStmtInterceptor;
+import com.huaweicloud.sermant.mariadbv2.interceptors.ExecuteInterceptor;
+import com.huaweicloud.sermant.mariadbv2.interceptors.ExecuteServerInterceptor;
+import com.huaweicloud.sermant.mariadbv2.interceptors.PrepareInterceptor;
+
+/**
+ * mariadb2.x拦截点辅助类
+ *
+ * @author daizhenyu
+ * @since 2024-01-26
+ **/
+public class MariadbV2EnhancementHelper {
+    private static final String QUERY_PROTOCOL_CLASS = "org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol";
+
+    private static final String EXECUTE_QUERY_METHOD_NAME = "executeQuery";
+
+    private static final String EXECUTE_BATCH_CLIENT_METHOD_NAME = "executeBatchClient";
+
+    private static final String EXECUTE_BATCH_SERVER_METHOD_NAME = "executeBatchServer";
+
+    private static final String EXECUTE_BATCH_STMT_METHOD_NAME = "executeBatchStmt";
+
+    private static final String EXECUTE_PREPARED_QUERY_METHOD_NAME = "executePreparedQuery";
+
+    private static final String PREPARE_METHOD_NAME = "prepare";
+
+    private static final int FIRST_OVER_LOAD_METHOD_PARAM_COUNT = 3;
+
+    private static final int SECOND_OVER_LOAD_METHOD_PARAM_COUNT = 4;
+
+    private static final int THIRD_OVER_LOAD_METHOD_PARAM_COUNT = 5;
+
+    private MariadbV2EnhancementHelper() {
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类的ClassMatcher
+     *
+     * @return ClassMatcher 类匹配器
+     */
+    public static ClassMatcher getQueryProtocolClassMatcher() {
+        return ClassMatcher.nameEquals(QUERY_PROTOCOL_CLASS);
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类sql执行无参拦截器数组
+     *
+     * @return InterceptDeclarer[] AbstractQueryProtocol类sql执行无参拦截器数组
+     */
+    public static InterceptDeclarer[] getQueryProtocolInterceptDeclarers() {
+        ExecuteInterceptor executeInterceptor = new ExecuteInterceptor();
+        ExecuteServerInterceptor executeServerInterceptor = new ExecuteServerInterceptor();
+        return new InterceptDeclarer[]{
+                InterceptDeclarer.build(getExecuteQueryMethodMatcher(), executeInterceptor),
+                InterceptDeclarer.build(getExecuteBatchClientMethodMatcher(), executeInterceptor),
+                InterceptDeclarer.build(getExecuteBatchStmtMethodMatcher(), new ExecuteBatchStmtInterceptor()),
+                InterceptDeclarer.build(getExecutePreparedQueryMethodMatcher(), executeServerInterceptor),
+                InterceptDeclarer.build(getExecuteBatchServerMethodMatcher(), executeServerInterceptor),
+                InterceptDeclarer.build(getPrepareMethodMatcher(), new PrepareInterceptor())
+        };
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeQuery方法无参拦截器
+     *
+     * @return InterceptDeclarer AbstractQueryProtocol类executeQuery方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteQueryInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteQueryMethodMatcher(),
+                new ExecuteInterceptor());
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeQuery方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer AbstractQueryProtocol类execute方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteQueryInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteQueryMethodMatcher(),
+                new ExecuteInterceptor(handler));
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeBatchClient方法无参拦截器
+     *
+     * @return InterceptDeclarer AbstractQueryProtocol类executeBatchClient方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteBatchClientInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteBatchClientMethodMatcher(),
+                new ExecuteInterceptor());
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeBatchClient方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer AbstractQueryProtocol类executeBatchClient方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteBatchClientInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteBatchClientMethodMatcher(),
+                new ExecuteInterceptor(handler));
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeBatchStmt方法无参拦截器
+     *
+     * @return InterceptDeclarer AbstractQueryProtocol类executeBatchStmt方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteBatchStmtInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteBatchStmtMethodMatcher(),
+                new ExecuteBatchStmtInterceptor());
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeBatchStmt方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer AbstractQueryProtocol类executeBatchStmt方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteBatchStmtInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteBatchStmtMethodMatcher(),
+                new ExecuteBatchStmtInterceptor(handler));
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executePreparedQuery方法无参拦截器
+     *
+     * @return InterceptDeclarer AbstractQueryProtocol类executePreparedQuery方法无参拦截器
+     */
+    public static InterceptDeclarer getExecutePreparedQueryInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecutePreparedQueryMethodMatcher(),
+                new ExecuteServerInterceptor());
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executePreparedQuery方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer AbstractQueryProtocol类executePreparedQuery方法有参拦截器
+     */
+    public static InterceptDeclarer getExecutePreparedQueryInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecutePreparedQueryMethodMatcher(),
+                new ExecuteServerInterceptor(handler));
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeBatchServer方法无参拦截器
+     *
+     * @return InterceptDeclarer AbstractQueryProtocol类executeBatchServer方法无参拦截器
+     */
+    public static InterceptDeclarer getExecuteBatchServerInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecuteBatchServerMethodMatcher(),
+                new ExecuteServerInterceptor());
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类executeBatchServer方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer AbstractQueryProtocol类executeBatchServer方法有参拦截器
+     */
+    public static InterceptDeclarer getExecuteBatchServerInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecuteBatchServerMethodMatcher(),
+                new ExecuteServerInterceptor(handler));
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类prepare方法无参拦截器
+     *
+     * @return InterceptDeclarer AbstractQueryProtocol类prepare方法无参拦截器
+     */
+    public static InterceptDeclarer getPrepareInterceptDeclarer() {
+        return InterceptDeclarer.build(getPrepareMethodMatcher(),
+                new PrepareInterceptor());
+    }
+
+    /**
+     * 获取AbstractQueryProtocol类prepare方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer AbstractQueryProtocol类prepare方法有参拦截器
+     */
+    public static InterceptDeclarer getPrepareInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getPrepareMethodMatcher(),
+                new PrepareInterceptor(handler));
+    }
+
+    private static MethodMatcher getExecuteQueryMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_QUERY_METHOD_NAME)
+                .and(MethodMatcher.paramCountEquals(FIRST_OVER_LOAD_METHOD_PARAM_COUNT)
+                        .or(MethodMatcher.paramCountEquals(SECOND_OVER_LOAD_METHOD_PARAM_COUNT))
+                        .or(MethodMatcher.paramCountEquals(THIRD_OVER_LOAD_METHOD_PARAM_COUNT)));
+    }
+
+    private static MethodMatcher getExecuteBatchStmtMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_BATCH_STMT_METHOD_NAME);
+    }
+
+    private static MethodMatcher getExecuteBatchClientMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_BATCH_CLIENT_METHOD_NAME);
+    }
+
+    private static MethodMatcher getExecutePreparedQueryMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_PREPARED_QUERY_METHOD_NAME);
+    }
+
+    private static MethodMatcher getExecuteBatchServerMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_BATCH_SERVER_METHOD_NAME);
+    }
+
+    private static MethodMatcher getPrepareMethodMatcher() {
+        return MethodMatcher.nameEquals(PREPARE_METHOD_NAME);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-2.x-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.huaweicloud.sermant.mariadbv2.declarers.QueryProtocolDeclarer

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sermant-database-write-prohibition</artifactId>
+        <groupId>com.huaweicloud.sermant</groupId>
+        <version>1.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>mysql-mariadb-3.x-plugin</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <config.skip.flag>false</config.skip.flag>
+        <package.plugin.type>plugin</package.plugin.type>
+        <mariadb.version>3.0.11</mariadb.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>sermant-agentcore-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>${mariadb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.huaweicloud.sermant</groupId>
+            <artifactId>database-controller</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/declarers/ReplayClientDeclarer.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/declarers/ReplayClientDeclarer.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv3.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.mariadbv3.utils.MariadbV3EnhancementHelper;
+
+/**
+ * ReplayClient类增强声明器
+ *
+ * @author daizhenyu
+ * @since 2024-01-30
+ **/
+public class ReplayClientDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return MariadbV3EnhancementHelper.getReplayClientClassMatcher();
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {
+                MariadbV3EnhancementHelper.getSendQueryInterceptDeclarer()
+        };
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/declarers/StandardClientDeclarer.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/declarers/StandardClientDeclarer.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv3.declarers;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.AbstractPluginDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.mariadbv3.utils.MariadbV3EnhancementHelper;
+
+/**
+ * StandardClient类增强声明器
+ *
+ * @author daizhenyu
+ * @since 2024-01-30
+ **/
+public class StandardClientDeclarer extends AbstractPluginDeclarer {
+    @Override
+    public ClassMatcher getClassMatcher() {
+        return MariadbV3EnhancementHelper.getStandardClientClassMatcher();
+    }
+
+    @Override
+    public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
+        return new InterceptDeclarer[] {
+                MariadbV3EnhancementHelper.getSendQueryInterceptDeclarer()
+        };
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/interceptors/SendQueryInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/interceptors/SendQueryInterceptor.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv3.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.database.constant.DatabaseType;
+import com.huaweicloud.sermant.database.controller.DatabaseController;
+import com.huaweicloud.sermant.database.entity.DatabaseInfo;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.database.interceptor.AbstractDatabaseInterceptor;
+import com.huaweicloud.sermant.database.utils.SqlParserUtils;
+
+import org.mariadb.jdbc.HostAddress;
+import org.mariadb.jdbc.client.impl.StandardClient;
+import org.mariadb.jdbc.message.ClientMessage;
+
+/**
+ * sendQuery方法拦截器
+ *
+ * @author daizhenyu
+ * @since 2024-01-30
+ **/
+public class SendQueryInterceptor extends AbstractDatabaseInterceptor {
+    /**
+     * 无参构造方法
+     */
+    public SendQueryInterceptor() {
+    }
+
+    /**
+     * 有参构造方法
+     *
+     * @param handler 写操作处理器
+     */
+    public SendQueryInterceptor(DatabaseHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    protected ExecuteContext doBefore(ExecuteContext context) {
+        ClientMessage clientMessage = (ClientMessage) context.getArguments()[0];
+        String database = getDataBaseInfo(context).getDatabaseName();
+        if (SqlParserUtils.isWriteOperation(clientMessage.description())
+                && DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().contains(database)) {
+            DatabaseController.disableDatabaseWriteOperation(database, context);
+        }
+        return context;
+    }
+
+    @Override
+    protected void createAndCacheDatabaseInfo(ExecuteContext context) {
+        DatabaseInfo info = new DatabaseInfo(DatabaseType.MYSQL);
+        context.setLocalFieldValue(DATABASE_INFO, info);
+        StandardClient client = (StandardClient) context.getObject();
+        if (client.getContext() != null) {
+            info.setDatabaseName(client.getContext().getDatabase());
+        }
+        HostAddress hostAddress = client.getHostAddress();
+        info.setHostAddress(hostAddress.host);
+        info.setPort(hostAddress.port);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/utils/MariadbV3EnhancementHelper.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/utils/MariadbV3EnhancementHelper.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv3.utils;
+
+import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
+import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
+import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.mariadbv3.interceptors.SendQueryInterceptor;
+
+/**
+ * mariadb3.x拦截点辅助类
+ *
+ * @author daizhenyu
+ * @since 2024-01-30
+ **/
+public class MariadbV3EnhancementHelper {
+    private static final String REPLAY_CLIENT_CLASS = "org.mariadb.jdbc.client.impl.ReplayClient";
+
+    private static final String STANDARD_CLIENT_CLASS = "org.mariadb.jdbc.client.impl.StandardClient";
+
+    private static final String SEND_QUERY_METHOD_NAME = "sendQuery";
+
+    private MariadbV3EnhancementHelper() {
+    }
+
+    /**
+     * 获取ReplayClient类的ClassMatcher
+     *
+     * @return ClassMatcher 类匹配器
+     */
+    public static ClassMatcher getReplayClientClassMatcher() {
+        return ClassMatcher.nameEquals(REPLAY_CLIENT_CLASS);
+    }
+
+    /**
+     * 获取StandardClient类的ClassMatcher
+     *
+     * @return ClassMatcher 类匹配器
+     */
+    public static ClassMatcher getStandardClientClassMatcher() {
+        return ClassMatcher.nameEquals(STANDARD_CLIENT_CLASS);
+    }
+
+    /**
+     * 获取sendQuery方法无参拦截器
+     *
+     * @return InterceptDeclarer sendQuery方法无参拦截器
+     */
+    public static InterceptDeclarer getSendQueryInterceptDeclarer() {
+        return InterceptDeclarer.build(getSendQueryMethodMatcher(),
+                new SendQueryInterceptor());
+    }
+
+    /**
+     * 获取sendQuery方法有参拦截器
+     *
+     * @param handler 数据库自定义处理器
+     * @return InterceptDeclarer sendQuery方法有参拦截器
+     */
+    public static InterceptDeclarer getSendQueryInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getSendQueryMethodMatcher(),
+                new SendQueryInterceptor(handler));
+    }
+
+    private static MethodMatcher getSendQueryMethodMatcher() {
+        return MethodMatcher.nameEquals(SEND_QUERY_METHOD_NAME);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/resources/META-INF/services/com.huaweicloud.sermant.core.plugin.agent.declarer.PluginDeclarer
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.huaweicloud.sermant.mariadbv3.declarers.ReplayClientDeclarer
+com.huaweicloud.sermant.mariadbv3.declarers.StandardClientDeclarer

--- a/sermant-plugins/sermant-database-write-prohibition/pom.xml
+++ b/sermant-plugins/sermant-database-write-prohibition/pom.xml
@@ -29,6 +29,8 @@
                 <module>database-controller</module>
                 <module>database-config-service</module>
                 <module>mongodb-3.x-4.x-plugin</module>
+                <module>mysql-mariadb-2.x-plugin</module>
+                <module>mysql-mariadb-3.x-plugin</module>
             </modules>
         </profile>
         <profile>
@@ -37,6 +39,8 @@
                 <module>database-controller</module>
                 <module>database-config-service</module>
                 <module>mongodb-3.x-4.x-plugin</module>
+                <module>mysql-mariadb-2.x-plugin</module>
+                <module>mysql-mariadb-3.x-plugin</module>
             </modules>
         </profile>
         <profile>
@@ -45,6 +49,8 @@
                 <module>database-controller</module>
                 <module>database-config-service</module>
                 <module>mongodb-3.x-4.x-plugin</module>
+                <module>mysql-mariadb-2.x-plugin</module>
+                <module>mysql-mariadb-3.x-plugin</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
【Fix issue】#1422

【Modified content】
1. Added mysql database write prohibition module
2. Modified the parameters passed to the handler and added a database instance

[Use case description] Not required

[Self-test situation] 1. Local static check passed

[Scope of Impact] Subsequent supplementary documentation on the use of the database write prohibition plug-in