### PR TITLE
[1.4.x] fix issue of plugin config reload dynamically failure

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/ConfigManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/ConfigManager.java
@@ -143,7 +143,7 @@ public abstract class ConfigManager {
             final String typeKey = ConfigKeyUtil.getTypeKey(config.getClass());
             final BaseConfig retainedConfig = CONFIG_MAP.get(typeKey);
             if (retainedConfig == null) {
-                CONFIG_MAP.put(typeKey, doLoad(configFile, config));
+                CONFIG_MAP.put(typeKey, doLoad(configFile, config, false));
             } else if (retainedConfig.getClass() == config.getClass()) {
                 LOGGER.fine(String.format(Locale.ROOT, "Skip load config [%s] repeatedly. ",
                         config.getClass().getName()));
@@ -159,14 +159,15 @@ public abstract class ConfigManager {
      *
      * @param configFile 配置文件
      * @param baseConfig 配置类
+     * @param isDynamic is the config loaded dynamically
      * @return 加载后的配置类
      */
-    public static BaseConfig doLoad(File configFile, BaseConfig baseConfig) {
+    public static BaseConfig doLoad(File configFile, BaseConfig baseConfig, boolean isDynamic) {
         // 通过FrameworkClassLoader 获取配置加载策略
         final LoadConfigStrategy<?> loadConfigStrategy = getLoadConfigStrategy(configFile,
                 ClassLoaderManager.getFrameworkClassLoader());
         final Object holder = loadConfigStrategy.getConfigHolder(configFile, argsMap);
-        return ((LoadConfigStrategy) loadConfigStrategy).loadConfig(holder, baseConfig);
+        return ((LoadConfigStrategy) loadConfigStrategy).loadConfig(holder, baseConfig, isDynamic);
     }
 
     /**

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/strategy/LoadConfigStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/config/strategy/LoadConfigStrategy.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
  * <p>加载配置信息主要分两步：
  * <pre>
  *     1.加载配置文件为配置信息{@link #getConfigHolder(File, Map)}
- *     2.将配置信息加载到配置对象中{@link #loadConfig(Object, BaseConfig)}
+ *     2.将配置信息加载到配置对象中{@link #loadConfig(Object, BaseConfig, boolean)}
  * </pre>
  *
  * @param <T> 配置主体
@@ -70,9 +70,10 @@ public interface LoadConfigStrategy<T> {
      * @param holder 配置信息主要承载对象
      * @param config 配置对象
      * @param <R>    配置对象类型
+     * @param isDynamic is the config loaded dynamically
      * @return 配置对象
      */
-    <R extends BaseConfig> R loadConfig(T holder, R config);
+    <R extends BaseConfig> R loadConfig(T holder, R config, boolean isDynamic);
 
     /**
      * 默认的{@link LoadConfigStrategy}，不做任何逻辑操作
@@ -96,7 +97,7 @@ public interface LoadConfigStrategy<T> {
         }
 
         @Override
-        public <R extends BaseConfig> R loadConfig(Object holder, R config) {
+        public <R extends BaseConfig> R loadConfig(Object holder, R config, boolean isDynamic) {
             LOGGER.log(Level.WARNING, String.format(Locale.ROOT, "[%s] will do nothing when loading config. ",
                     DefaultLoadConfigStrategy.class.getName()));
             return config;

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/config/PluginConfigManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/com/huaweicloud/sermant/core/plugin/config/PluginConfigManager.java
@@ -68,7 +68,8 @@ public class PluginConfigManager {
             final BaseConfig retainedConfig = PLUGIN_CONFIG_MAP.get(pluginConfigKey);
             if (pluginConfigFile.exists() && pluginConfigFile.isFile()) {
                 if (retainedConfig == null) {
-                    PLUGIN_CONFIG_MAP.put(pluginConfigKey, ConfigManager.doLoad(pluginConfigFile, config));
+                    PLUGIN_CONFIG_MAP.put(pluginConfigKey,
+                            ConfigManager.doLoad(pluginConfigFile, config, plugin.isDynamic()));
                     plugin.getConfigs().add(pluginConfigKey);
                 } else if (retainedConfig.getClass() == pluginConfigCls) {
                     LOGGER.fine(String.format(Locale.ROOT, "Skip load config [%s] repeatedly. ",

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/LoadPropertiesStrategy.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/LoadPropertiesStrategy.java
@@ -104,7 +104,7 @@ public class LoadPropertiesStrategy implements LoadConfigStrategy<Properties> {
      * @return 配置对象泛型
      */
     @Override
-    public <R extends BaseConfig> R loadConfig(Properties holder, R config) {
+    public <R extends BaseConfig> R loadConfig(Properties holder, R config, boolean isDynamic) {
         return loadConfig(holder, config.getClass(), config);
     }
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/SermantYamlConstructor.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/com/huaweicloud/sermant/implement/config/SermantYamlConstructor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024-2024 Sermant Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huaweicloud.sermant.implement.config;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+/**
+ * Yaml constructor for sermant config load
+ *
+ * @author lilai
+ * @since 2024-05-22
+ */
+public class SermantYamlConstructor extends Constructor {
+    private ClassLoader loader;
+
+    /**
+     * constructor
+     */
+    public SermantYamlConstructor() {
+        super(Object.class, new LoaderOptions());
+        loader = Thread.currentThread().getContextClassLoader();
+    }
+
+    /**
+     * Load class with specific classLoader
+     *
+     * @param name class name
+     * @return created class
+     * @throws ClassNotFoundException class not found
+     */
+    @Override
+    protected Class<?> getClassForName(String name) throws ClassNotFoundException {
+        return Class.forName(name, true, loader);
+    }
+
+    /**
+     * set classLoader
+     *
+     * @param classLoader the classLoader for config object
+     * @throws NullPointerException no classloader is provided
+     */
+    public void setLoader(ClassLoader classLoader) {
+        if (classLoader == null) {
+            throw new NullPointerException("classLoader must be provided.");
+        }
+        this.loader = classLoader;
+    }
+
+    /**
+     * clear snakeyaml class cache
+     */
+    public void clearCache() {
+        typeTags.clear();
+    }
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

Add a custom yaml constructor for snakeyaml to make the same plugin config string can be loaded by new pluginclassloader rather than old pluginclassloader when install a plugin at the second time

**Which issue(s) this PR fixes？**

Fixes #1520

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
