### PR TITLE
Fix the issue that failed to execute XdsRouterUtilTest.

### DIFF
--- a/sermant-plugins/sermant-router/router-common/src/main/java/io/sermant/router/common/utils/XdsRouterUtils.java
+++ b/sermant-plugins/sermant-router/router-common/src/main/java/io/sermant/router/common/utils/XdsRouterUtils.java
@@ -77,6 +77,17 @@ public class XdsRouterUtils {
         }
     }
 
+    /**
+     * updateServiceDiscovery
+     *
+     * @param xdsServiceDiscovery xdsServiceDiscovery
+     */
+    public static void updateServiceDiscovery(XdsServiceDiscovery xdsServiceDiscovery) {
+        if (xdsServiceDiscovery != null) {
+            serviceDiscovery = xdsServiceDiscovery;
+        }
+    }
+
     private static Optional<ServiceInstance> getMatchedServiceInstanceByPodIp(Set<ServiceInstance> serviceInstances,
             String podIp) {
         return serviceInstances.stream()

--- a/sermant-plugins/sermant-router/router-common/src/test/java/io/sermant/router/common/utils/XdsRouterUtilTest.java
+++ b/sermant-plugins/sermant-router/router-common/src/test/java/io/sermant/router/common/utils/XdsRouterUtilTest.java
@@ -48,8 +48,6 @@ import java.util.Set;
  * @since 2024-08-31
  **/
 public class XdsRouterUtilTest {
-    private static XdsServiceDiscovery serviceDiscovery;
-
     private static MockedStatic<ServiceManager> serviceManager;
 
     private static MockedStatic<NetworkUtils> networkUtils;
@@ -57,23 +55,24 @@ public class XdsRouterUtilTest {
     private static MockedStatic<ConfigManager> configManager;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         XdsCoreService xdsCoreService = Mockito.mock(XdsCoreService.class);
         serviceManager = Mockito.mockStatic(ServiceManager.class);
         Mockito.when(ServiceManager.getService(XdsCoreService.class)).thenReturn(xdsCoreService);
         networkUtils = Mockito.mockStatic(NetworkUtils.class);
         Mockito.when(NetworkUtils.getKubernetesPodIp()).thenReturn("127.0.0.1");
 
-        serviceDiscovery = Mockito.mock(XdsServiceDiscovery.class);
+        XdsServiceDiscovery serviceDiscovery = Mockito.mock(XdsServiceDiscovery.class);
         Mockito.when(xdsCoreService.getXdsServiceDiscovery()).thenReturn(serviceDiscovery);
         Mockito.when(serviceDiscovery.getServiceInstance("serviceA"))
                 .thenReturn(createServiceInstance4Service(Arrays.asList("127.0.0.1", "host", "localhost")));
 
+        XdsRouterUtils.updateServiceDiscovery(serviceDiscovery);
         configManager = Mockito.mockStatic(ConfigManager.class);
     }
 
     @AfterClass
-    public static void tearDown() throws Exception {
+    public static void tearDown() {
         serviceManager.close();
         networkUtils.close();
         configManager.close();

--- a/sermant-plugins/sermant-router/router-common/src/test/java/io/sermant/router/common/xds/XdsRouterHandlerTest.java
+++ b/sermant-plugins/sermant-router/router-common/src/test/java/io/sermant/router/common/xds/XdsRouterHandlerTest.java
@@ -49,15 +49,13 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
+ * XdsRouterHandlerTest
+ *
  * @author daizhenyu
  * @since 2024-08-30
  **/
 public class XdsRouterHandlerTest {
     private static final String CLUSTER_NAME = "outbound|8080||serviceA.default.svc.cluster.local";
-
-    private static XdsRouteService routeService;
-
-    private static XdsServiceDiscovery serviceDiscovery;
 
     private static MockedStatic<ServiceManager> serviceManager;
 
@@ -69,8 +67,8 @@ public class XdsRouterHandlerTest {
 
     @BeforeClass
     public static void setUp() {
-        routeService = Mockito.mock(XdsRouteService.class);
-        serviceDiscovery = Mockito.mock(XdsServiceDiscovery.class);
+        XdsRouteService routeService = Mockito.mock(XdsRouteService.class);
+        XdsServiceDiscovery serviceDiscovery = Mockito.mock(XdsServiceDiscovery.class);
         XdsCoreService xdsCoreService = Mockito.mock(XdsCoreService.class);
         Mockito.when(xdsCoreService.getXdsRouteService()).thenReturn(routeService);
         Mockito.when(xdsCoreService.getXdsServiceDiscovery()).thenReturn(serviceDiscovery);


### PR DESCRIPTION
**What type of PR is this?**

Bug.

**What this PR does / why we need it?**

XdsRouterUtil has been loaded in XdsRouterHandlerTest, so the private static field XdsServiceDiscovery serviceDiscovery has been created. The new mock logic takes effect only after serviceDiscovery is updated in XdsRouterUtilTest.

**Which issue(s) this PR fixes？**

Fixes #1642

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [ ] GitHub Actions works fine in this PR.
