### PR TITLE
Fix the issue where parameter information cannot be set during plugin install

### DIFF
--- a/sermant-backend/src/main/webapp/frontend/src/views/InstancesView.vue
+++ b/sermant-backend/src/main/webapp/frontend/src/views/InstancesView.vue
@@ -195,7 +195,8 @@
         <TooltipIcon :content="$t('instanceView.agentPathNotice')"/>
       </el-form-item>
       <el-form-item
-          v-if="hotPluggingConfig.commandType == 'UPDATE-AGENT' || hotPluggingConfig.commandType == 'UPDATE-PLUGINS'"
+          v-if="hotPluggingConfig.commandType == 'UPDATE-AGENT' || hotPluggingConfig.commandType == 'UPDATE-PLUGINS'
+            || hotPluggingConfig.commandType == 'INSTALL-PLUGINS'"
           :label="$t('instanceView.param')" label-width="140px"
           prop="param">
         <el-input v-model="hotPluggingConfig.params" class="input-style"


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

The parameter text box is not displayed when a plug-in is selected for installation.

**Which issue(s) this PR fixes？**

Fixes #1633 

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [ ] GitHub Actions works fine in this PR.
