### PR TITLE
Fix graceful shutdown notify failure

### DIFF
--- a/.github/actions/scenarios/spring/graceful/action.yml
+++ b/.github/actions/scenarios/spring/graceful/action.yml
@@ -37,6 +37,7 @@ runs:
         grace.rule.enableGraceShutdown: true
         grace.rule.enableOfflineNotify: true
         grace.rule.warmUpTime: 600
+        grace.rule.upstreamAddressExpiredTime: 600
         servicecomb.service.enableSpringRegister: true
         servicecomb.service.preferIpAddress: true
       # graceful-rest-provider service port 8443 do not change, it special for springCloud Edgware.SR2 test ssl feature.

--- a/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/io/sermant/integration/lane/LaneTest.java
+++ b/sermant-integration-tests/dubbo-test/dubbo-integration-test/src/test/java/io/sermant/integration/lane/LaneTest.java
@@ -61,7 +61,7 @@ public class LaneTest {
     }
 
     @Test
-    public void testDubbo() {
+    public void testDubbo() throws InterruptedException {
         if (isExecuteSpringTest){
             testBySpring("Dubbo");
         }
@@ -121,7 +121,7 @@ public class LaneTest {
     }
 
     @Test
-    public void testFeign() {
+    public void testFeign() throws InterruptedException {
         if (isExecuteSpringTest){
             testBySpring("Feign");
             testByDubbo("Feign");
@@ -129,7 +129,7 @@ public class LaneTest {
     }
 
     @Test
-    public void testRest() {
+    public void testRest() throws InterruptedException {
         if (isExecuteSpringTest){
             testBySpring("Rest");
             testByDubbo("Rest");
@@ -200,7 +200,8 @@ public class LaneTest {
      *
      * @param path 路径
      */
-    private void testByDubbo(String path) {
+    private void testByDubbo(String path) throws InterruptedException {
+        Thread.sleep(10000);
         // 正常染色
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<>(null, headers);

--- a/sermant-integration-tests/spring-test/spring-integration-test/src/test/java/io/sermant/integration/graceful/GracefulTest.java
+++ b/sermant-integration-tests/spring-test/spring-integration-test/src/test/java/io/sermant/integration/graceful/GracefulTest.java
@@ -66,7 +66,7 @@ public abstract class GracefulTest {
         final Map<String, Integer> statisticMap = new HashMap<>();
         for (int i = 0; i < 4; i++) {
             try {
-                for(int j = 0; j < UP_REQUEST_COUNT; j++) {
+                for (int j = 0; j < UP_REQUEST_COUNT; j++) {
                     statistic(statisticMap);
                 }
                 Thread.sleep(10000);
@@ -98,15 +98,14 @@ public abstract class GracefulTest {
     /**
      * 测试优雅下线
      */
+    @Test
     public void testGracefulDown() {
         if (!isTargetTest("down")) {
             return;
         }
         try {
             for (int i = 0; i < DOWN_REQUEST_COUNT; i++) {
-                String port = RequestUtils.get(buildUrl("testGraceful"), Collections.emptyMap(),
-                        String.class);
-                System.out.println("port: " + port);
+                RequestUtils.get(buildUrl("testGraceful"), Collections.emptyMap(), String.class);
             }
         } catch (Exception exception) {
             LOGGER.error(exception.getMessage(), exception);

--- a/sermant-plugins/sermant-service-registry/registry-common/src/main/java/io/sermant/registry/config/GraceConfig.java
+++ b/sermant-plugins/sermant-service-registry/registry-common/src/main/java/io/sermant/registry/config/GraceConfig.java
@@ -115,6 +115,11 @@ public class GraceConfig implements PluginConfig, Cloneable {
     private long upstreamAddressExpiredTime = GraceConstants.UPSTREAM_ADDRESS_DEFAULT_EXPIRED_TIME;
 
     /**
+     * Cache the wait time of notifying upstream addresses
+     */
+    private long waitNotifyTime = GraceConstants.WAIT_NOTIFY_TIME;
+
+    /**
      * Correct the relevant switch attributes according to the aggregation switch,
      * and turn on all functions of elegant online and offline with one click
      */
@@ -260,6 +265,14 @@ public class GraceConfig implements PluginConfig, Cloneable {
 
     public void setUpstreamAddressExpiredTime(long upstreamAddressExpiredTime) {
         this.upstreamAddressExpiredTime = upstreamAddressExpiredTime;
+    }
+
+    public long getWaitNotifyTime() {
+        return waitNotifyTime;
+    }
+
+    public void setWaitNotifyTime(long waitNotifyTime) {
+        this.waitNotifyTime = waitNotifyTime;
     }
 
     /**

--- a/sermant-plugins/sermant-service-registry/registry-common/src/main/java/io/sermant/registry/config/grace/GraceConstants.java
+++ b/sermant-plugins/sermant-service-registry/registry-common/src/main/java/io/sermant/registry/config/grace/GraceConstants.java
@@ -157,6 +157,11 @@ public class GraceConstants {
     public static final long UPSTREAM_ADDRESS_DEFAULT_EXPIRED_TIME = 60L;
 
     /**
+     * The default wait time of notifying upstream addresses
+     */
+    public static final long WAIT_NOTIFY_TIME = 20L;
+
+    /**
      * Maximum port
      */
     public static final int MAX_HTTP_SERVER_PORT = 65535;

--- a/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/io/sermant/registry/entity/GraceShutdownBehavior.java
+++ b/sermant-plugins/sermant-service-registry/spring-cloud-registry-plugin/src/main/java/io/sermant/registry/entity/GraceShutdownBehavior.java
@@ -56,6 +56,8 @@ public class GraceShutdownBehavior implements Runnable {
     }
 
     private void graceShutDown() {
+        // wait notify consumer complete
+        CommonUtils.sleep(graceConfig.getWaitNotifyTime() * ConfigConstants.SEC_DELTA);
         long shutdownWaitTime = graceConfig.getShutdownWaitTime() * ConfigConstants.SEC_DELTA;
         final long shutdownCheckTimeUnit = graceConfig.getShutdownCheckTimeUnit() * ConfigConstants.SEC_DELTA;
         while (GraceContext.INSTANCE.getGraceShutDownManager().getRequestCount() > 0 && shutdownWaitTime > 0) {


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

When one instance of provider is going to be shutdown，send requests continuously to it. Sometimes we will get 500 response code. So this pr manages to make sure the notification to consumer is send correctly.

**Which issue(s) this PR fixes？**

Fixes #1589

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
