### PR TITLE
Fix bug of Mysql database write prohibition plugin test.

### DIFF
--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/declarers/StandardClientDeclarer.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/declarers/StandardClientDeclarer.java
@@ -35,8 +35,9 @@ public class StandardClientDeclarer extends AbstractPluginDeclarer {
 
     @Override
     public InterceptDeclarer[] getInterceptDeclarers(ClassLoader classLoader) {
-        return new InterceptDeclarer[] {
-                MariadbV3EnhancementHelper.getSendQueryInterceptDeclarer()
+        return new InterceptDeclarer[]{
+                MariadbV3EnhancementHelper.getSendQueryInterceptDeclarer(),
+                MariadbV3EnhancementHelper.getExecutePipelineInterceptDeclarer()
         };
     }
 }

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/interceptors/AbstractMariadbV3Interceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/interceptors/AbstractMariadbV3Interceptor.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.mariadbv3.interceptors;
+
+import com.huaweicloud.sermant.core.common.LoggerFactory;
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.constant.DatabaseType;
+import com.huaweicloud.sermant.database.entity.DatabaseInfo;
+import com.huaweicloud.sermant.database.interceptor.AbstractDatabaseInterceptor;
+
+import org.mariadb.jdbc.HostAddress;
+import org.mariadb.jdbc.client.impl.StandardClient;
+
+import java.util.logging.Logger;
+
+/**
+ * Abstract Interceptor of Mariadb3.X
+ *
+ * @author daizhenyu
+ * @since 2024-01-30
+ **/
+public abstract class AbstractMariadbV3Interceptor extends AbstractDatabaseInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger();
+
+    @Override
+    protected void createAndCacheDatabaseInfo(ExecuteContext context) {
+        DatabaseInfo info = new DatabaseInfo(DatabaseType.MYSQL);
+        context.setLocalFieldValue(DATABASE_INFO, info);
+        StandardClient client = (StandardClient) context.getObject();
+        if (client.getContext() != null) {
+            info.setDatabaseName(client.getContext().getDatabase());
+        } else {
+            LOGGER.warning("Failed to obtain database name.");
+        }
+        HostAddress hostAddress = client.getHostAddress();
+        info.setHostAddress(hostAddress.host);
+        info.setPort(hostAddress.port);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/interceptors/ExecutePipelineInterceptor.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/interceptors/ExecutePipelineInterceptor.java
@@ -25,34 +25,39 @@ import com.huaweicloud.sermant.database.utils.SqlParserUtils;
 import org.mariadb.jdbc.message.ClientMessage;
 
 /**
- * sendQuery方法拦截器
+ * executePipeline Method Interceptor
  *
  * @author daizhenyu
  * @since 2024-01-30
  **/
-public class SendQueryInterceptor extends AbstractMariadbV3Interceptor {
+public class ExecutePipelineInterceptor extends AbstractMariadbV3Interceptor {
     /**
-     * 无参构造方法
+     * No-argument constructor
      */
-    public SendQueryInterceptor() {
+    public ExecutePipelineInterceptor() {
     }
 
     /**
-     * 有参构造方法
+     * Parametric constructor
      *
-     * @param handler 写操作处理器
+     * @param handler write operation handler
      */
-    public SendQueryInterceptor(DatabaseHandler handler) {
+    public ExecutePipelineInterceptor(DatabaseHandler handler) {
         this.handler = handler;
     }
 
     @Override
     protected ExecuteContext doBefore(ExecuteContext context) {
-        ClientMessage clientMessage = (ClientMessage) context.getArguments()[0];
         String database = getDataBaseInfo(context).getDatabaseName();
-        if (SqlParserUtils.isWriteOperation(clientMessage.description())
-                && DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().contains(database)) {
-            DatabaseController.disableDatabaseWriteOperation(database, context);
+        if (!DatabaseWriteProhibitionManager.getMySqlProhibitionDatabases().contains(database)) {
+            return context;
+        }
+        ClientMessage[] clientMessages = (ClientMessage[]) context.getArguments()[0];
+        for (ClientMessage clientMessage : clientMessages) {
+            if (SqlParserUtils.isWriteOperation(clientMessage.description())) {
+                DatabaseController.disableDatabaseWriteOperation(database, context);
+                return context;
+            }
         }
         return context;
     }

--- a/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/utils/MariadbV3EnhancementHelper.java
+++ b/sermant-plugins/sermant-database-write-prohibition/mysql-mariadb-3.x-plugin/src/main/java/com/huaweicloud/sermant/mariadbv3/utils/MariadbV3EnhancementHelper.java
@@ -20,10 +20,11 @@ import com.huaweicloud.sermant.core.plugin.agent.declarer.InterceptDeclarer;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.ClassMatcher;
 import com.huaweicloud.sermant.core.plugin.agent.matcher.MethodMatcher;
 import com.huaweicloud.sermant.database.handler.DatabaseHandler;
+import com.huaweicloud.sermant.mariadbv3.interceptors.ExecutePipelineInterceptor;
 import com.huaweicloud.sermant.mariadbv3.interceptors.SendQueryInterceptor;
 
 /**
- * mariadb3.x拦截点辅助类
+ * mariadb3.x declarer helper
  *
  * @author daizhenyu
  * @since 2024-01-30
@@ -35,31 +36,33 @@ public class MariadbV3EnhancementHelper {
 
     private static final String SEND_QUERY_METHOD_NAME = "sendQuery";
 
+    private static final String EXECUTE_PIPELINE_METHOD_NAME = "executePipeline";
+
     private MariadbV3EnhancementHelper() {
     }
 
     /**
-     * 获取ReplayClient类的ClassMatcher
+     * Get ClassMatcher of ReplayClient
      *
-     * @return ClassMatcher 类匹配器
+     * @return ClassMatcher ClassMatcher
      */
     public static ClassMatcher getReplayClientClassMatcher() {
         return ClassMatcher.nameEquals(REPLAY_CLIENT_CLASS);
     }
 
     /**
-     * 获取StandardClient类的ClassMatcher
+     * Get ClassMatcher of StandardClient
      *
-     * @return ClassMatcher 类匹配器
+     * @return ClassMatcher ClassMatcher
      */
     public static ClassMatcher getStandardClientClassMatcher() {
         return ClassMatcher.nameEquals(STANDARD_CLIENT_CLASS);
     }
 
     /**
-     * 获取sendQuery方法无参拦截器
+     * Get No-argument Interceptor of sendQuery Method
      *
-     * @return InterceptDeclarer sendQuery方法无参拦截器
+     * @return InterceptDeclarer No-argument Interceptor of sendQuery Method
      */
     public static InterceptDeclarer getSendQueryInterceptDeclarer() {
         return InterceptDeclarer.build(getSendQueryMethodMatcher(),
@@ -67,17 +70,42 @@ public class MariadbV3EnhancementHelper {
     }
 
     /**
-     * 获取sendQuery方法有参拦截器
+     * Get Parametric Interceptor of sendQuery Method
      *
-     * @param handler 数据库自定义处理器
-     * @return InterceptDeclarer sendQuery方法有参拦截器
+     * @param handler write operation handler
+     * @return InterceptDeclarer Parametric Interceptor of sendQuery Method
      */
     public static InterceptDeclarer getSendQueryInterceptDeclarer(DatabaseHandler handler) {
         return InterceptDeclarer.build(getSendQueryMethodMatcher(),
                 new SendQueryInterceptor(handler));
     }
 
+    /**
+     * Get No-argument Interceptor of executePipeline Method
+     *
+     * @return InterceptDeclarer No-argument Interceptor of executePipeline Method
+     */
+    public static InterceptDeclarer getExecutePipelineInterceptDeclarer() {
+        return InterceptDeclarer.build(getExecutePipelineMethodMatcher(),
+                new ExecutePipelineInterceptor());
+    }
+
+    /**
+     * Get Parametric Interceptor of executePipeline Method
+     *
+     * @param handler write operation handler
+     * @return InterceptDeclarer Parametric Interceptor of executePipeline Method
+     */
+    public static InterceptDeclarer getExecutePipelineInterceptDeclarer(DatabaseHandler handler) {
+        return InterceptDeclarer.build(getExecutePipelineMethodMatcher(),
+                new ExecutePipelineInterceptor(handler));
+    }
+
     private static MethodMatcher getSendQueryMethodMatcher() {
         return MethodMatcher.nameEquals(SEND_QUERY_METHOD_NAME);
+    }
+
+    private static MethodMatcher getExecutePipelineMethodMatcher() {
+        return MethodMatcher.nameEquals(EXECUTE_PIPELINE_METHOD_NAME);
     }
 }


### PR DESCRIPTION
【Issue】#1448

【Content】Fix  executePipeline method of StandardClient does not throw SQLException with mariadb-java-client3.x

【Case Description】No need

【Self-Test Result】1、The local static check is passed.

【Scope of Influence】Follow-up supplementary documents