### PR TITLE
Fix the issue that a NullPointerException occurs when initialize the unified configuration

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/config/utils/ConfigValueUtil.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/config/utils/ConfigValueUtil.java
@@ -207,6 +207,9 @@ public class ConfigValueUtil {
     }
 
     private static <R> void parseConfigToCollection(String configStr, Class<R> type, Collection<R> result) {
+        if (StringUtils.isBlank(configStr)) {
+            return;
+        }
         for (String configSlice : configStr.split(CONFIG_SEPARATOR)) {
             final R obj = toBaseType(configSlice.trim(), type);
             if (obj == null) {
@@ -240,6 +243,9 @@ public class ConfigValueUtil {
      */
     public static <K, V> Map<K, V> toMapType(String configStr, Class<K> keyType, Class<V> valueType) {
         final Map<K, V> result = new HashMap<K, V>();
+        if (StringUtils.isBlank(configStr)) {
+            return result;
+        }
         for (String kvSlice : configStr.split(CONFIG_SEPARATOR)) {
             final String[] kvEntry = kvSlice.trim().split(":");
             if (kvEntry.length != MAP_KV_LEN) {

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/event/EventCollector.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/event/EventCollector.java
@@ -37,11 +37,14 @@ import java.util.logging.Logger;
 public class EventCollector {
     private static final Logger LOGGER = LoggerFactory.getLogger();
 
+    /**
+     * Event configuration. Set as protected for easy use by subclasses
+     */
+    protected EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
+
     // BlockingQueue for event cache. If the queue is not full, event is reported periodically. If
     // the queue is full, event is reported automatically
     private final BlockingQueue<Event> eventQueue = new ArrayBlockingQueue<>(100);
-
-    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
 
     private final ConcurrentHashMap<EventInfo, Long> eventInfoOfferTimeCache = new ConcurrentHashMap<>();
 
@@ -69,7 +72,7 @@ public class EventCollector {
      * @return result
      */
     public boolean offerEvent(Event event) {
-        if (!eventConfig.isEnable()) {
+        if (!isEnableEvent()) {
             return false;
         }
         if (event.getEventInfo() != null) {
@@ -125,5 +128,17 @@ public class EventCollector {
                 eventInfoOfferTimeCache.remove(eventInfo);
             }
         }
+    }
+
+    /**
+     * Check if the event is enabled
+     *
+     * @return Verification results
+     */
+    protected boolean isEnableEvent() {
+        if (eventConfig == null) {
+            eventConfig = ConfigManager.getConfig(EventConfig.class);
+        }
+        return eventConfig != null && eventConfig.isEnable();
     }
 }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/event/collector/FrameworkEventCollector.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/event/collector/FrameworkEventCollector.java
@@ -16,11 +16,9 @@
 
 package io.sermant.core.event.collector;
 
-import io.sermant.core.config.ConfigManager;
 import io.sermant.core.event.Event;
 import io.sermant.core.event.EventCollector;
 import io.sermant.core.event.EventInfo;
-import io.sermant.core.event.config.EventConfig;
 
 /**
  * Framework event collector
@@ -30,8 +28,6 @@ import io.sermant.core.event.config.EventConfig;
  */
 public class FrameworkEventCollector extends EventCollector {
     private static FrameworkEventCollector frameworkEventCollector;
-
-    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
 
     private FrameworkEventCollector() {
     }

--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/event/collector/LogEventCollector.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/event/collector/LogEventCollector.java
@@ -16,13 +16,11 @@
 
 package io.sermant.core.event.collector;
 
-import io.sermant.core.config.ConfigManager;
 import io.sermant.core.event.Event;
 import io.sermant.core.event.EventCollector;
 import io.sermant.core.event.EventLevel;
 import io.sermant.core.event.EventType;
 import io.sermant.core.event.LogInfo;
-import io.sermant.core.event.config.EventConfig;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.LogRecord;
@@ -35,8 +33,6 @@ import java.util.logging.LogRecord;
  */
 public class LogEventCollector extends EventCollector {
     private static LogEventCollector logEventCollector;
-
-    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
 
     private final ConcurrentHashMap<LogInfo, Long> logInfoOfferTimeCache = new ConcurrentHashMap<>();
 
@@ -61,7 +57,7 @@ public class LogEventCollector extends EventCollector {
      * @param record log record
      */
     public void offerWarning(LogRecord record) {
-        if (!eventConfig.isEnable() || !eventConfig.isOfferWarnLog()) {
+        if (!isEnableEvent() || !eventConfig.isOfferWarnLog()) {
             return;
         }
         LogInfo logInfo = new LogInfo(record);
@@ -77,7 +73,7 @@ public class LogEventCollector extends EventCollector {
      * @param record log record
      */
     public void offerError(LogRecord record) {
-        if (!eventConfig.isEnable() || !eventConfig.isOfferErrorLog()) {
+        if (!isEnableEvent() || !eventConfig.isOfferErrorLog()) {
             return;
         }
         LogInfo logInfo = new LogInfo(record);

--- a/sermant-plugins/sermant-router/router-common/src/main/java/io/sermant/router/common/event/RouterEventCollector.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/io/sermant/router/common/event/RouterEventCollector.java
@@ -16,12 +16,10 @@
 
 package io.sermant.router.common.event;
 
-import io.sermant.core.config.ConfigManager;
 import io.sermant.core.event.Event;
 import io.sermant.core.event.EventCollector;
 import io.sermant.core.event.EventInfo;
 import io.sermant.core.event.EventManager;
-import io.sermant.core.event.config.EventConfig;
 
 /**
  * Routing plugin event collector
@@ -31,8 +29,6 @@ import io.sermant.core.event.config.EventConfig;
  */
 public class RouterEventCollector extends EventCollector {
     private static volatile RouterEventCollector routerEventCollector;
-
-    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
 
     private RouterEventCollector() {
     }

--- a/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/io/sermant/discovery/event/SpringBootRegistryEventCollector.java
+++ b/sermant-plugins/sermant-springboot-registry/springboot-registry-plugin/src/main/java/io/sermant/discovery/event/SpringBootRegistryEventCollector.java
@@ -16,12 +16,10 @@
 
 package io.sermant.discovery.event;
 
-import io.sermant.core.config.ConfigManager;
 import io.sermant.core.event.Event;
 import io.sermant.core.event.EventCollector;
 import io.sermant.core.event.EventInfo;
 import io.sermant.core.event.EventManager;
-import io.sermant.core.event.config.EventConfig;
 import io.sermant.discovery.entity.DefaultServiceInstance;
 
 /**
@@ -32,8 +30,6 @@ import io.sermant.discovery.entity.DefaultServiceInstance;
  */
 public class SpringBootRegistryEventCollector extends EventCollector {
     private static volatile SpringBootRegistryEventCollector collector;
-
-    private final EventConfig eventConfig = ConfigManager.getConfig(EventConfig.class);
 
     private SpringBootRegistryEventCollector() {
     }


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

Fix the issue that a NullPointerException occurs when the configuration item type is set and the configuration content is empty during configuration initialization parsing.  When the configuration type of a configuration item is collection and the configuration content is empty, an warning log is recorded. The LogEventCollector collects and reports warning logs. However, the event configuration is not initialized, so a NullPointerException is thrown on event collection

**Which issue(s) this PR fixes？**

Fixes #1591 

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [ ] GitHub Actions works fine in this PR.
