### PR TITLE
fix the issue that integration test fails due to the upgrade of the ubuntu environment of gitHub action

### DIFF
--- a/.github/actions/scenarios/database-write-prohibition/postgresql/action.yml
+++ b/.github/actions/scenarios/database-write-prohibition/postgresql/action.yml
@@ -10,10 +10,11 @@ runs:
     - name: install postgresql
       shell: bash
       run: |
-        curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-        echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |sudo tee  /etc/apt/sources.list.d/pgdg.list
+        curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+        echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
         sudo apt update
-        sudo apt install postgresql-14 -y
+        apt-cache madison postgresql-14
+        sudo apt install -y postgresql-14
         sudo service postgresql start
         sudo service postgresql status
         sudo -u postgres psql -c "CREATE DATABASE test;"

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -5,12 +5,12 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         java_version: [8]
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
     permissions:
       checks: write
       contents: write

--- a/.github/workflows/database_write_prohibition_integration_test.yml
+++ b/.github/workflows/database_write_prohibition_integration_test.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   set-execution-conditions:
     name: set-execution-conditions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +44,7 @@ jobs:
       enableOpengaussAndPostgresqlDataBaseWriteProhibitionAction: ${{ steps.set-outputs.outputs.enableOpengaussAndPostgresqlDataBaseWriteProhibitionAction }}
   download-midwares-and-cache:
     name: download midwares and cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: cache zookeeper
@@ -60,7 +60,7 @@ jobs:
           bash ./sermant-integration-tests/scripts/tryDownloadMidware.sh zk
   build-agent-and-cache:
     name: build agent and cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 8
@@ -82,7 +82,7 @@ jobs:
           mvn package -DskipTests -Ptest --file pom.xml
   test-for-database-write-prohibition-mongodb:
     name: Test for database-write-prohibition mongodb
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: needs.set-execution-conditions.outputs.enableMongodbDataBaseWriteProhibitionAction == 'true'
     needs: [set-execution-conditions, build-agent-and-cache, download-midwares-and-cache]
     strategy:
@@ -121,7 +121,7 @@ jobs:
   test-for-database-write-prohibition-mysql:
     name: Test for database-write-prohibition mysql
     if: needs.set-execution-conditions.outputs.enableMysqlDataBaseWriteProhibitionAction == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [set-execution-conditions, build-agent-and-cache, download-midwares-and-cache]
     strategy:
       matrix:
@@ -148,7 +148,7 @@ jobs:
         uses: ./.github/actions/scenarios/database-write-prohibition/mysql
   test-for-postgresql:
     name: Test for postgresql
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: needs.set-execution-conditions.outputs.enableOpengaussAndPostgresqlDataBaseWriteProhibitionAction == 'true'
     needs: [set-execution-conditions, build-agent-and-cache, download-midwares-and-cache]
     strategy:
@@ -209,7 +209,7 @@ jobs:
         uses: ./.github/actions/scenarios/database-write-prohibition/postgresql/
   test-for-opengauss:
     name: Test for opengauss
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: needs.set-execution-conditions.outputs.enableOpengaussDataBaseWriteProhibitionAction == 'true'
     needs: [set-execution-conditions, build-agent-and-cache, download-midwares-and-cache]
     strategy:


### PR DESCRIPTION
**What type of PR is this?**

Bug.

**What this PR does / why we need it?**

fix the issue that integration test fails due to the upgrade of the ubuntu environment of gitHub action, include
1. postgresql action of database write prohibition plugin
2. dubbo-router-service moudle UT

**Which issue(s) this PR fixes？**

Fixes #1701

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [ ] GitHub Actions works fine in this PR.
