### PR TITLE
fixed when consumerGroupTag contains uppercase characters, the gray flag cannot be matched problem

### DIFF
--- a/sermant-plugins/sermant-mq-grayscale/mq-config-common/src/main/java/io/sermant/mq/grayscale/config/MqGrayscaleConfig.java
+++ b/sermant-plugins/sermant-mq-grayscale/mq-config-common/src/main/java/io/sermant/mq/grayscale/config/MqGrayscaleConfig.java
@@ -18,6 +18,7 @@ package io.sermant.mq.grayscale.config;
 
 import io.sermant.core.config.common.ConfigTypeKey;
 import io.sermant.core.plugin.config.PluginConfig;
+import io.sermant.core.utils.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -109,6 +110,9 @@ public class MqGrayscaleConfig implements PluginConfig {
      * @return gray tag item
      */
     public Optional<GrayTagItem> getGrayTagByGroupTag(String grayGroupTag) {
+        if (StringUtils.isEmpty(grayGroupTag)) {
+            return Optional.empty();
+        }
         for (GrayTagItem item : grayscale) {
             if (grayGroupTag.equals(item.getConsumerGroupTag())) {
                 return Optional.of(item);

--- a/sermant-plugins/sermant-mq-grayscale/mq-grayscale-rocketmq-plugin/src/main/java/io/sermant/mq/grayscale/rocketmq/utils/RocketMqGrayscaleConfigUtils.java
+++ b/sermant-plugins/sermant-mq-grayscale/mq-grayscale-rocketmq-plugin/src/main/java/io/sermant/mq/grayscale/rocketmq/utils/RocketMqGrayscaleConfigUtils.java
@@ -16,6 +16,7 @@
 
 package io.sermant.mq.grayscale.rocketmq.utils;
 
+import io.sermant.core.common.LoggerFactory;
 import io.sermant.core.config.ConfigManager;
 import io.sermant.core.plugin.config.ServiceMeta;
 import io.sermant.mq.grayscale.config.ConsumeModeEnum;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
@@ -46,9 +48,11 @@ public class RocketMqGrayscaleConfigUtils {
     private static final Map<String, String> MICRO_SERVICE_PROPERTIES = new HashMap<>();
 
     /**
-     * consumerGroup name rule: ^[%|a-zA-Z0-9_-]+$
+     * consumerGroup name rule: ^[a-zA-Z0-9_-]+$
      */
-    private static final Pattern PATTERN = Pattern.compile("[^%|a-zA-Z0-9_-]");
+    private static final Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger();
 
     static {
         ServiceMeta serviceMeta = ConfigManager.getConfig(ServiceMeta.class);
@@ -72,7 +76,18 @@ public class RocketMqGrayscaleConfigUtils {
         }
         Optional<GrayTagItem> itemOptional
                 = MqGrayConfigCache.getCacheConfig().getMatchedGrayTagByServiceMeta(MICRO_SERVICE_PROPERTIES);
-        return itemOptional.map(grayTagItem -> standardFormatGroupTag(grayTagItem.getConsumerGroupTag())).orElse("");
+        if (itemOptional.isPresent()) {
+            GrayTagItem grayTagItem = itemOptional.get();
+            String consumerGroup = grayTagItem.getConsumerGroupTag();
+            if (PATTERN.matcher(consumerGroup).matches()) {
+                return consumerGroup;
+            } else {
+                LOGGER.warning(String.format(Locale.ENGLISH, "current consumerGroup tag [%s] not matches pattern "
+                        + "[a-zA-Z0-9_-], Please modify it to conform to this pattern and restart the service.",
+                        consumerGroup));
+            }
+        }
+        return "";
     }
 
     /**
@@ -91,16 +106,6 @@ public class RocketMqGrayscaleConfigUtils {
      */
     public static long getAutoCheckDelayTime() {
         return MqGrayConfigCache.getCacheConfig().getBase().getAutoCheckDelayTime();
-    }
-
-    /**
-     * format grayGroupTag
-     *
-     * @param grayGroupTag grayGroupTag
-     * @return standard grayGroupTag
-     */
-    public static String standardFormatGroupTag(String grayGroupTag) {
-        return PATTERN.matcher(grayGroupTag.toLowerCase(Locale.ROOT)).replaceAll("-");
     }
 
     /**

--- a/sermant-plugins/sermant-mq-grayscale/mq-grayscale-rocketmq-plugin/src/test/java/io/sermant/mq/grayscale/rocketmq/utils/RocketMqGrayscaleConfigUtilsTest.java
+++ b/sermant-plugins/sermant-mq-grayscale/mq-grayscale-rocketmq-plugin/src/test/java/io/sermant/mq/grayscale/rocketmq/utils/RocketMqGrayscaleConfigUtilsTest.java
@@ -17,6 +17,9 @@
 package io.sermant.mq.grayscale.rocketmq.utils;
 
 import io.sermant.mq.grayscale.config.ConsumeModeEnum;
+import io.sermant.mq.grayscale.config.GrayTagItem;
+import io.sermant.mq.grayscale.config.MqGrayConfigCache;
+import io.sermant.mq.grayscale.config.MqGrayscaleConfig;
 import io.sermant.mq.grayscale.rocketmq.RocketMqTestAbstract;
 
 import org.apache.rocketmq.common.message.Message;
@@ -36,6 +39,15 @@ public class RocketMqGrayscaleConfigUtilsTest extends RocketMqTestAbstract {
     }
 
     @Test
+    public void testGetGrayGroupTagError() {
+        MqGrayscaleConfig config = MqGrayConfigCache.getCacheConfig();
+        for (GrayTagItem item : config.getGrayscale()) {
+            item.setConsumerGroupTag("%gray&");
+        }
+        Assert.assertEquals("", RocketMqGrayscaleConfigUtils.getGrayGroupTag());
+    }
+
+    @Test
     public void testGetConsumeType() {
         Assert.assertSame(RocketMqGrayscaleConfigUtils.getConsumeType(), ConsumeModeEnum.AUTO);
     }
@@ -43,11 +55,6 @@ public class RocketMqGrayscaleConfigUtilsTest extends RocketMqTestAbstract {
     @Test
     public void testGetAutoCheckDelayTime() {
         Assert.assertSame(RocketMqGrayscaleConfigUtils.getAutoCheckDelayTime(), 15L);
-    }
-
-    @Test
-    public void testStandardFormatGroupTag() {
-        Assert.assertEquals("gray-group", RocketMqGrayscaleConfigUtils.standardFormatGroupTag("grAY.Group"));
     }
 
     @Test


### PR DESCRIPTION
**What type of PR is this?**

Bug.

**What this PR does / why we need it?**

When consumerGroupTag contains uppercase characters, the gray flag cannot be matched.

**Which issue(s) this PR fixes？**

Fixes #1782

**Does this PR introduce a user-facing change?**

No

<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/sermant-io/Sermant/issues) related with this PR before you start working on it.
- [x] Make sure you have squashed your change to one single commit.
- [x] GitHub Actions works fine in this PR.
