### PR TITLE
add the service provider isolation

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/classloader/FrameworkClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/classloader/FrameworkClassLoader.java
@@ -122,6 +122,13 @@ public class FrameworkClassLoader extends URLClassLoader {
         if ("org/slf4j/impl/StaticLoggerBinder.class".equals(name)) {
             return findResources(name);
         }
+
+        // Due to class isolation, the service loader does not obtain the service provider from the parent
+        // classloader, but returns only the resources in the classloader
+        if (name.startsWith("META-INF/services/")) {
+            return findResources(name);
+        }
+
         return super.getResources(name);
     }
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

Due to class isolation, the service loader does not obtain the service provider from the parent classloader, but returns only the resources in the framework classloader

**Which issue(s) this PR fixes？**

Fixes #1567

**Does this PR introduce a user-facing change?**

No


## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
