### PR TITLE
Fix remove tag issue for DubboProviderInterceptor in consumer side

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/main/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/main/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptor.java
@@ -84,6 +84,10 @@ public class AlibabaDubboProviderInterceptor extends AbstractServerInterceptor<R
 
     @Override
     protected ExecuteContext doAfter(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
+
         TrafficUtils.removeTrafficTag();
         return context;
     }
@@ -123,6 +127,9 @@ public class AlibabaDubboProviderInterceptor extends AbstractServerInterceptor<R
 
     @Override
     public ExecuteContext onThrow(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/test/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/test/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptorTest.java
@@ -93,6 +93,32 @@ public class AlibabaDubboProviderInterceptorTest extends AbstractRpcInterceptorT
         interceptor.after(returnContext);
     }
 
+    @Test
+    public void testConsumerSideRemoveTrafficTag() {
+        // If interceptor is invoked in consumer side, it should not remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+    }
+
+    @Test
+    public void testProviderSideRemoveTrafficTag() {
+        // If interceptor is invoked in provider side, it should remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+    }
+
     private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
         URL url = new URL("http", "127.0.0.1", 8080);
         url = url.addParameter("side", side);

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/main/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/main/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptor.java
@@ -83,12 +83,18 @@ public class ApacheDubboProviderInterceptor extends AbstractServerInterceptor<Rp
 
     @Override
     protected ExecuteContext doAfter(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }
 
     @Override
     public ExecuteContext onThrow(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/test/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/test/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptorTest.java
@@ -92,6 +92,32 @@ public class ApacheDubboProviderInterceptorTest extends AbstractRpcInterceptorTe
         interceptor.after(returnContext);
     }
 
+    @Test
+    public void testConsumerSideRemoveTrafficTag() {
+        // If interceptor is invoked in consumer side, it should not remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+    }
+
+    @Test
+    public void testProviderSideRemoveTrafficTag() {
+        // If interceptor is invoked in provider side, it should remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+    }
+
     private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
         URL url = new URL("http", "127.0.0.1", 8080);
         url = url.addParameter("side", side);

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/main/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/main/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptor.java
@@ -83,12 +83,18 @@ public class ApacheDubboProviderInterceptor extends AbstractServerInterceptor<Rp
 
     @Override
     protected ExecuteContext doAfter(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }
 
     @Override
     public ExecuteContext onThrow(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/test/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/test/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptorTest.java
@@ -92,6 +92,32 @@ public class ApacheDubboProviderInterceptorTest extends AbstractRpcInterceptorTe
         interceptor.after(returnContext);
     }
 
+    @Test
+    public void testConsumerSideRemoveTrafficTag() {
+        // If interceptor is invoked in consumer side, it should not remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+    }
+
+    @Test
+    public void testProviderSideRemoveTrafficTag() {
+        // If interceptor is invoked in provider side, it should remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+    }
+
     private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
         URL url = new URL("http", "127.0.0.1", 8080);
         url = url.addParameter("side", side);


### PR DESCRIPTION
…t will cause previously traffic tag removed and the follow up invocation can not get traffic tag from thread local

**What type of PR is this?**

Bug

**What this PR does / why we need it?**

DubboProviderInterceptor will be invoked in consumer side(MonitorFilter is enable in both provider and consumer side in default),  it will cause previous traffic tag removed and the follow up invocation can not get traffic tag from ThreadLocal when the traffic tag used for traffic route later if remove traffic tag unconditionally.  


Here is stack for real case and  the route later which use traffic tag does not work because the traffic tag is removed by DubboProviderInterceptor method previously executed.

`
ts=2024-10-22 17:20:38.674;thread_name=rpc-core-13;id=754;is_daemon=false;priority=5;TCCL=org.springframework.boot.web.embedded.tomcat.TomcatEmbeddedWebappClassLoader@3a1eb893
 @com.huaweicloud.sermant.core.utils.tag.TrafficUtils.removeTrafficTag()
 at com.huaweicloud.sermant.tag.transmission.dubbov3.interceptors.ApacheDubboProviderInterceptor.doAfter(ApacheDubboProviderInterceptor.java:86)
 at com.huaweicloud.sermant.tag.transmission.interceptors.AbstractServerInterceptor.after(AbstractServerInterceptor.java:58)
 at com.huaweicloud.sermant.core.plugin.agent.template.BaseAdviseHandler.handleMethodExit(BaseAdviseHandler.java:169)
 at com.huaweicloud.sermant.core.plugin.agent.template.BaseAdviseHandler.handleMethodExit(BaseAdviseHandler.java:130)
 at com.huaweicloud.sermant.core.plugin.agent.template.DefaultAdviser.onMethodExit(DefaultAdviser.java:63)
 at com.huaweicloud.sermant.core.plugin.agent.adviser.AdviserScheduler.onMethodExit(AdviserScheduler.java:96)
 at org.apache.dubbo.monitor.support.MonitorFilter.invoke(MonitorFilter.java:91)
 at org.apache.dubbo.rpc.protocol.FilterNode.invoke(FilterNode.java:61)
 at org.apache.dubbo.rpc.protocol.dubbo.filter.FutureFilter.invoke(FutureFilter.java:52)
 at org.apache.dubbo.rpc.protocol.FilterNode.invoke(FilterNode.java:61)
 at org.apache.dubbo.rpc.filter.ConsumerContextFilter.invoke(ConsumerContextFilter.java:69)
 at org.apache.dubbo.rpc.protocol.FilterNode.invoke(FilterNode.java:61)
 at org.apache.dubbo.rpc.protocol.InvokerWrapper.invoke(InvokerWrapper.java:56)
 at org.apache.dubbo.rpc.cluster.support.FailoverClusterInvoker.doInvoke(FailoverClusterInvoker.java:82)
 at org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker.invoke(AbstractClusterInvoker.java:265)
 at org.apache.dubbo.rpc.cluster.interceptor.ClusterInterceptor.intercept(ClusterInterceptor.java:47)
 at org.apache.dubbo.rpc.cluster.support.wrapper.AbstractCluster$InterceptorInvokerNode.invoke(AbstractCluster.java:92)
 at org.apache.dubbo.rpc.cluster.support.wrapper.MockClusterInvoker.invoke(MockClusterInvoker.java:93)
 at org.apache.dubbo.registry.client.migration.MigrationInvoker.invoke(MigrationInvoker.java:169)
 at org.apache.dubbo.rpc.cluster.support.registry.ZoneAwareClusterInvoker.doInvoke(ZoneAwareClusterInvoker.java:105)
 at org.apache.dubbo.rpc.cluster.support.AbstractClusterInvoker.invoke(AbstractClusterInvoker.java:265)
 at org.apache.dubbo.rpc.cluster.interceptor.ClusterInterceptor.intercept(ClusterInterceptor.java:47)
 at org.apache.dubbo.rpc.cluster.support.wrapper.AbstractCluster$InterceptorInvokerNode.invoke(AbstractCluster.java:92)
 at org.apache.dubbo.rpc.proxy.InvokerInvocationHandler.invoke(InvokerInvocationHandler.java:96)
 at org.apache.dubbo.common.bytecode.proxy4.queryPage(proxy4.java:-1)
...
`


**Which issue(s) this PR fixes？**

It will not remove traffic tag if DubboProviderInterceptor in consumer side in after method.
https://github.com/sermant-io/Sermant/issues/1654

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
