### PR TITLE
fix: When use redis store event, incorrect key was used to query the …

### DIFF
--- a/sermant-backend/src/main/java/io/sermant/backend/common/conf/CommonConst.java
+++ b/sermant-backend/src/main/java/io/sermant/backend/common/conf/CommonConst.java
@@ -64,11 +64,6 @@ public class CommonConst {
     public static final int DEFAULT_REDIS_PORT = 6379;
 
     /**
-     * redis hash key of instance meta
-     */
-    public static final String REDIS_HASH_KEY_OF_INSTANCE_META = "sermant_meta";
-
-    /**
      * redis event key
      */
     public static final String REDIS_EVENT_KEY = "sermant_events_hash";

--- a/sermant-backend/src/main/java/io/sermant/backend/dao/redis/RedisClientImpl.java
+++ b/sermant-backend/src/main/java/io/sermant/backend/dao/redis/RedisClientImpl.java
@@ -192,7 +192,7 @@ public class RedisClientImpl implements EventDao {
     @Override
     public QueryResultEventInfoEntity getDoNotifyEvent(Event event) {
         QueryResultEventInfoEntity queryResultEventInfoEntity = new QueryResultEventInfoEntity();
-        String instanceMeta = redisOperation.hget(CommonConst.REDIS_HASH_KEY_OF_INSTANCE_META, event.getMetaHash());
+        String instanceMeta = redisOperation.get(event.getMetaHash());
         if (!DbUtils.isEmpty(instanceMeta)) {
             InstanceMeta agentInstanceMeta = JSONObject.parseObject(instanceMeta, InstanceMeta.class);
             queryResultEventInfoEntity = DbUtils.aggregationEvent(event, agentInstanceMeta);


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

When use redis store event, incorrect key was used to query the InstanceMeta.

**Which issue(s) this PR fixes？**

Fixes #1616 

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [ ] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [ ] Make sure you have squashed your change to one single commit.
- [ ] GitHub Actions works fine in this PR.
