### PR TITLE
fix the issue that xds routing fails when okhttp2.2.0 is used

### DIFF
--- a/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/io/sermant/router/spring/interceptor/OkHttpClientInterceptorChainInterceptor.java
+++ b/sermant-plugins/sermant-router/spring-router-plugin/src/main/java/io/sermant/router/spring/interceptor/OkHttpClientInterceptorChainInterceptor.java
@@ -17,7 +17,6 @@
 package io.sermant.router.spring.interceptor;
 
 import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.Request;
 
 import io.sermant.core.common.LoggerFactory;
@@ -31,6 +30,7 @@ import io.sermant.router.spring.utils.BaseHttpRouterUtils;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -89,8 +89,15 @@ public class OkHttpClientInterceptorChainInterceptor implements Interceptor {
     }
 
     private Request rebuildRequest(Request request, URI uri, ServiceInstance serviceInstance) {
+        URL url = null;
+        try {
+            url = new URL(BaseHttpRouterUtils.rebuildUrlByXdsServiceInstance(uri, serviceInstance));
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Convert url string to url failed.", e.getMessage());
+            return request;
+        }
         return request.newBuilder()
-                .url(HttpUrl.parse(BaseHttpRouterUtils.rebuildUrlByXdsServiceInstance(uri, serviceInstance)))
+                .url(url)
                 .build();
     }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug.

**What this PR does / why we need it?**

fix the issue that xds routing fails when okhttp2.2.0 is used. The cause is that the okhttp2 earlier version uses java.net.URL instead of com.squareup.okhttp.HttpUrl.

**Which issue(s) this PR fixes？**

Fixes #1647

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [ ] GitHub Actions works fine in this PR.
