### PR TITLE
fix issue of plugin config reload dynamically failure

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/config/ConfigManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/config/ConfigManager.java
@@ -148,7 +148,7 @@ public abstract class ConfigManager {
             final String typeKey = ConfigKeyUtil.getTypeKey(config.getClass());
             final BaseConfig retainedConfig = CONFIG_MAP.get(typeKey);
             if (retainedConfig == null) {
-                CONFIG_MAP.put(typeKey, doLoad(configFile, config));
+                CONFIG_MAP.put(typeKey, doLoad(configFile, config, false));
             } else if (retainedConfig.getClass() == config.getClass()) {
                 LOGGER.fine(String.format(Locale.ROOT, "Skip load config [%s] repeatedly. ",
                         config.getClass().getName()));
@@ -164,14 +164,15 @@ public abstract class ConfigManager {
      *
      * @param configFile configuration file
      * @param baseConfig base config
+     * @param isDynamic is the config loaded dynamically
      * @return The configuration object after loading
      */
-    public static BaseConfig doLoad(File configFile, BaseConfig baseConfig) {
+    public static BaseConfig doLoad(File configFile, BaseConfig baseConfig, boolean isDynamic) {
         // Obtain configuration loading strategy using the FrameworkClassLoader
         final LoadConfigStrategy<?> loadConfigStrategy = getLoadConfigStrategy(configFile,
                 ClassLoaderManager.getFrameworkClassLoader());
         final Object holder = loadConfigStrategy.getConfigHolder(configFile, argsMap);
-        return ((LoadConfigStrategy) loadConfigStrategy).loadConfig(holder, baseConfig);
+        return ((LoadConfigStrategy) loadConfigStrategy).loadConfig(holder, baseConfig, isDynamic);
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/config/strategy/LoadConfigStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/config/strategy/LoadConfigStrategy.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
  * <p>Loading configuration information consists of two steps:
  * <pre>
  *     1.Load the configuration file as configuration information{@link #getConfigHolder(File, Map)}
- *     2.Load the configuration information into the configuration object{@link #loadConfig(Object, BaseConfig)}
+ *     2.Load the configuration information into the configuration object{@link #loadConfig(Object, BaseConfig,boolean)}
  * </pre>
  *
  * @param <T> configuration type
@@ -67,14 +67,15 @@ public interface LoadConfigStrategy<T> {
     T getConfigHolder(File config, Map<String, Object> argsMap);
 
     /**
-     * 加载配置，将配置信息主要承载对象中的配置信息加载到配置对象中
+     * Loading configuration: Loads the configuration information of the main carrier object to the configuration object
      *
-     * @param holder 配置信息主要承载对象
-     * @param config 配置对象
-     * @param <R>    配置对象类型
-     * @return 配置对象
+     * @param holder configuration holder
+     * @param config configuration object
+     * @param <R>    configuration class type
+     * @param isDynamic is the config loaded dynamically
+     * @return configuration object after processing
      */
-    <R extends BaseConfig> R loadConfig(T holder, R config);
+    <R extends BaseConfig> R loadConfig(T holder, R config, boolean isDynamic);
 
     /**
      * default {@link LoadConfigStrategy}, do not perform any logical operations
@@ -100,7 +101,7 @@ public interface LoadConfigStrategy<T> {
         }
 
         @Override
-        public <R extends BaseConfig> R loadConfig(Object holder, R config) {
+        public <R extends BaseConfig> R loadConfig(Object holder, R config, boolean isDynamic) {
             LOGGER.log(Level.WARNING, String.format(Locale.ROOT, "[%s] will do nothing when loading config. ",
                     DefaultLoadConfigStrategy.class.getName()));
             return config;

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/plugin/config/PluginConfigManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/plugin/config/PluginConfigManager.java
@@ -67,7 +67,8 @@ public class PluginConfigManager {
             final BaseConfig retainedConfig = PLUGIN_CONFIG_MAP.get(pluginConfigKey);
             if (pluginConfigFile.exists() && pluginConfigFile.isFile()) {
                 if (retainedConfig == null) {
-                    PLUGIN_CONFIG_MAP.put(pluginConfigKey, ConfigManager.doLoad(pluginConfigFile, config));
+                    PLUGIN_CONFIG_MAP.put(pluginConfigKey,
+                            ConfigManager.doLoad(pluginConfigFile, config, plugin.isDynamic()));
                     plugin.getConfigs().add(pluginConfigKey);
                 } else if (retainedConfig.getClass() == pluginConfigCls) {
                     LOGGER.fine(String.format(Locale.ROOT, "Skip load config [%s] repeatedly. ",
@@ -120,6 +121,7 @@ public class PluginConfigManager {
      * @return plugin configuration file
      */
     public static File getPluginConfigFile(String pluginPath) {
-        return new File(pluginPath + File.separatorChar + PluginConstant.CONFIG_DIR_NAME + File.separatorChar + PluginConstant.CONFIG_FILE_NAME);
+        return new File(pluginPath + File.separatorChar + PluginConstant.CONFIG_DIR_NAME + File.separatorChar
+                + PluginConstant.CONFIG_FILE_NAME);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/config/LoadPropertiesStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/config/LoadPropertiesStrategy.java
@@ -110,7 +110,7 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
      * @return Configure object generics
      */
     @Override
-    public <R extends BaseConfig> R loadConfig(Properties holder, R config) {
+    public <R extends BaseConfig> R loadConfig(Properties holder, R config, boolean isDynamic) {
         return loadConfig(holder, config.getClass(), config);
     }
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/config/LoadYamlStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/config/LoadYamlStrategy.java
@@ -86,13 +86,16 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
      */
     private Map<String, Object> argsMap;
 
+    private final SermantYamlConstructor constructor;
+
     /**
      * Constructor
      */
     public LoadYamlStrategy() {
         Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(true);
-        this.yaml = new Yaml(representer);
+        this.constructor = new SermantYamlConstructor();
+        this.yaml = new Yaml(constructor, representer);
     }
 
     @Override
@@ -108,7 +111,7 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
     }
 
     @Override
-    public <R extends BaseConfig> R loadConfig(Map holder, R config) {
+    public <R extends BaseConfig> R loadConfig(Map holder, R config, boolean isDynamic) {
         final Class<R> cls = (Class<R>) config.getClass();
         final String typeKey = ConfigKeyUtil.getTypeKey(cls);
         final Object typeVal = holder.get(typeKey);
@@ -125,13 +128,11 @@ public class LoadYamlStrategy implements LoadConfigStrategy<Map> {
                 configMap.put(field.getName(), null);
             }
         }
-        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        try {
-            Thread.currentThread().setContextClassLoader(cls.getClassLoader());
-            return (R) yaml.loadAs(yaml.dump(fixEntry(configMap, cls)), cls);
-        } finally {
-            Thread.currentThread().setContextClassLoader(classLoader);
+        constructor.setLoader(cls.getClassLoader());
+        if (isDynamic) {
+            constructor.clearCache();
         }
+        return (R) yaml.loadAs(yaml.dump(fixEntry(configMap, cls)), cls);
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/config/SermantYamlConstructor.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/config/SermantYamlConstructor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024-2024 Sermant Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sermant.implement.config;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+/**
+ * Yaml constructor for sermant config load
+ *
+ * @author lilai
+ * @since 2024-05-22
+ */
+public class SermantYamlConstructor extends Constructor {
+    private ClassLoader loader;
+
+    /**
+     * constructor
+     */
+    public SermantYamlConstructor() {
+        super(Object.class, new LoaderOptions());
+        loader = Thread.currentThread().getContextClassLoader();
+    }
+
+    /**
+     * Load class with specific classLoader
+     *
+     * @param name class name
+     * @return created class
+     * @throws ClassNotFoundException class not found
+     */
+    @Override
+    protected Class<?> getClassForName(String name) throws ClassNotFoundException {
+        return Class.forName(name, true, loader);
+    }
+
+    /**
+     * set classLoader
+     *
+     * @param classLoader the classLoader for config object
+     * @throws NullPointerException no classloader is provided
+     */
+    public void setLoader(ClassLoader classLoader) {
+        if (classLoader == null) {
+            throw new NullPointerException("classLoader must be provided.");
+        }
+        this.loader = classLoader;
+    }
+
+    /**
+     * clear snakeyaml class cache
+     */
+    public void clearCache() {
+        typeTags.clear();
+    }
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

Add a custom yaml constructor for snakeyaml to make the same plugin config string can be loaded by new pluginclassloader rather than old pluginclassloader when install a plugin at the second time

**Which issue(s) this PR fixes？**

Fixes #1520

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
