### PR TITLE
Add UT for Postgresql and OpenGauss.

### DIFF
--- a/sermant-plugins/sermant-database-write-prohibition/opengauss-3.0.x-plugin/src/test/java/com/huaweicloud/sermant/opengaussv30/interceptors/QueryExecutorImplInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/opengauss-3.0.x-plugin/src/test/java/com/huaweicloud/sermant/opengaussv30/interceptors/QueryExecutorImplInterceptorTest.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.opengaussv30.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opengauss.core.NativeQuery;
+import org.opengauss.core.Query;
+import org.opengauss.core.v3.BatchedQuery;
+import org.opengauss.core.v3.QueryExecutorImpl;
+import org.opengauss.util.HostSpec;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test class for executing SQL operation interceptor QueryExecutorImplInterceptor
+ *
+ * @author zhp
+ * @since 2024-02-04
+ **/
+public class QueryExecutorImplInterceptorTest {
+    private static final DatabaseWriteProhibitionConfig GLOBAL_CONFIG = new DatabaseWriteProhibitionConfig();
+
+    private static Method methodMock;
+
+    private static Object[] argument;
+
+    private static QueryExecutorImpl queryExecutor;
+
+    private static final String WRITE_SQL =
+            "INSERT INTO `test`.`students` (`id`, `name`, `age`) VALUES (19, 'lilei', 111)";
+
+    private static final String READ_SQL = "SELECT * FROM students WHERE id = 19";
+
+    private final QueryExecutorImplInterceptor queryExecutorImplInterceptor = new QueryExecutorImplInterceptor();
+
+    @BeforeClass
+    public static void setUp() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(GLOBAL_CONFIG);
+        methodMock = Mockito.mock(Method.class);
+        queryExecutor = Mockito.mock(QueryExecutorImpl.class);
+        Mockito.when(queryExecutor.getDatabase()).thenReturn("database-test");
+        HostSpec hostSpec = new HostSpec("127.0.0.1", 8080);
+        Mockito.when(queryExecutor.getHostSpec()).thenReturn(hostSpec);
+        NativeQuery nativeQuery = new NativeQuery(WRITE_SQL, null);
+        Query query = new BatchedQuery(nativeQuery, null, 0, 0, false);
+        argument = new Object[]{query, null, null, null, null, null, null};
+    }
+
+    @Test
+    public void testDoBefore() throws Exception {
+        // Database write prohibition switch turned off
+        GLOBAL_CONFIG.setEnableOpenGaussWriteProhibition(false);
+        ExecuteContext context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned off, and the write prohibition database set contains the
+         * intercepted database
+         */
+        Set<String> databases = new HashSet<>();
+        databases.add("database-test");
+        GLOBAL_CONFIG.setOpenGaussDatabases(databases);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection contains
+         * the intercepted databases
+         */
+        GLOBAL_CONFIG.setEnableOpenGaussWriteProhibition(true);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection contains
+         * the intercepted database. SQL does not perform write operations
+         */
+        Query readQuery = new BatchedQuery(new NativeQuery(READ_SQL, null),
+                null, 0, 0, false);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock,
+                new Object[]{readQuery, null, null, null, null, null, null}, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection does not
+         * contain the intercepted database
+         */
+        GLOBAL_CONFIG.setOpenGaussDatabases(new HashSet<>());
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+        DatabaseWriteProhibitionManager.updateGlobalConfig(null);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/opengauss-3.1.x-plugin/src/test/java/com/huaweicloud/sermant/opengaussv31/interceptors/QueryExecutorImplInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/opengauss-3.1.x-plugin/src/test/java/com/huaweicloud/sermant/opengaussv31/interceptors/QueryExecutorImplInterceptorTest.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.opengaussv31.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.postgresql.core.NativeQuery;
+import org.postgresql.core.Query;
+import org.postgresql.core.v3.BatchedQuery;
+import org.postgresql.core.v3.QueryExecutorImpl;
+import org.postgresql.util.HostSpec;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test class for executing SQL operation interceptor QueryExecutorImplInterceptor
+ *
+ * @author zhp
+ * @since 2024-02-04
+ **/
+public class QueryExecutorImplInterceptorTest {
+    private static final DatabaseWriteProhibitionConfig GLOBAL_CONFIG = new DatabaseWriteProhibitionConfig();
+
+    private static Method methodMock;
+
+    private static Object[] argument;
+
+    private static QueryExecutorImpl queryExecutor;
+
+    private static final String WRITE_SQL =
+            "INSERT INTO `test`.`students` (`id`, `name`, `age`) VALUES (19, 'lilei', 111)";
+
+    private static final String READ_SQL = "SELECT * FROM students WHERE id = 19";
+
+    private final QueryExecutorImplInterceptor queryExecutorImplInterceptor = new QueryExecutorImplInterceptor();
+
+    @BeforeClass
+    public static void setUp() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(GLOBAL_CONFIG);
+        methodMock = Mockito.mock(Method.class);
+        queryExecutor = Mockito.mock(QueryExecutorImpl.class);
+        Mockito.when(queryExecutor.getDatabase()).thenReturn("database-test");
+        HostSpec hostSpec = new HostSpec("127.0.0.1", 8080);
+        Mockito.when(queryExecutor.getHostSpec()).thenReturn(hostSpec);
+        NativeQuery nativeQuery = new NativeQuery(WRITE_SQL, null);
+        Query query = new BatchedQuery(nativeQuery, null, 0, 0, false);
+        argument = new Object[]{query, null, null, null, null, null, null};
+    }
+
+    @Test
+    public void testDoBefore() throws Exception {
+        // Database write prohibition switch turned off
+        GLOBAL_CONFIG.setEnableOpenGaussWriteProhibition(false);
+        ExecuteContext context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned off, and the write intercepted database set contains the
+         * intercepted database
+         */
+        Set<String> databases = new HashSet<>();
+        databases.add("database-test");
+        GLOBAL_CONFIG.setOpenGaussDatabases(databases);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write intercepted database collection contains
+         * the intercepted databases
+         */
+        GLOBAL_CONFIG.setEnableOpenGaussWriteProhibition(true);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection contains
+         * the intercepted database. SQL does not perform write operations
+         */
+        Query readQuery = new BatchedQuery(new NativeQuery(READ_SQL, null),
+                null, 0, 0, false);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock,
+                new Object[]{readQuery, null, null, null, null, null, null}, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection does not
+         * contain the intercepted database
+         */
+        GLOBAL_CONFIG.setOpenGaussDatabases(new HashSet<>());
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+        DatabaseWriteProhibitionManager.updateGlobalConfig(null);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/postgresql-42.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv42/interceptors/QueryExecutorImplInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/postgresql-42.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv42/interceptors/QueryExecutorImplInterceptorTest.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.postgresqlv42.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.postgresql.core.NativeQuery;
+import org.postgresql.core.Query;
+import org.postgresql.core.v3.BatchedQuery;
+import org.postgresql.core.v3.QueryExecutorImpl;
+import org.postgresql.util.HostSpec;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test class for interceptors executing SQL operations
+ *
+ * @author zhp
+ * @since 2024-02-04
+ **/
+public class QueryExecutorImplInterceptorTest {
+    private static final DatabaseWriteProhibitionConfig GLOBAL_CONFIG = new DatabaseWriteProhibitionConfig();
+
+    private static Method methodMock;
+
+    private static Object[] argument;
+
+    private static QueryExecutorImpl queryExecutor;
+
+    private static final String WRITE_SQL =
+            "INSERT INTO `test`.`students` (`id`, `name`, `age`) VALUES (19, 'lilei', 111)";
+
+    private static final String READ_SQL = "SELECT * FROM students WHERE id = 19";
+
+    private final QueryExecutorImplInterceptor queryExecutorImplInterceptor = new QueryExecutorImplInterceptor();
+
+    @BeforeClass
+    public static void setUp() {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(GLOBAL_CONFIG);
+        methodMock = Mockito.mock(Method.class);
+        queryExecutor = Mockito.mock(QueryExecutorImpl.class);
+        Mockito.when(queryExecutor.getDatabase()).thenReturn("database-test");
+        HostSpec hostSpec = new HostSpec("127.0.0.1", 8080);
+        Mockito.when(queryExecutor.getHostSpec()).thenReturn(hostSpec);
+        NativeQuery nativeQuery = new NativeQuery(WRITE_SQL, null);
+        Query query = new BatchedQuery(nativeQuery, null, 0, 0, false);
+        argument = new Object[]{query, null, null, null, null, null, null};
+    }
+
+    @Test
+    public void testDoBefore() throws Exception {
+        // Database write prohibition switch turned off
+        GLOBAL_CONFIG.setEnablePostgreSqlWriteProhibition(false);
+        ExecuteContext context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned off, and the write prohibition database set contains the
+         * intercepted database
+         */
+        Set<String> databases = new HashSet<>();
+        databases.add("database-test");
+        GLOBAL_CONFIG.setPostgreSqlDatabases(databases);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection contains
+         * the intercepted databases
+         */
+        GLOBAL_CONFIG.setEnablePostgreSqlWriteProhibition(true);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection contains
+         * the intercepted database. SQL does not perform write operations
+         */
+        Query readQuery = new BatchedQuery(new NativeQuery(READ_SQL, null),
+                null, 0, 0, false);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock,
+                new Object[]{readQuery, null, null, null, null, null, null}, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection does not
+         * contain the intercepted database
+         */
+        GLOBAL_CONFIG.setPostgreSqlDatabases(new HashSet<>());
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Mockito.clearAllCaches();
+        DatabaseWriteProhibitionManager.updateGlobalConfig(null);
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/postgresql-9.4.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv9/interceptors/Jdbc4StatementInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/postgresql-9.4.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv9/interceptors/Jdbc4StatementInterceptorTest.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.postgresqlv9.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.postgresqlv9.utils.ThreadConnectionUtil;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.jdbc3g.AbstractJdbc3gStatement;
+import org.postgresql.jdbc4.Jdbc4Connection;
+import org.postgresql.jdbc4.Jdbc4DatabaseMetaData;
+
+import java.lang.reflect.Method;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+/**
+ * Statement interceptor test class for executing SQL operations
+ *
+ * @author zhp
+ * @since 2024-02-04
+ **/
+public class Jdbc4StatementInterceptorTest {
+    private static final DatabaseWriteProhibitionConfig GLOBAL_CONFIG = new DatabaseWriteProhibitionConfig();
+
+    private static Method methodMock;
+
+    private static AbstractJdbc3gStatement abstractJdbc3gStatement;
+
+    private static BaseConnection connection;
+
+    private final Jdbc4StatementInterceptor jdbc4StatementInterceptor = new Jdbc4StatementInterceptor();
+
+    @BeforeClass
+    public static void setUp() throws SQLException {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(GLOBAL_CONFIG);
+        methodMock = Mockito.mock(Method.class);
+        abstractJdbc3gStatement = Mockito.mock(AbstractJdbc3gStatement.class);
+        DatabaseMetaData metaData = Mockito.mock(Jdbc4DatabaseMetaData.class);
+        connection = Mockito.mock(Jdbc4Connection.class);
+        Mockito.when(connection.getMetaData()).thenReturn(metaData);
+        Mockito.when(abstractJdbc3gStatement.getPGConnection()).thenReturn(connection);
+    }
+
+    @Test
+    public void testDoBefore() throws Exception {
+        ExecuteContext context = ExecuteContext.forMemberMethod(abstractJdbc3gStatement, methodMock,
+                null, null, null);
+        jdbc4StatementInterceptor.before(context);
+        Assert.assertNotNull(ThreadConnectionUtil.getConnection());
+    }
+
+    @AfterClass
+    public static void tearDown() throws SQLException {
+        connection.close();
+        Mockito.clearAllCaches();
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/postgresql-9.4.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv9/interceptors/PostSqlQuery.java
+++ b/sermant-plugins/sermant-database-write-prohibition/postgresql-9.4.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv9/interceptors/PostSqlQuery.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.postgresqlv9.interceptors;
+
+import org.postgresql.core.ParameterList;
+import org.postgresql.core.Query;
+
+/**
+ * Database SQL Query Implementation
+ *
+ * @author zhp
+ * @since 2024-02-17
+ **/
+public class PostSqlQuery implements Query {
+    private final String sql;
+
+    public PostSqlQuery(String sql) {
+        this.sql = sql;
+    }
+
+    @Override
+    public ParameterList createParameterList() {
+        return null;
+    }
+
+    @Override
+    public String toString(ParameterList parameters) {
+        return sql;
+    }
+
+    @Override
+    public void close() {
+        // Test data write prohibition, no specific shutdown function required
+    }
+
+    @Override
+    public boolean isStatementDescribed() {
+        return false;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return sql;
+    }
+}

--- a/sermant-plugins/sermant-database-write-prohibition/postgresql-9.4.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv9/interceptors/QueryExecutorImplInterceptorTest.java
+++ b/sermant-plugins/sermant-database-write-prohibition/postgresql-9.4.x-plugin/src/test/java/com/huaweicloud/sermant/postgresqlv9/interceptors/QueryExecutorImplInterceptorTest.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (C) 2024-2024 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.huaweicloud.sermant.postgresqlv9.interceptors;
+
+import com.huaweicloud.sermant.core.plugin.agent.entity.ExecuteContext;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionConfig;
+import com.huaweicloud.sermant.database.config.DatabaseWriteProhibitionManager;
+import com.huaweicloud.sermant.postgresqlv9.utils.ThreadConnectionUtil;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.postgresql.core.Query;
+import org.postgresql.core.v3.QueryExecutorImpl;
+import org.postgresql.jdbc4.Jdbc4Connection;
+import org.postgresql.jdbc4.Jdbc4DatabaseMetaData;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test class for interceptors executing SQL operations
+ *
+ * @author zhp
+ * @since 2024-02-04
+ **/
+public class QueryExecutorImplInterceptorTest {
+    private static final DatabaseWriteProhibitionConfig GLOBAL_CONFIG = new DatabaseWriteProhibitionConfig();
+
+    private static Method methodMock;
+
+    private static Object[] argument;
+
+    private static QueryExecutorImpl queryExecutor;
+
+    private static Connection connection;
+
+    private static final String URL = "jdbc:postgresql://localhost:5432/database-test?useUnicode=true&useSSL=false"
+            + "&characterEncoding=utf8&serverTimezone=GMT%2B8&allowPublicKeyRetrieval=true";
+
+    private static final String WRITE_SQL =
+            "INSERT INTO `test`.`students` (`id`, `name`, `age`) VALUES (19, 'lilei', 111)";
+
+    private static final String READ_SQL = "SELECT * FROM students WHERE id = 19";
+
+    private final QueryExecutorImplInterceptor queryExecutorImplInterceptor = new QueryExecutorImplInterceptor();
+
+    @BeforeClass
+    public static void setUp() throws SQLException {
+        DatabaseWriteProhibitionManager.updateGlobalConfig(GLOBAL_CONFIG);
+        methodMock = Mockito.mock(Method.class);
+        queryExecutor = Mockito.mock(QueryExecutorImpl.class);
+        DatabaseMetaData metaData = Mockito.mock(Jdbc4DatabaseMetaData.class);
+        connection = Mockito.mock(Jdbc4Connection.class);
+        ThreadConnectionUtil.setConnection(connection);
+        Mockito.when(metaData.getURL()).thenReturn(URL);
+        Mockito.when(connection.getMetaData()).thenReturn(metaData);
+        Query query = new PostSqlQuery(WRITE_SQL);
+        argument = new Object[]{query, null, null, null, null, null, null};
+    }
+
+    @Test
+    public void testDoBefore() throws Exception {
+        // Database write prohibition switch turned off
+        GLOBAL_CONFIG.setEnablePostgreSqlWriteProhibition(false);
+        ExecuteContext context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned off, and the write prohibition database set contains the
+         * intercepted database
+         */
+        Set<String> databases = new HashSet<>();
+        databases.add("database-test");
+        GLOBAL_CONFIG.setPostgreSqlDatabases(databases);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection contains
+         * the intercepted databases
+         */
+        GLOBAL_CONFIG.setEnablePostgreSqlWriteProhibition(true);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertEquals("Database prohibit to write, database: database-test",
+                context.getThrowableOut().getMessage());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection contains
+         * the intercepted database. SQL does not perform write operations
+         */
+        Query readQuery = new PostSqlQuery(READ_SQL);
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock,
+                new Object[]{readQuery, null, null, null, null, null, null}, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+
+        /*
+         * The database write prohibition switch is turned on, and the write prohibition database collection does not
+         * contain the intercepted database
+         */
+        GLOBAL_CONFIG.setPostgreSqlDatabases(new HashSet<>());
+        context = ExecuteContext.forMemberMethod(queryExecutor, methodMock, argument, null, null);
+        queryExecutorImplInterceptor.before(context);
+        Assert.assertNull(context.getThrowableOut());
+    }
+
+    @AfterClass
+    public static void tearDown() throws SQLException {
+        connection.close();
+        Mockito.clearAllCaches();
+        DatabaseWriteProhibitionManager.updateGlobalConfig(null);
+    }
+}


### PR DESCRIPTION
【Fix issue】#1450

[Modification content] 1. Add UT for Postgresql and OpenGauss

[Use case description] 1. No need, no functional code changes

[Self-test status] 1. Local static inspection and cleaning status; 2. Self-test passed

[Scope of influence] 1. No impact on users’ use