### PR TITLE
fix_2.1.x: classloaders in Sermant should not load implementations of SPI interface from parent classloader

### DIFF
--- a/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/plugin/classloader/PluginClassLoader.java
+++ b/sermant-agentcore/sermant-agentcore-core/src/main/java/io/sermant/core/plugin/classloader/PluginClassLoader.java
@@ -20,8 +20,10 @@ import io.sermant.core.common.LoggerFactory;
 import io.sermant.core.config.ConfigManager;
 import io.sermant.core.plugin.agent.config.AgentConfig;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -148,6 +150,17 @@ public class PluginClassLoader extends URLClassLoader {
             }
         }
         return clazz;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        // Due to class isolation, the service loader does not obtain the service provider from the parent
+        // classloader, but returns only the resources in current classloader
+        if (name.startsWith("META-INF/services/")) {
+            return findResources(name);
+        }
+
+        return super.getResources(name);
     }
 
     /**


### PR DESCRIPTION
**What type of PR is this?**

Bug

**What this PR does / why we need it?**

Due to class isolation, the service loader does not obtain the service provider from the parent classloader, but returns only the SPI resources in current classloader

**Which issue(s) this PR fixes？**

Fixes #1685

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
