### PR TITLE
support custom args in agentmain for dynamic installation and uninstallation

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/command/CommandProcessor.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/command/CommandProcessor.java
@@ -39,6 +39,8 @@ public class CommandProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger();
 
+    private static final String COMMAND = "command";
+
     static {
         COMMAND_EXECUTOR_MAP.put(Command.INSTALL_PLUGINS.getValue(), new PluginsInstallCommandExecutor());
         COMMAND_EXECUTOR_MAP.put(Command.UNINSTALL_AGENT.getValue(), new AgentUnInstallCommandExecutor());
@@ -55,9 +57,10 @@ public class CommandProcessor {
     /**
      * process command
      *
-     * @param command command
+     * @param agentArgsMap agent args map for dynamic command
      */
-    public static void process(String command) {
+    public static void process(Map<String, String> agentArgsMap) {
+        String command = agentArgsMap.get(COMMAND);
         if (StringUtils.isEmpty(command)) {
             LOGGER.warning("Command information is empty.");
             return;
@@ -74,6 +77,7 @@ public class CommandProcessor {
             return;
         }
         String commandArgs = commandInfo.length > 1 ? commandInfo[1] : null;
+        DynamicAgentArgsManager.refreshAgentArgs(agentArgsMap);
         commandExecutor.execute(commandArgs);
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/command/DynamicAgentArgsManager.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/command/DynamicAgentArgsManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024-2024 Sermant Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sermant.core.command;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Agent args manager for dynamic install and uninstall
+ *
+ * @author lilai
+ * @since 2024-06-20
+ */
+public class DynamicAgentArgsManager {
+    /**
+     * AGENT_ARGS will be updated every time execute dynamic command
+     */
+    private static final Map<String, String> AGENT_ARGS = new HashMap<>();
+
+    private DynamicAgentArgsManager() {
+    }
+
+    /**
+     * refresh AGENT_ARGS
+     *
+     * @param newAgentArgs new coming agent args
+     */
+    public static void refreshAgentArgs(Map<String, String> newAgentArgs) {
+        AGENT_ARGS.putAll(newAgentArgs);
+    }
+
+    /**
+     * get AGENT_ARGS
+     *
+     * @param key key
+     * @return value
+     */
+    public static String getAgentArg(String key) {
+        return AGENT_ARGS.get(key);
+    }
+}

--- a/sermant-agentcore/sermant-agentcore-premain/src/main/java/io/sermant/premain/common/AgentArgsResolver.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/main/java/io/sermant/premain/common/AgentArgsResolver.java
@@ -36,8 +36,8 @@ public class AgentArgsResolver {
      * @return Resolve result
      * @throws IllegalArgumentException Agent arguments are unavailable
      */
-    public static Map<String, Object> resolveAgentArgs(String agentArgs) {
-        final Map<String, Object> argsMap = new HashMap<>();
+    public static Map<String, String> resolveAgentArgs(String agentArgs) {
+        final Map<String, String> argsMap = new HashMap<>();
         if (agentArgs == null) {
             return argsMap;
         }

--- a/sermant-agentcore/sermant-agentcore-premain/src/test/java/io/sermant/premain/common/BootArgsBuilderTest.java
+++ b/sermant-agentcore/sermant-agentcore-premain/src/test/java/io/sermant/premain/common/BootArgsBuilderTest.java
@@ -114,10 +114,11 @@ public class BootArgsBuilderTest {
     @Test
     public void testParseArgs() {
         String agentArgs = "appName=test,command=INSTALL_PLUGIN:monitor/flowcontrol,server.port=9000";
-        Map<String, Object> argsMap = AgentArgsResolver.resolveAgentArgs(agentArgs);
-        BootArgsBuilder.build(argsMap, PathDeclarer.getAgentPath());
-        Assert.assertEquals("test", argsMap.get("appName"));
-        Assert.assertEquals("9000", argsMap.get("server.port"));
-        Assert.assertEquals("INSTALL_PLUGIN:monitor/flowcontrol", argsMap.get("command"));
+        Map<String, String> agentArgsMap = AgentArgsResolver.resolveAgentArgs(agentArgs);
+        Map<String, Object> bootArgsMap = new HashMap<>(agentArgsMap);
+        BootArgsBuilder.build(bootArgsMap, PathDeclarer.getAgentPath());
+        Assert.assertEquals("test", bootArgsMap.get("appName"));
+        Assert.assertEquals("9000", bootArgsMap.get("server.port"));
+        Assert.assertEquals("INSTALL_PLUGIN:monitor/flowcontrol", bootArgsMap.get("command"));
     }
 }


### PR DESCRIPTION
**What type of PR is this?**

Enhancement

**What this PR does / why we need it?**

When use agentmain to install sermant-agent and plugins，now we can add additional arguments for custom requirements. This makes developers input some variable parameters，and get them in sermant

**Which issue(s) this PR fixes？**

Fixes #1552

**Does this PR introduce a user-facing change?**

You can add some arguments in command like : command=INSTALL-PLUGINS:monitor, city=hangzhou, mood=happy
(https://sermant.io/zh/document/user-guide/sermant-agent.html#%E5%8A%A8%E6%80%81%E5%AE%89%E8%A3%85%E6%8F%92%E4%BB%B6)

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
