### PR TITLE
Fix the problem that the service loading order is inconsistent with the order defined in the SPI file

### DIFF
--- a/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/service/httpserver/HttpServerServiceImpl.java
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/java/io/sermant/implement/service/httpserver/HttpServerServiceImpl.java
@@ -19,13 +19,10 @@ package io.sermant.implement.service.httpserver;
 import io.sermant.core.common.LoggerFactory;
 import io.sermant.core.config.ConfigManager;
 import io.sermant.core.exception.SermantRuntimeException;
-import io.sermant.core.service.BaseService;
 import io.sermant.core.service.httpserver.HttpServerService;
 import io.sermant.core.service.httpserver.config.HttpServerConfig;
 import io.sermant.core.service.httpserver.config.HttpServerTypeEnum;
 import io.sermant.core.utils.SpiLoadUtils;
-
-import org.kohsuke.MetaInfServices;
 
 import java.util.Map;
 import java.util.logging.Logger;
@@ -37,7 +34,6 @@ import java.util.stream.Collectors;
  * @author zwmagic
  * @since 2024-02-02
  */
-@MetaInfServices(BaseService.class)
 public class HttpServerServiceImpl implements HttpServerService {
     private static final Logger LOGGER = LoggerFactory.getLogger();
 

--- a/sermant-agentcore/sermant-agentcore-implement/src/main/resources/META-INF/services/io.sermant.core.service.BaseService
+++ b/sermant-agentcore/sermant-agentcore-implement/src/main/resources/META-INF/services/io.sermant.core.service.BaseService
@@ -4,3 +4,4 @@ io.sermant.implement.service.dynamicconfig.BufferedDynamicConfigService
 io.sermant.implement.service.tracing.TracingServiceImpl
 io.sermant.implement.service.inject.InjectServiceImpl
 io.sermant.implement.service.xds.XdsCoreServiceImpl
+io.sermant.implement.service.httpserver.HttpServerServiceImpl


### PR DESCRIPTION
**What type of PR is this?**

**Bug**

**What this PR does / why we need it?**

Fix the problem that the service loading order is inconsistent with the order defined in the SPI file。The cause of the problem is that HttpServerServiceImpl is loaded through the MetaInfServices annotation, causing the server to fail to load in the order defined by the SPI file.

**Which issue(s) this PR fixes？**

Fixes #1602 

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [ ] GitHub Actions works fine in this PR.
