### PR TITLE
Fixed an issue where DubboProviderInterceptor remove tag on the consumer side. As a result, the traffic tag is removed and cannot be obtained from thread local

### DIFF
--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/main/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/main/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptor.java
@@ -84,6 +84,10 @@ public class AlibabaDubboProviderInterceptor extends AbstractServerInterceptor<R
 
     @Override
     protected ExecuteContext doAfter(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
+
         TrafficUtils.removeTrafficTag();
         return context;
     }
@@ -123,6 +127,9 @@ public class AlibabaDubboProviderInterceptor extends AbstractServerInterceptor<R
 
     @Override
     public ExecuteContext onThrow(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/test/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.6.x-plugin/src/test/java/io/sermant/tag/transmission/alibabadubbo/interceptors/AlibabaDubboProviderInterceptorTest.java
@@ -93,6 +93,32 @@ public class AlibabaDubboProviderInterceptorTest extends AbstractRpcInterceptorT
         interceptor.after(returnContext);
     }
 
+    @Test
+    public void testConsumerSideRemoveTrafficTag() {
+        // If interceptor is invoked in consumer side, it should not remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+    }
+
+    @Test
+    public void testProviderSideRemoveTrafficTag() {
+        // If interceptor is invoked in provider side, it should remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+    }
+
     private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
         URL url = new URL("http", "127.0.0.1", 8080);
         url = url.addParameter("side", side);

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/main/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/main/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptor.java
@@ -83,12 +83,18 @@ public class ApacheDubboProviderInterceptor extends AbstractServerInterceptor<Rp
 
     @Override
     protected ExecuteContext doAfter(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }
 
     @Override
     public ExecuteContext onThrow(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/test/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo2.7.x-plugin/src/test/java/io/sermant/tag/transmission/apachedubbov2/interceptors/ApacheDubboProviderInterceptorTest.java
@@ -92,6 +92,32 @@ public class ApacheDubboProviderInterceptorTest extends AbstractRpcInterceptorTe
         interceptor.after(returnContext);
     }
 
+    @Test
+    public void testConsumerSideRemoveTrafficTag() {
+        // If interceptor is invoked in consumer side, it should not remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+    }
+
+    @Test
+    public void testProviderSideRemoveTrafficTag() {
+        // If interceptor is invoked in provider side, it should remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+    }
+
     private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
         URL url = new URL("http", "127.0.0.1", 8080);
         url = url.addParameter("side", side);

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/main/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptor.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/main/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptor.java
@@ -83,12 +83,18 @@ public class ApacheDubboProviderInterceptor extends AbstractServerInterceptor<Rp
 
     @Override
     protected ExecuteContext doAfter(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }
 
     @Override
     public ExecuteContext onThrow(ExecuteContext context) {
+        if (isConsumer(context)) {
+            return context;
+        }
         TrafficUtils.removeTrafficTag();
         return context;
     }

--- a/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/test/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptorTest.java
+++ b/sermant-plugins/sermant-tag-transmission/tag-transmission-dubbo3.x-plugin/src/test/java/io/sermant/tag/transmission/dubbov3/interceptors/ApacheDubboProviderInterceptorTest.java
@@ -92,6 +92,32 @@ public class ApacheDubboProviderInterceptorTest extends AbstractRpcInterceptorTe
         interceptor.after(returnContext);
     }
 
+    @Test
+    public void testConsumerSideRemoveTrafficTag() {
+        // If interceptor is invoked in consumer side, it should not remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "consumer");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+    }
+
+    @Test
+    public void testProviderSideRemoveTrafficTag() {
+        // If interceptor is invoked in provider side, it should remove traffic tag in after method.
+        Map<String, List<String>> expectTag = buildExpectTrafficTag("id", "name");
+        TrafficUtils.setTrafficTag(new TrafficTag(expectTag));
+
+        ExecuteContext context = buildContext(new RpcInvocation(), new HashMap<>(), "provider");
+        interceptor.before(context);
+        Assert.assertEquals(TrafficUtils.getTrafficTag().getTag(), expectTag);
+        interceptor.after(context);
+        Assert.assertNull(TrafficUtils.getTrafficTag());
+    }
+
     private ExecuteContext buildContext(RpcInvocation rpcInvocation, Map<String, String> headers, String side) {
         URL url = new URL("http", "127.0.0.1", 8080);
         url = url.addParameter("side", side);


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

Fix remove tag issue for DubboProviderInterceptor in consumer side ,it will cause previously traffic tag removed and the follow up invocation can not get traffic tag from thread local. 

This PR is copied from #1652 to fix this issue in later releases of 2.1.x

**Which issue(s) this PR fixes？**

Fixes #1654 

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
